### PR TITLE
Add feature mapping to generator

### DIFF
--- a/experts/StrategyTemplate.mq4
+++ b/experts/StrategyTemplate.mq4
@@ -27,13 +27,7 @@ double GetFeature(int index)
       to zero. */
    switch(index)
    {
-      case 0:
-         // Hour of day (0-23)
-         return(TimeHour(TimeCurrent()));
-      case 1:
-         // Current market spread in points
-         return(MarketInfo(SymbolToTrade, MODE_SPREAD));
-      default:
+__FEATURE_CASES__      default:
          return(0.0);
    }
 }

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -13,6 +13,7 @@ def test_generate(tmp_path: Path):
         "coefficients": [0.1, -0.2],
         "intercept": 0.05,
         "threshold": 0.6,
+        "feature_names": ["hour", "spread"],
     }
     model_file = tmp_path / "model.json"
     with open(model_file, "w") as f:
@@ -29,3 +30,5 @@ def test_generate(tmp_path: Path):
     assert "double ModelCoefficients[] = {0.1, -0.2};" in content
     assert "double ModelIntercept = 0.05;" in content
     assert "double ModelThreshold = 0.6;" in content
+    assert "TimeHour(TimeCurrent())" in content
+    assert "MODE_SPREAD" in content


### PR DESCRIPTION
## Summary
- support reading `feature_names` from model.json when generating MQL4
- render feature cases dynamically in template
- update StrategyTemplate to include placeholder
- extend tests to verify feature mapping

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882e0c152e4832f8161e5368c05822e