### PR TITLE
Add threshold tuning and model type option

### DIFF
--- a/experts/StrategyTemplate.mq4
+++ b/experts/StrategyTemplate.mq4
@@ -7,6 +7,7 @@ extern int MagicNumber = 1234;
 
 double ModelCoefficients[] = {__COEFFICIENTS__};
 double ModelIntercept = __INTERCEPT__;
+double ModelThreshold = __THRESHOLD__;
 
 int OnInit()
 {
@@ -63,9 +64,9 @@ void OnTick()
 
    double prob = ComputeLogisticScore();
 
-   // Very naive trade logic: open buy if probability > 0.5 else sell
+   // Open buy if probability exceeds threshold else sell
    int ticket;
-   if(prob > 0.5)
+   if(prob > ModelThreshold)
    {
       ticket = OrderSend(SymbolToTrade, OP_BUY, Lots, Ask, 3, 0, 0,
                          "model", MagicNumber, 0, clrBlue);

--- a/scripts/generate_mql4_from_model.py
+++ b/scripts/generate_mql4_from_model.py
@@ -32,6 +32,9 @@ def generate(model_json: Path, out_dir: Path):
 
     intercept = model.get('intercept', 0.0)
     output = output.replace('__INTERCEPT__', _fmt(intercept))
+
+    threshold = model.get('threshold', 0.5)
+    output = output.replace('__THRESHOLD__', _fmt(threshold))
     out_file = out_dir / f"Generated_{model.get('model_id', 'model')}.mq4"
     with open(out_file, 'w') as f:
         f.write(output)

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -12,6 +12,7 @@ def test_generate(tmp_path: Path):
         "magic": 777,
         "coefficients": [0.1, -0.2],
         "intercept": 0.05,
+        "threshold": 0.6,
     }
     model_file = tmp_path / "model.json"
     with open(model_file, "w") as f:
@@ -27,3 +28,4 @@ def test_generate(tmp_path: Path):
     assert "MagicNumber = 777" in content
     assert "double ModelCoefficients[] = {0.1, -0.2};" in content
     assert "double ModelIntercept = 0.05;" in content
+    assert "double ModelThreshold = 0.6;" in content

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -81,6 +81,7 @@ def test_train(tmp_path: Path):
     with open(model_file) as f:
         data = json.load(f)
     assert "coefficients" in data
+    assert "threshold" in data
 
 
 def test_train_with_indicators(tmp_path: Path):


### PR DESCRIPTION
## Summary
- add probability threshold optimization and classifier choice to `train_target_clone.py`
- output threshold in `model.json`
- apply threshold in `StrategyTemplate.mq4`
- embed threshold in generated strategies
- update unit tests for new functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882cd5f9838832fb15e597ed9971c01