### PR TITLE
Implement skeleton for MT4 observer system

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,49 @@
-# BotCopier
+# MT4 Observer + Learner
+
+This project provides a skeleton framework for creating an "Observer" Expert Advisor (EA) that monitors other bots trading in the same MetaTrader 4 account.  It logs trade activity, exports data for learning and can generate candidate strategy EAs based on that information.
+
+## Directory Layout
+
+- `experts/` – MQL4 source files.
+  - `Observer_TBot.mq4` – main observer EA.
+  - `StrategyTemplate.mq4` – template used for generated strategies.
+  - `model_interface.mqh` – shared structures.
+- `scripts/` – helper Python scripts.
+  - `train_target_clone.py` – trains a model from exported logs.
+  - `generate_mql4_from_model.py` – renders a new EA from a trained model description.
+  - `evaluate_predictions.py` – basic log evaluation utility.
+  - `promote_best_models.py` – copies highest scoring models to a best directory.
+- `models/` – location for generated models.
+- `utils/` – miscellaneous utilities.
+- `config.json` – example configuration file.
+
+## Installation
+
+1. Install MetaTrader 4 on a Windows machine or VPS.
+2. Copy the contents of `experts/` to your terminal's `MQL4\Experts` folder.
+3. Copy the `scripts/` directory somewhere accessible with Python 3 installed.
+4. Restart the MT4 terminal and compile `Observer_TBot.mq4` using MetaEditor.
+5. Attach `Observer_TBot` to a single chart and adjust the extern inputs as needed (magic numbers to observe, log directory, etc.).
+
+## External Training
+
+Exported logs can be processed by the Python scripts.  A typical workflow is:
+
+```bash
+python train_target_clone.py --data-dir "C:\\path\\to\\observer_logs" --out-dir models
+python generate_mql4_from_model.py models/model.json experts
+```
+
+Compile the generated MQ4 file and the observer will begin evaluating predictions from that model.
+
+## Maintenance
+
+Logs are written to the directory specified by the EA parameter `LogDirectoryName` (default `observer_logs`).  Periodically archive or clean this directory to avoid large disk usage.  Models placed in the `models/best` folder can be retained for future analysis.
+
+## Troubleshooting
+
+- Ensure the MT4 terminal has permission to write files in `MQL4\Files`.
+- When running Python scripts, verify the paths to log files and models are correct.
+- Use the Experts and Journal tabs inside MT4 for additional debugging information.
+
+This repository contains only minimal placeholder code to get started.  Extend the MQL4 and Python modules to implement full learning and cloning functionality.

--- a/config.json
+++ b/config.json
@@ -1,0 +1,6 @@
+{
+  "log_dir": "observer_logs",
+  "prediction_window_sec": 60,
+  "rolling_days": 7,
+  "max_models": 3
+}

--- a/experts/Observer_TBot.mq4
+++ b/experts/Observer_TBot.mq4
@@ -1,0 +1,54 @@
+#property strict
+#include "model_interface.mqh"
+
+extern string TargetMagicNumbers = "12345,23456";
+extern int    LearningExportIntervalMinutes = 15;
+extern int    PredictionWindowSeconds       = 60;
+extern double LotSizeTolerancePct           = 20.0;
+extern double PriceTolerancePips            = 5.0;
+extern bool   EnableLiveCloneMode           = false;
+extern int    MaxModelsToRetain             = 3;
+extern int    MetricsRollingDays            = 7;
+extern string LogDirectoryName              = "observer_logs";
+extern bool   EnableDebugLogging            = false;
+extern bool   UseBrokerTime                 = true;
+extern string SymbolsToTrack                = ""; // empty=all
+
+int timer_handle;
+
+int OnInit()
+{
+   EventSetTimer(1);
+   return(INIT_SUCCEEDED);
+}
+
+void OnDeinit(const int reason)
+{
+   EventKillTimer();
+}
+
+void OnTick()
+{
+   // placeholder for trade monitoring
+}
+
+void OnTimer()
+{
+   // placeholder for periodic export and panel update
+}
+
+void LogTrade(string action, int ticket, int magic, string source,
+              string symbol, int order_type, double lots, double price,
+              double sl, double tp, datetime time_event, string comment)
+{
+   string fname = LogDirectoryName + "\\trades_raw.csv";
+   int f = FileOpen(fname, FILE_CSV|FILE_WRITE|FILE_READ|FILE_TXT|FILE_SHARE_WRITE, ';');
+   if(f==INVALID_HANDLE)
+      return;
+   FileSeek(f, 0, SEEK_END);
+   string line = StringFormat("%s;%d;%d;%s;%s;%d;%.2f;%.5f;%.5f;%.5f;%s",
+      TimeToString(time_event, TIME_DATE|TIME_SECONDS),
+      ticket, magic, source, symbol, order_type, lots, price, sl, tp, comment);
+   FileWrite(f, line);
+   FileClose(f);
+}

--- a/experts/StrategyTemplate.mq4
+++ b/experts/StrategyTemplate.mq4
@@ -1,0 +1,20 @@
+#property strict
+#include "model_interface.mqh"
+
+extern string SymbolToTrade = "EURUSD";
+extern double Lots = 0.1;
+extern int MagicNumber = 1234;
+
+int OnInit()
+{
+   return(INIT_SUCCEEDED);
+}
+
+void OnTick()
+{
+   // Placeholder for generated strategy logic
+}
+
+void OnDeinit(const int reason)
+{
+}

--- a/experts/model_interface.mqh
+++ b/experts/model_interface.mqh
@@ -1,0 +1,24 @@
+#ifndef __MODEL_INTERFACE_MQH__
+#define __MODEL_INTERFACE_MQH__
+
+struct ModelSignal
+{
+   datetime timestamp;
+   string   symbol;
+   int      direction; // 1 = buy, -1 = sell
+   double   lots;
+   double   price;
+   double   sl;
+   double   tp;
+};
+
+struct ModelMetrics
+{
+   string   model_id;
+   int      predicted_events;
+   int      matched_events;
+   double   success_pct;
+   double   coverage_pct;
+};
+
+#endif

--- a/scripts/evaluate_predictions.py
+++ b/scripts/evaluate_predictions.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+"""Evaluate prediction accuracy from logs."""
+import csv
+import argparse
+from pathlib import Path
+
+
+def evaluate(log_file: Path):
+    with open(log_file, newline='') as f:
+        reader = csv.reader(f, delimiter=';')
+        rows = list(reader)
+    print(f"Loaded {len(rows)} rows from {log_file}")
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument('log_file')
+    args = p.parse_args()
+    evaluate(Path(args.log_file))
+
+if __name__ == '__main__':
+    main()

--- a/scripts/generate_mql4_from_model.py
+++ b/scripts/generate_mql4_from_model.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+"""Render MQL4 strategy file from model description."""
+import argparse
+import json
+from pathlib import Path
+
+template_path = Path(__file__).resolve().parent.parent / 'experts' / 'StrategyTemplate.mq4'
+
+
+def generate(model_json: Path, out_dir: Path):
+    with open(model_json) as f:
+        model = json.load(f)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    with open(template_path) as f:
+        template = f.read()
+    # Placeholder: simply copy template
+    output = template.replace('MagicNumber = 1234', f'MagicNumber = {model.get("magic", 9999)}')
+    out_file = out_dir / f"Generated_{model.get('model_id','model')}.mq4"
+    with open(out_file, 'w') as f:
+        f.write(output)
+    print(f"Strategy written to {out_file}")
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument('model_json')
+    p.add_argument('out_dir')
+    args = p.parse_args()
+    generate(Path(args.model_json), Path(args.out_dir))
+
+if __name__ == '__main__':
+    main()

--- a/scripts/promote_best_models.py
+++ b/scripts/promote_best_models.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+"""Select best models and copy to best folder."""
+import argparse
+import shutil
+from pathlib import Path
+
+
+def promote(models_dir: Path, best_dir: Path, max_models: int):
+    best_dir.mkdir(parents=True, exist_ok=True)
+    models = sorted(models_dir.glob('model_*.json'))[:max_models]
+    for m in models:
+        dest = best_dir / m.name
+        shutil.copy(m, dest)
+        print(f"Promoted {m} to {dest}")
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument('models_dir')
+    p.add_argument('best_dir')
+    p.add_argument('--max-models', type=int, default=3)
+    args = p.parse_args()
+    promote(Path(args.models_dir), Path(args.best_dir), args.max_models)
+
+if __name__ == '__main__':
+    main()

--- a/scripts/train_target_clone.py
+++ b/scripts/train_target_clone.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+"""Train model from exported features.
+This is a placeholder that demonstrates expected interface.
+"""
+import argparse
+import json
+from pathlib import Path
+
+def train(data_dir: Path, out_dir: Path):
+    out_dir.mkdir(parents=True, exist_ok=True)
+    model = {
+        "model_id": "demo_model",
+        "timestamp": "0000",
+        "params": {}
+    }
+    with open(out_dir / "model.json", "w") as f:
+        json.dump(model, f)
+    print(f"Model written to {out_dir / 'model.json'}")
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument('--data-dir', required=True)
+    p.add_argument('--out-dir', required=True)
+    args = p.parse_args()
+    train(Path(args.data_dir), Path(args.out_dir))
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add initial observer EA and strategy template
- include Python helpers for model training and generation
- provide basic config example
- write project README with installation and usage instructions

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687dcdb91420832f89ab6096a8973183