### PR TITLE
Add debug logging mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ over the last `MetricsRollingDays` days. Old entries beyond
 ## Maintenance
 
 Logs are written to the directory specified by the EA parameter `LogDirectoryName` (default `observer_logs`).  Periodically archive or clean this directory to avoid large disk usage.  Models placed in the `models/best` folder can be retained for future analysis.
-Trade events are stored in a small in-memory buffer before being flushed to `trades_raw.csv` on each timer tick or when the buffer reaches `LogBufferSize` lines.  Set `EnableDebugLogging` to `true` to force immediate writes for easier debugging.
+Trade events are stored in a small in-memory buffer before being flushed to `trades_raw.csv` on each timer tick or when the buffer reaches `LogBufferSize` lines.  Set `EnableDebugLogging` to `true` to enable verbose output and force immediate writes for easier debugging.
 Metrics entries older than the number of days specified by `MetricsDaysToKeep` (default 30) are removed automatically during log export.
 
 ## Real-time Streaming
@@ -77,6 +77,11 @@ pytest
 - Ensure the MT4 terminal has permission to write files in `MQL4\Files`.
 - When running Python scripts, verify the paths to log files and models are correct.
 - Use the Experts and Journal tabs inside MT4 for additional debugging information.
+
+## Debugging Tips
+
+- Set `EnableDebugLogging` to `true` to print socket status and feature values.
+- Review the Experts and Journal tabs in MT4 to see these messages.
 
 This repository contains only minimal placeholder code to get started.  Extend the MQL4 and Python modules to implement full learning and cloning functionality.
 

--- a/experts/Observer_TBot.mq4
+++ b/experts/Observer_TBot.mq4
@@ -156,9 +156,19 @@ int OnInit()
       {
          if(!SocketConnect(log_socket, LogSocketHost, LogSocketPort, 1000))
          {
+            if(EnableDebugLogging)
+               Print("Socket connection failed: ", GetLastError());
             SocketClose(log_socket);
             log_socket = INVALID_HANDLE;
          }
+         else if(EnableDebugLogging)
+         {
+            Print("Socket connected to ", LogSocketHost, ":", LogSocketPort);
+         }
+      }
+      else if(EnableDebugLogging)
+      {
+         Print("Socket creation failed: ", GetLastError());
       }
    }
 
@@ -177,6 +187,8 @@ void OnDeinit(const int reason)
    }
    if(log_socket!=INVALID_HANDLE)
    {
+      if(EnableDebugLogging)
+         Print("Closing log socket");
       SocketClose(log_socket);
       log_socket = INVALID_HANDLE;
    }

--- a/experts/StrategyTemplate.mq4
+++ b/experts/StrategyTemplate.mq4
@@ -4,6 +4,7 @@
 extern string SymbolToTrade = "EURUSD";
 extern double Lots = 0.1;
 extern int MagicNumber = 1234;
+extern bool EnableDebugLogging = false;
 
 double ModelCoefficients[] = {__COEFFICIENTS__};
 double ModelIntercept = __INTERCEPT__;
@@ -63,6 +64,17 @@ void OnTick()
       return;
 
    double prob = ComputeLogisticScore();
+   if(EnableDebugLogging)
+   {
+      string feat_vals = "";
+      int n_feats = ArraySize(ModelCoefficients);
+      for(int i=0; i<n_feats; i++)
+      {
+         if(i>0) feat_vals += ",";
+         feat_vals += DoubleToString(GetFeature(i), 2);
+      }
+      Print("Features: [" + feat_vals + "] prob=" + DoubleToString(prob, 4));
+   }
 
    // Open buy if probability exceeds threshold else sell
    int ticket;


### PR DESCRIPTION
## Summary
- expand `EnableDebugLogging` to print socket connection status
- log socket closing when deinitializing the EA
- add debug flag and feature printing to `StrategyTemplate.mq4`
- document verbose logging and tips in README

## Testing
- `pip install numpy scikit-learn --quiet`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882d804b5a0832f9e0d8ceae15af6f1