### PR TITLE
Implement log buffering

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ over the last `MetricsRollingDays` days. Old entries beyond
 ## Maintenance
 
 Logs are written to the directory specified by the EA parameter `LogDirectoryName` (default `observer_logs`).  Periodically archive or clean this directory to avoid large disk usage.  Models placed in the `models/best` folder can be retained for future analysis.
+Trade events are stored in a small in-memory buffer before being flushed to `trades_raw.csv` on each timer tick or when the buffer reaches `LogBufferSize` lines.  Set `EnableDebugLogging` to `true` to force immediate writes for easier debugging.
 Metrics entries older than the number of days specified by `MetricsDaysToKeep` (default 30) are removed automatically during log export.
 
 ## Running Tests


### PR DESCRIPTION
## Summary
- implement log buffering in Observer_TBot
- flush buffered logs every timer tick or when the buffer is full
- document log buffer behaviour in README

## Testing
- `pip install numpy`
- `pip install scikit-learn`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882cd5a1cb4832fb62d90ea633ef6b4