### PR TITLE
Add tests and pep8 fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,14 @@ Compile the generated MQ4 file and the observer will begin evaluating prediction
 
 Logs are written to the directory specified by the EA parameter `LogDirectoryName` (default `observer_logs`).  Periodically archive or clean this directory to avoid large disk usage.  Models placed in the `models/best` folder can be retained for future analysis.
 
+## Running Tests
+
+Install the Python requirements and run `pytest` from the repository root:
+
+```bash
+pytest
+```
+
 ## Troubleshooting
 
 - Ensure the MT4 terminal has permission to write files in `MQL4\Files`.

--- a/scripts/evaluate_predictions.py
+++ b/scripts/evaluate_predictions.py
@@ -32,8 +32,12 @@ def _load_predictions(pred_file: Path) -> List[Dict]:
         reader = csv.DictReader(f, delimiter=";")
         preds = []
         for r in reader:
-            ts = _parse_time(r.get("timestamp") or r.get("time") or r[reader.fieldnames[0]])
-            direction_raw = str(r.get("direction") or r.get("order_type") or "").lower()
+            ts = _parse_time(
+                r.get("timestamp") or r.get("time") or r[reader.fieldnames[0]]
+            )
+            direction_raw = str(
+                r.get("direction") or r.get("order_type") or ""
+            ).lower()
             if direction_raw in ("1", "buy", "0"):
                 direction = 1
             elif direction_raw in ("-1", "sell", "1"):
@@ -62,12 +66,18 @@ def _load_actual_trades(log_file: Path) -> List[Dict]:
         for r in reader:
             action = (r.get("action") or "").upper()
             ticket = r.get("ticket")
-            ts = _parse_time(r.get("event_time") or r.get("time_event") or r[reader.fieldnames[0]])
+            ts = _parse_time(
+                r.get("event_time")
+                or r.get("time_event")
+                or r[reader.fieldnames[0]]
+            )
             if action == "OPEN":
                 open_map[ticket] = {
                     "open_time": ts,
                     "symbol": r.get("symbol", ""),
-                    "direction": 1 if int(float(r.get("order_type", 0))) == 0 else -1,
+                    "direction": 1
+                    if int(float(r.get("order_type", 0))) == 0
+                    else -1,
                     "lots": float(r.get("lots", 0) or 0),
                 }
             elif action == "CLOSE" and ticket in open_map:
@@ -134,11 +144,24 @@ def main() -> None:
     p = argparse.ArgumentParser(description="Evaluate prediction logs")
     p.add_argument("predicted_log", help="CSV of predicted signals")
     p.add_argument("actual_log", help="CSV of observed trades")
-    p.add_argument("--window", type=int, default=60, help="matching window in seconds")
-    p.add_argument("--json-out", type=Path, help="optional path for JSON summary")
+    p.add_argument(
+        "--window",
+        type=int,
+        default=60,
+        help="matching window in seconds",
+    )
+    p.add_argument(
+        "--json-out",
+        type=Path,
+        help="optional path for JSON summary",
+    )
     args = p.parse_args()
 
-    stats = evaluate(Path(args.predicted_log), Path(args.actual_log), args.window)
+    stats = evaluate(
+        Path(args.predicted_log),
+        Path(args.actual_log),
+        args.window,
+    )
 
     if args.json_out:
         with open(args.json_out, "w") as f:
@@ -147,11 +170,16 @@ def main() -> None:
 
     print("--- Evaluation Summary ---")
     print(f"Predicted events : {stats['predicted_events']}")
-    print(f"Matched events   : {stats['matched_events']} ({stats['hit_rate']*100:.1f}% hit rate)")
+    print(
+        f"Matched events   : {stats['matched_events']}"
+        f" ({stats['hit_rate']*100:.1f}% hit rate)"
+    )
     print(f"Coverage         : {stats['coverage']*100:.1f}% of actual trades")
     print(
-        f"Profit Factor    : {stats['profit_factor']:.2f} (gross P/L: {stats['gross_profit']-stats['gross_loss']:.2f})"
+        f"Profit Factor    : {stats['profit_factor']:.2f}"
+        f" (gross P/L: {stats['gross_profit']-stats['gross_loss']:.2f})"
     )
+
 
 if __name__ == '__main__':
     main()

--- a/scripts/generate_mql4_from_model.py
+++ b/scripts/generate_mql4_from_model.py
@@ -4,7 +4,9 @@ import argparse
 import json
 from pathlib import Path
 
-template_path = Path(__file__).resolve().parent.parent / 'experts' / 'StrategyTemplate.mq4'
+template_path = (
+    Path(__file__).resolve().parent.parent / 'experts' / 'StrategyTemplate.mq4'
+)
 
 
 def generate(model_json: Path, out_dir: Path):
@@ -14,8 +16,11 @@ def generate(model_json: Path, out_dir: Path):
     with open(template_path) as f:
         template = f.read()
     # Placeholder: simply copy template
-    output = template.replace('MagicNumber = 1234', f'MagicNumber = {model.get("magic", 9999)}')
-    out_file = out_dir / f"Generated_{model.get('model_id','model')}.mq4"
+    output = template.replace(
+        'MagicNumber = 1234',
+        f"MagicNumber = {model.get('magic', 9999)}",
+    )
+    out_file = out_dir / f"Generated_{model.get('model_id', 'model')}.mq4"
     with open(out_file, 'w') as f:
         f.write(output)
     print(f"Strategy written to {out_file}")
@@ -27,6 +32,7 @@ def main():
     p.add_argument('out_dir')
     args = p.parse_args()
     generate(Path(args.model_json), Path(args.out_dir))
+
 
 if __name__ == '__main__':
     main()

--- a/scripts/promote_best_models.py
+++ b/scripts/promote_best_models.py
@@ -44,7 +44,12 @@ def _score_for_model(model_json: Path, metric: str) -> float:
     return score
 
 
-def promote(models_dir: Path, best_dir: Path, max_models: int, metric: str) -> None:
+def promote(
+    models_dir: Path,
+    best_dir: Path,
+    max_models: int,
+    metric: str,
+) -> None:
     """Copy the top ``max_models`` from ``models_dir`` to ``best_dir``."""
 
     best_dir.mkdir(parents=True, exist_ok=True)
@@ -70,7 +75,13 @@ def main():
     p.add_argument('--metric', default='success_pct',
                    help='metric key to sort by')
     args = p.parse_args()
-    promote(Path(args.models_dir), Path(args.best_dir), args.max_models, args.metric)
+    promote(
+        Path(args.models_dir),
+        Path(args.best_dir),
+        args.max_models,
+        args.metric,
+    )
+
 
 if __name__ == '__main__':
     main()

--- a/scripts/train_target_clone.py
+++ b/scripts/train_target_clone.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
 """Train model from exported features.
 
-The observer EA continuously exports trade logs as CSV files.  This script loads
-those logs, extracts a few simple features from each trade entry and trains a
-very small predictive model.  The resulting parameters along with some training
-metadata are written to ``model.json`` so they can be consumed by other helper
-scripts.
+The observer EA continuously exports trade logs as CSV files. This script
+loads those logs, extracts a few simple features from each trade entry and
+trains a very small predictive model. The resulting parameters along with
+some training metadata are written to ``model.json`` so they can be consumed
+by other helper scripts.
 """
 import argparse
 import csv
@@ -17,6 +17,7 @@ import numpy as np
 from sklearn.feature_extraction import DictVectorizer
 from sklearn.linear_model import LogisticRegression
 from sklearn.metrics import accuracy_score
+
 
 def _load_logs(data_dir: Path):
     """Load log rows from ``data_dir``.
@@ -63,7 +64,10 @@ def _load_logs(data_dir: Path):
                     rows.append(dict(zip(fields, row)))
                 else:
                     # best effort alignment
-                    r = {fields[i]: row[i] for i in range(min(len(row), len(fields)))}
+                    r = {
+                        fields[i]: row[i]
+                        for i in range(min(len(row), len(fields)))
+                    }
                     rows.append(r)
     return rows
 
@@ -146,6 +150,7 @@ def main():
     p.add_argument('--out-dir', required=True)
     args = p.parse_args()
     train(Path(args.data_dir), Path(args.out_dir))
+
 
 if __name__ == '__main__':
     main()

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -1,0 +1,45 @@
+import csv
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from scripts.evaluate_predictions import evaluate
+
+
+def _write_prediction(file: Path, ts: str):
+    with open(file, "w", newline="") as f:
+        writer = csv.writer(f, delimiter=";")
+        writer.writerow(["timestamp", "symbol", "direction", "lots"])
+        writer.writerow([ts, "EURUSD", "buy", "0.1"])
+
+
+def _write_actual(file: Path, ts_open: str, ts_close: str):
+    fields = [
+        "event_time",
+        "action",
+        "ticket",
+        "symbol",
+        "order_type",
+        "lots",
+        "profit",
+    ]
+    rows = [
+        [ts_open, "OPEN", "1", "EURUSD", "0", "0.1", "0"],
+        [ts_close, "CLOSE", "1", "EURUSD", "0", "0.1", "10"],
+    ]
+    with open(file, "w", newline="") as f:
+        writer = csv.writer(f, delimiter=";")
+        writer.writerow(fields)
+        writer.writerows(rows)
+
+
+def test_evaluate(tmp_path: Path):
+    pred_file = tmp_path / "preds.csv"
+    log_file = tmp_path / "trades.csv"
+    _write_prediction(pred_file, "2024.01.01 00:00:00")
+    _write_actual(log_file, "2024.01.01 00:00:05", "2024.01.01 00:01:00")
+
+    stats = evaluate(pred_file, log_file, window=60)
+
+    assert stats["matched_events"] == 1
+    assert stats["predicted_events"] == 1

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -1,0 +1,22 @@
+import json
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from scripts.generate_mql4_from_model import generate
+
+
+def test_generate(tmp_path: Path):
+    model = {"model_id": "test", "magic": 777}
+    model_file = tmp_path / "model.json"
+    with open(model_file, "w") as f:
+        json.dump(model, f)
+
+    out_dir = tmp_path / "out"
+    generate(model_file, out_dir)
+
+    out_file = out_dir / "Generated_test.mq4"
+    assert out_file.exists()
+    with open(out_file) as f:
+        content = f.read()
+    assert "MagicNumber = 777" in content

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -1,0 +1,83 @@
+import csv
+import json
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from scripts.train_target_clone import train
+
+
+def _write_log(file: Path):
+    fields = [
+        "event_time",
+        "broker_time",
+        "local_time",
+        "action",
+        "ticket",
+        "magic",
+        "source",
+        "symbol",
+        "order_type",
+        "lots",
+        "price",
+        "sl",
+        "tp",
+        "profit",
+        "comment",
+    ]
+    rows = [
+        [
+            "2024.01.01 00:00:00",
+            "",
+            "",
+            "OPEN",
+            "1",
+            "",
+            "",
+            "EURUSD",
+            "0",
+            "0.1",
+            "1.1000",
+            "1.0950",
+            "1.1100",
+            "0",
+            "",
+        ],
+        [
+            "2024.01.01 01:00:00",
+            "",
+            "",
+            "OPEN",
+            "2",
+            "",
+            "",
+            "EURUSD",
+            "1",
+            "0.1",
+            "1.2000",
+            "1.1950",
+            "1.2100",
+            "0",
+            "",
+        ],
+    ]
+    with open(file, "w", newline="") as f:
+        writer = csv.writer(f, delimiter=";")
+        writer.writerow(fields)
+        writer.writerows(rows)
+
+
+def test_train(tmp_path: Path):
+    data_dir = tmp_path / "logs"
+    out_dir = tmp_path / "out"
+    data_dir.mkdir()
+    log_file = data_dir / "trades_test.csv"
+    _write_log(log_file)
+
+    train(data_dir, out_dir)
+
+    model_file = out_dir / "model.json"
+    assert model_file.exists()
+    with open(model_file) as f:
+        data = json.load(f)
+    assert "coefficients" in data


### PR DESCRIPTION
## Summary
- clean up pep8 issues in helper scripts
- add simple unit tests for training, generation and evaluation utilities
- document how to run tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687eef3d4a60832f8e6142c125037694