### PR TITLE
Extend trade logs with extra fields

### DIFF
--- a/experts/Observer_TBot.mq4
+++ b/experts/Observer_TBot.mq4
@@ -22,6 +22,7 @@ int      target_magics[];
 string   track_symbols[];
 datetime last_export = 0;
 int      trade_log_handle = INVALID_HANDLE;
+int      next_log_id = 1;
 
 int OnInit()
 {
@@ -49,7 +50,7 @@ int OnInit()
       FileSeek(trade_log_handle, 0, SEEK_END);
       if(need_header)
       {
-         string header = "event_time;broker_time;local_time;action;ticket;magic;source;symbol;order_type;lots;price;sl;tp;profit;comment";
+         string header = "event_time;broker_time;local_time;action;ticket;magic;source;symbol;order_type;lots;price;sl;tp;profit;comment;spread;balance;uid";
          FileWrite(trade_log_handle, header);
       }
    }
@@ -189,11 +190,15 @@ void LogTrade(string action, int ticket, int magic, string source,
    if(trade_log_handle==INVALID_HANDLE)
       return;
    FileSeek(trade_log_handle, 0, SEEK_END);
-   string line = StringFormat("%s;%s;%s;%s;%d;%d;%s;%s;%d;%.2f;%.5f;%.5f;%.5f;%.2f;%s",
+   double spread = MarketInfo(symbol, MODE_SPREAD) * Point;
+   double balance = AccountBalance();
+   int uid = next_log_id++;
+   string line = StringFormat("%s;%s;%s;%s;%d;%d;%s;%s;%d;%.2f;%.5f;%.5f;%.5f;%.2f;%s;%.5f;%.2f;%d",
       TimeToString(time_event, TIME_DATE|TIME_SECONDS),
       TimeToString(TimeCurrent(), TIME_DATE|TIME_SECONDS),
       TimeToString(TimeLocal(), TIME_DATE|TIME_SECONDS),
-      action, ticket, magic, source, symbol, order_type, lots, price, sl, tp, profit, comment);
+      action, ticket, magic, source, symbol, order_type, lots, price, sl, tp, profit, comment,
+      spread, balance, uid);
    FileWrite(trade_log_handle, line);
    FileFlush(trade_log_handle);
 }

--- a/scripts/train_target_clone.py
+++ b/scripts/train_target_clone.py
@@ -50,6 +50,9 @@ def _load_logs(data_dir: Path):
         "tp",
         "profit",
         "comment",
+        "spread",
+        "balance",
+        "uid",
     ]
 
     rows = []

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -24,6 +24,9 @@ def _write_log(file: Path):
         "tp",
         "profit",
         "comment",
+        "spread",
+        "balance",
+        "uid",
     ]
     rows = [
         [
@@ -42,6 +45,9 @@ def _write_log(file: Path):
             "1.1100",
             "0",
             "",
+            "0.0002",
+            "1000.00",
+            "1",
         ],
         [
             "2024.01.01 01:00:00",
@@ -59,6 +65,9 @@ def _write_log(file: Path):
             "1.2100",
             "0",
             "",
+            "0.0003",
+            "1000.00",
+            "2",
         ],
     ]
     with open(file, "w", newline="") as f:


### PR DESCRIPTION
## Summary
- log spread, account balance, and a unique ID when recording trades
- include new columns in observer log header
- parse new log fields when training target clone
- update unit tests for extended log format

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881a7cfc8c8832fa0adfb17c82a7cee