### PR TITLE
Fix prediction direction handling

### DIFF
--- a/scripts/evaluate_predictions.py
+++ b/scripts/evaluate_predictions.py
@@ -37,12 +37,14 @@ def _load_predictions(pred_file: Path) -> List[Dict]:
             )
             direction_raw = str(
                 r.get("direction") or r.get("order_type") or ""
-            ).lower()
-            if direction_raw in ("1", "buy", "0"):
+            ).strip().lower()
+
+            if direction_raw in ("1", "buy"):
                 direction = 1
-            elif direction_raw in ("-1", "sell", "1"):
+            elif direction_raw in ("0", "-1", "sell"):
                 direction = -1
             else:
+                # default to buy when direction is missing
                 direction = 1
 
             preds.append(

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -6,14 +6,14 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from scripts.evaluate_predictions import evaluate
 
 
-def _write_prediction(file: Path, ts: str):
+def _write_prediction(file: Path, ts: str, direction: str = "buy"):
     with open(file, "w", newline="") as f:
         writer = csv.writer(f, delimiter=";")
         writer.writerow(["timestamp", "symbol", "direction", "lots"])
-        writer.writerow([ts, "EURUSD", "buy", "0.1"])
+        writer.writerow([ts, "EURUSD", direction, "0.1"])
 
 
-def _write_actual(file: Path, ts_open: str, ts_close: str):
+def _write_actual(file: Path, ts_open: str, ts_close: str, order_type: str = "0"):
     fields = [
         "event_time",
         "action",
@@ -24,8 +24,8 @@ def _write_actual(file: Path, ts_open: str, ts_close: str):
         "profit",
     ]
     rows = [
-        [ts_open, "OPEN", "1", "EURUSD", "0", "0.1", "0"],
-        [ts_close, "CLOSE", "1", "EURUSD", "0", "0.1", "10"],
+        [ts_open, "OPEN", "1", "EURUSD", order_type, "0.1", "0"],
+        [ts_close, "CLOSE", "1", "EURUSD", order_type, "0.1", "10"],
     ]
     with open(file, "w", newline="") as f:
         writer = csv.writer(f, delimiter=";")
@@ -43,3 +43,28 @@ def test_evaluate(tmp_path: Path):
 
     assert stats["matched_events"] == 1
     assert stats["predicted_events"] == 1
+
+
+def test_direction_mapping(tmp_path: Path):
+    cases = [
+        ("1", "0"),
+        ("buy", "0"),
+        ("0", "1"),
+        ("-1", "1"),
+        ("sell", "1"),
+        ("", "0"),
+    ]
+
+    for direction_value, order_type in cases:
+        pred_file = tmp_path / f"pred_{direction_value or 'empty'}.csv"
+        log_file = tmp_path / f"trades_{direction_value or 'empty'}.csv"
+        _write_prediction(pred_file, "2024.01.01 00:00:00", direction_value)
+        _write_actual(
+            log_file,
+            "2024.01.01 00:00:05",
+            "2024.01.01 00:01:00",
+            order_type,
+        )
+
+        stats = evaluate(pred_file, log_file, window=60)
+        assert stats["matched_events"] == 1


### PR DESCRIPTION
## Summary
- correct direction mapping in `evaluate_predictions.py`
- allow `tests/test_evaluate.py` helpers to specify direction/order type
- regression test for various direction formats

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881a7d1d2fc832fa319c0e6cb803f65