### PR TITLE
Add model coefficients to generated MQL4

### DIFF
--- a/experts/StrategyTemplate.mq4
+++ b/experts/StrategyTemplate.mq4
@@ -5,6 +5,9 @@ extern string SymbolToTrade = "EURUSD";
 extern double Lots = 0.1;
 extern int MagicNumber = 1234;
 
+double ModelCoefficients[] = {__COEFFICIENTS__};
+double ModelIntercept = __INTERCEPT__;
+
 int OnInit()
 {
    return(INIT_SUCCEEDED);

--- a/scripts/generate_mql4_from_model.py
+++ b/scripts/generate_mql4_from_model.py
@@ -15,10 +15,17 @@ def generate(model_json: Path, out_dir: Path):
     out_dir.mkdir(parents=True, exist_ok=True)
     with open(template_path) as f:
         template = f.read()
-    # Placeholder: simply copy template
+
     output = template.replace(
         'MagicNumber = 1234',
         f"MagicNumber = {model.get('magic', 9999)}",
+    )
+
+    coeffs = model.get('coefficients', [])
+    coeff_str = ', '.join(str(c) for c in coeffs)
+    output = output.replace('__COEFFICIENTS__', coeff_str)
+    output = output.replace(
+        '__INTERCEPT__', str(model.get('intercept', 0.0))
     )
     out_file = out_dir / f"Generated_{model.get('model_id', 'model')}.mq4"
     with open(out_file, 'w') as f:

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -7,7 +7,12 @@ from scripts.generate_mql4_from_model import generate
 
 
 def test_generate(tmp_path: Path):
-    model = {"model_id": "test", "magic": 777}
+    model = {
+        "model_id": "test",
+        "magic": 777,
+        "coefficients": [0.1, -0.2],
+        "intercept": 0.05,
+    }
     model_file = tmp_path / "model.json"
     with open(model_file, "w") as f:
         json.dump(model, f)
@@ -20,3 +25,6 @@ def test_generate(tmp_path: Path):
     with open(out_file) as f:
         content = f.read()
     assert "MagicNumber = 777" in content
+    assert "0.1" in content
+    assert "-0.2" in content
+    assert "0.05" in content


### PR DESCRIPTION
## Summary
- pass coefficients and intercept from `model.json` into generated expert advisors
- update StrategyTemplate to include placeholders for parameters
- verify coefficients are embedded via unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880611aeba0832f8d0336c21214eff2