### PR TITLE
Add per-model metrics logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,14 @@ python generate_mql4_from_model.py models/model.json experts
 
 Compile the generated MQ4 file and the observer will begin evaluating predictions from that model.
 
+## Metrics Tracking
+
+During operation the EA records a summary line for each tracked model in
+`observer_logs/metrics.csv`. Each entry contains the time of capture, the model
+identifier (its magic number), the hit rate and the profit factor calculated
+over the last `MetricsRollingDays` days. Old entries beyond
+`MetricsDaysToKeep` days are pruned automatically.
+
 ## Maintenance
 
 Logs are written to the directory specified by the EA parameter `LogDirectoryName` (default `observer_logs`).  Periodically archive or clean this directory to avoid large disk usage.  Models placed in the `models/best` folder can be retained for future analysis.

--- a/experts/Observer_TBot.mq4
+++ b/experts/Observer_TBot.mq4
@@ -178,6 +178,7 @@ void OnTimer()
       return;
 
    ExportLogs(now);
+   UpdateModelMetrics(now);
    ManageMetrics(now);
    last_export = now;
 }
@@ -219,7 +220,67 @@ void ExportLogs(datetime ts)
       FileClose(out_h);
    }
    FileClose(in_h);
-   FileDelete(src);
+  FileDelete(src);
+}
+
+void UpdateModelMetrics(datetime ts)
+{
+   string fname = LogDirectoryName + "\\metrics.csv";
+   int h = FileOpen(fname, FILE_CSV|FILE_READ|FILE_WRITE|FILE_TXT|FILE_SHARE_WRITE|FILE_SHARE_READ, ';');
+   if(h==INVALID_HANDLE)
+   {
+      h = FileOpen(fname, FILE_CSV|FILE_WRITE|FILE_TXT|FILE_SHARE_WRITE, ';');
+      if(h==INVALID_HANDLE)
+         return;
+      FileWrite(h, "time;model_id;hit_rate;profit_factor");
+   }
+   else
+   {
+      FileSeek(h, 0, SEEK_END);
+   }
+
+   datetime cutoff = ts - MetricsRollingDays*24*60*60;
+   for(int m=0; m<ArraySize(target_magics); m++)
+   {
+      int magic = target_magics[m];
+      int trades = 0;
+      int wins = 0;
+      double profit_pos = 0.0;
+      double profit_neg = 0.0;
+
+      for(int i=OrdersHistoryTotal()-1; i>=0; i--)
+      {
+         if(!OrderSelect(i, SELECT_BY_POS, MODE_HISTORY))
+            continue;
+         if(OrderMagicNumber()!=magic)
+            continue;
+         if(OrderCloseTime() < cutoff)
+            continue;
+
+         double p = OrderProfit()+OrderSwap()+OrderCommission();
+         trades++;
+         if(p >= 0)
+         {
+            wins++;
+            profit_pos += p;
+         }
+         else
+         {
+            profit_neg += -p;
+         }
+      }
+
+      if(trades==0)
+         continue;
+
+      double hit_rate = double(wins)/trades;
+      double profit_factor = profit_neg>0 ? profit_pos/profit_neg : 0.0;
+
+      string line = StringFormat("%s;%d;%.3f;%.3f", TimeToString(ts, TIME_DATE|TIME_MINUTES), magic, hit_rate, profit_factor);
+      FileWrite(h, line);
+   }
+
+   FileClose(h);
 }
 
 void ManageMetrics(datetime ts)


### PR DESCRIPTION
## Summary
- add UpdateModelMetrics function to Observer_TBot
- call the new metrics function from OnTimer
- keep metrics for MetricsDaysToKeep days
- document metrics tracking in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881a7d04bfc832f8dd1cffb01732524