### PR TITLE
Add MetricsDaysToKeep setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Compile the generated MQ4 file and the observer will begin evaluating prediction
 ## Maintenance
 
 Logs are written to the directory specified by the EA parameter `LogDirectoryName` (default `observer_logs`).  Periodically archive or clean this directory to avoid large disk usage.  Models placed in the `models/best` folder can be retained for future analysis.
+Metrics entries older than the number of days specified by `MetricsDaysToKeep` (default 30) are removed automatically during log export.
 
 ## Running Tests
 

--- a/experts/Observer_TBot.mq4
+++ b/experts/Observer_TBot.mq4
@@ -9,6 +9,7 @@ extern double PriceTolerancePips            = 5.0;
 extern bool   EnableLiveCloneMode           = false;
 extern int    MaxModelsToRetain             = 3;
 extern int    MetricsRollingDays            = 7;
+extern int    MetricsDaysToKeep             = 30;
 extern string LogDirectoryName              = "observer_logs";
 extern bool   EnableDebugLogging            = false;
 extern bool   UseBrokerTime                 = true;
@@ -219,7 +220,7 @@ void ManageMetrics(datetime ts)
    if(in_h==INVALID_HANDLE)
       return;
    string lines[];
-   datetime cutoff = ts - MetricsRollingDays*24*60*60;
+   datetime cutoff = ts - MetricsDaysToKeep*24*60*60;
    while(!FileIsEnding(in_h))
    {
       string l = FileReadString(in_h);
@@ -242,7 +243,7 @@ void ManageMetrics(datetime ts)
    int out_h = FileOpen(fname, FILE_CSV|FILE_WRITE|FILE_TXT|FILE_SHARE_WRITE, ';');
    if(out_h==INVALID_HANDLE)
       return;
-   for(int i=0; i<MathMin(ArraySize(lines), MaxModelsToRetain); i++)
+   for(int i=0; i<ArraySize(lines); i++)
       FileWrite(out_h, lines[i]);
    FileClose(out_h);
 }


### PR DESCRIPTION
## Summary
- add `MetricsDaysToKeep` extern variable to Observer EA
- prune metrics based on this days-to-keep interval
- document the new parameter in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68806119b4b0832fa59c784b08017832