### PR TITLE
Include validation accuracy

### DIFF
--- a/scripts/train_target_clone.py
+++ b/scripts/train_target_clone.py
@@ -166,8 +166,9 @@ def train(data_dir: Path, out_dir: Path):
         "coefficients": clf.coef_[0].tolist(),
         "intercept": float(clf.intercept_[0]),
         "train_accuracy": train_acc,
-        "accuracy": train_acc,
         "val_accuracy": val_acc,
+        # main accuracy metric is validation performance when available
+        "accuracy": val_acc,
         "num_samples": int(labels.shape[0]),
     }
 


### PR DESCRIPTION
## Summary
- ensure validation accuracy is the main accuracy metric
- keep 80/20 split for training vs validation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688195de3e74832f8e2be75276fa642d