### PR TITLE
Add technical indicators and grid search

### DIFF
--- a/scripts/train_target_clone.py
+++ b/scripts/train_target_clone.py
@@ -17,7 +17,50 @@ import numpy as np
 from sklearn.feature_extraction import DictVectorizer
 from sklearn.linear_model import LogisticRegression
 from sklearn.metrics import accuracy_score
-from sklearn.model_selection import train_test_split
+from sklearn.model_selection import train_test_split, GridSearchCV
+
+
+def _sma(values, window):
+    """Simple moving average for the last ``window`` values."""
+    if not values:
+        return 0.0
+    w = min(window, len(values))
+    return float(sum(values[-w:]) / w)
+
+
+def _rsi(values, period):
+    """Very small RSI implementation on ``values``."""
+    if len(values) < 2:
+        return 50.0
+    deltas = np.diff(values[-(period + 1) :])
+    gains = deltas[deltas > 0].sum()
+    losses = -deltas[deltas < 0].sum()
+    if losses == 0:
+        return 100.0
+    rs = gains / losses
+    return float(100 - (100 / (1 + rs)))
+
+
+def _macd_update(state, price, short=12, long=26, signal=9):
+    """Update MACD EMA state with ``price`` and return (macd, signal)."""
+    alpha_short = 2 / (short + 1)
+    alpha_long = 2 / (long + 1)
+    alpha_signal = 2 / (signal + 1)
+
+    ema_short = state.get("ema_short")
+    ema_long = state.get("ema_long")
+    ema_signal = state.get("ema_signal")
+
+    ema_short = price if ema_short is None else alpha_short * price + (1 - alpha_short) * ema_short
+    ema_long = price if ema_long is None else alpha_long * price + (1 - alpha_long) * ema_long
+    macd = ema_short - ema_long
+    ema_signal = macd if ema_signal is None else alpha_signal * macd + (1 - alpha_signal) * ema_signal
+
+    state["ema_short"] = ema_short
+    state["ema_long"] = ema_long
+    state["ema_signal"] = ema_signal
+
+    return macd, ema_signal
 
 
 def _load_logs(data_dir: Path):
@@ -73,9 +116,18 @@ def _load_logs(data_dir: Path):
     return rows
 
 
-def _extract_features(rows):
+def _extract_features(
+    rows,
+    use_sma=False,
+    sma_window=5,
+    use_rsi=False,
+    rsi_period=14,
+    use_macd=False,
+):
     feature_dicts = []
     labels = []
+    prices = []
+    macd_state = {}
     for r in rows:
         if r.get("action", "").upper() != "OPEN":
             continue
@@ -104,16 +156,47 @@ def _extract_features(rows):
             "tp_dist": tp - price,
         }
 
+        if use_sma:
+            feat["sma"] = _sma(prices, sma_window)
+
+        if use_rsi:
+            feat["rsi"] = _rsi(prices, rsi_period)
+
+        if use_macd:
+            macd, signal = _macd_update(macd_state, price)
+            feat["macd"] = macd
+            feat["macd_signal"] = signal
+
+        prices.append(price)
+
         feature_dicts.append(feat)
         labels.append(label)
     return feature_dicts, np.array(labels)
 
 
-def train(data_dir: Path, out_dir: Path):
+def train(
+    data_dir: Path,
+    out_dir: Path,
+    *,
+    use_sma: bool = False,
+    sma_window: int = 5,
+    use_rsi: bool = False,
+    rsi_period: int = 14,
+    use_macd: bool = False,
+    grid_search: bool = False,
+    c_values=None,
+):
     """Train a simple logistic regression model from the log directory."""
 
     rows = _load_logs(data_dir)
-    features, labels = _extract_features(rows)
+    features, labels = _extract_features(
+        rows,
+        use_sma=use_sma,
+        sma_window=sma_window,
+        use_rsi=use_rsi,
+        rsi_period=rsi_period,
+        use_macd=use_macd,
+    )
 
     if not features:
         raise ValueError(f"No training data found in {data_dir}")
@@ -145,17 +228,26 @@ def train(data_dir: Path, out_dir: Path):
     else:
         X_val = np.empty((0, X_train.shape[1]))
 
-    clf = LogisticRegression(max_iter=200)
-    clf.fit(X_train, y_train)
-
-    train_preds = clf.predict(X_train)
-    train_acc = float(accuracy_score(y_train, train_preds))
-
-    if len(y_val) > 0:
-        val_preds = clf.predict(X_val)
-        val_acc = float(accuracy_score(y_val, val_preds))
+    if grid_search:
+        if c_values is None:
+            c_values = [0.01, 0.1, 1.0, 10.0]
+        param_grid = {"C": c_values}
+        gs = GridSearchCV(LogisticRegression(max_iter=200), param_grid, cv=3)
+        gs.fit(X_train, y_train)
+        clf = gs.best_estimator_
+        train_preds = clf.predict(X_train)
+        train_acc = float(accuracy_score(y_train, train_preds))
+        val_acc = float(gs.best_score_)
     else:
-        val_acc = float("nan")
+        clf = LogisticRegression(max_iter=200)
+        clf.fit(X_train, y_train)
+        train_preds = clf.predict(X_train)
+        train_acc = float(accuracy_score(y_train, train_preds))
+        if len(y_val) > 0:
+            val_preds = clf.predict(X_val)
+            val_acc = float(accuracy_score(y_val, val_preds))
+        else:
+            val_acc = float("nan")
 
     out_dir.mkdir(parents=True, exist_ok=True)
 
@@ -183,8 +275,25 @@ def main():
     p = argparse.ArgumentParser()
     p.add_argument('--data-dir', required=True)
     p.add_argument('--out-dir', required=True)
+    p.add_argument('--use-sma', action='store_true', help='include moving average feature')
+    p.add_argument('--sma-window', type=int, default=5)
+    p.add_argument('--use-rsi', action='store_true', help='include RSI feature')
+    p.add_argument('--rsi-period', type=int, default=14)
+    p.add_argument('--use-macd', action='store_true', help='include MACD feature')
+    p.add_argument('--grid-search', action='store_true', help='enable grid search with cross-validation')
+    p.add_argument('--c-values', type=float, nargs='*')
     args = p.parse_args()
-    train(Path(args.data_dir), Path(args.out_dir))
+    train(
+        Path(args.data_dir),
+        Path(args.out_dir),
+        use_sma=args.use_sma,
+        sma_window=args.sma_window,
+        use_rsi=args.use_rsi,
+        rsi_period=args.rsi_period,
+        use_macd=args.use_macd,
+        grid_search=args.grid_search,
+        c_values=args.c_values,
+    )
 
 
 if __name__ == '__main__':

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -81,3 +81,19 @@ def test_train(tmp_path: Path):
     with open(model_file) as f:
         data = json.load(f)
     assert "coefficients" in data
+
+
+def test_train_with_indicators(tmp_path: Path):
+    data_dir = tmp_path / "logs"
+    out_dir = tmp_path / "out"
+    data_dir.mkdir()
+    log_file = data_dir / "trades_test.csv"
+    _write_log(log_file)
+
+    train(data_dir, out_dir, use_sma=True, use_rsi=True, use_macd=True)
+
+    model_file = out_dir / "model.json"
+    assert model_file.exists()
+    with open(model_file) as f:
+        data = json.load(f)
+    assert any(name in data.get("feature_names", []) for name in ["sma", "rsi", "macd"])


### PR DESCRIPTION
## Summary
- compute SMA, RSI and MACD when training models
- expose command line flags for indicator usage and grid search
- support hyperparameter search with cross‑validation
- test training with optional indicators

## Testing
- `pip install numpy scikit-learn pandas --quiet`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881a7cd7400832fbf36fc7506593d61