### PR TITLE
Implement runtime logistic regression scoring

### DIFF
--- a/experts/StrategyTemplate.mq4
+++ b/experts/StrategyTemplate.mq4
@@ -13,9 +13,71 @@ int OnInit()
    return(INIT_SUCCEEDED);
 }
 
+//----------------------------------------------------------------------
+// Feature extraction utilities
+//----------------------------------------------------------------------
+
+double GetFeature(int index)
+{
+   /* Return a simple set of features for the logistic model.
+      Feature mapping is intentionally minimal and should be kept in
+      sync with the Python training script.  Unknown indices default
+      to zero. */
+   switch(index)
+   {
+      case 0:
+         // Hour of day (0-23)
+         return(TimeHour(TimeCurrent()));
+      case 1:
+         // Current market spread in points
+         return(MarketInfo(SymbolToTrade, MODE_SPREAD));
+      default:
+         return(0.0);
+   }
+}
+
+double ComputeLogisticScore()
+{
+   double z = ModelIntercept;
+   int n = ArraySize(ModelCoefficients);
+   for(int i=0; i<n; i++)
+      z += ModelCoefficients[i] * GetFeature(i);
+   // logistic function
+   return(1.0 / (1.0 + MathExp(-z)));
+}
+
+bool HasOpenOrders()
+{
+   for(int i = OrdersTotal() - 1; i >= 0; i--)
+      if(OrderSelect(i, SELECT_BY_POS) &&
+         OrderMagicNumber() == MagicNumber &&
+         OrderSymbol() == SymbolToTrade)
+         return(true);
+   return(false);
+}
+
 void OnTick()
 {
-   // Placeholder for generated strategy logic
+   if(HasOpenOrders())
+      return;
+
+   double prob = ComputeLogisticScore();
+
+   // Very naive trade logic: open buy if probability > 0.5 else sell
+   int ticket;
+   if(prob > 0.5)
+   {
+      ticket = OrderSend(SymbolToTrade, OP_BUY, Lots, Ask, 3, 0, 0,
+                         "model", MagicNumber, 0, clrBlue);
+   }
+   else
+   {
+      ticket = OrderSend(SymbolToTrade, OP_SELL, Lots, Bid, 3, 0, 0,
+                         "model", MagicNumber, 0, clrRed);
+   }
+
+   if(ticket < 0)
+      Print("OrderSend error: ", GetLastError());
 }
 
 void OnDeinit(const int reason)

--- a/experts/model_interface.mqh
+++ b/experts/model_interface.mqh
@@ -21,4 +21,14 @@ struct ModelMetrics
    double   coverage_pct;
 };
 
+// Description of a simple logistic regression model used by generated
+// strategies.  ``coefficients`` is an array of weights that should be
+// multiplied by the feature vector returned at runtime.  ``intercept``
+// is added to the weighted sum before applying the logistic function.
+struct LogisticModel
+{
+   double coefficients[];
+   double intercept;
+};
+
 #endif


### PR DESCRIPTION
## Summary
- implement logistic regression prediction logic in the strategy template
- provide helper functions for feature extraction and open order checks
- call prediction logic within `OnTick` to make trading decisions
- document logistic model struct in `model_interface.mqh`

## Testing
- `pip install numpy scikit-learn pytest -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881a7cb2498832fa4ed36403920fd65