### PR TITLE
Embed regression params in generated MQL4

### DIFF
--- a/scripts/generate_mql4_from_model.py
+++ b/scripts/generate_mql4_from_model.py
@@ -4,6 +4,11 @@ import argparse
 import json
 from pathlib import Path
 
+
+def _fmt(value: float) -> str:
+    """Format floats for insertion into MQL4 code."""
+    return f"{value:.6g}"
+
 template_path = (
     Path(__file__).resolve().parent.parent / 'experts' / 'StrategyTemplate.mq4'
 )
@@ -22,11 +27,11 @@ def generate(model_json: Path, out_dir: Path):
     )
 
     coeffs = model.get('coefficients', [])
-    coeff_str = ', '.join(str(c) for c in coeffs)
+    coeff_str = ', '.join(_fmt(c) for c in coeffs)
     output = output.replace('__COEFFICIENTS__', coeff_str)
-    output = output.replace(
-        '__INTERCEPT__', str(model.get('intercept', 0.0))
-    )
+
+    intercept = model.get('intercept', 0.0)
+    output = output.replace('__INTERCEPT__', _fmt(intercept))
     out_file = out_dir / f"Generated_{model.get('model_id', 'model')}.mq4"
     with open(out_file, 'w') as f:
         f.write(output)

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -25,6 +25,5 @@ def test_generate(tmp_path: Path):
     with open(out_file) as f:
         content = f.read()
     assert "MagicNumber = 777" in content
-    assert "0.1" in content
-    assert "-0.2" in content
-    assert "0.05" in content
+    assert "double ModelCoefficients[] = {0.1, -0.2};" in content
+    assert "double ModelIntercept = 0.05;" in content


### PR DESCRIPTION
## Summary
- format floats when generating MQL4 strategies
- embed coefficients and intercept values in generated code
- check for these values in unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688195dec81c832f94b99984529144e5