### PR TITLE
Add event ID to trade logs

### DIFF
--- a/experts/Observer_TBot.mq4
+++ b/experts/Observer_TBot.mq4
@@ -31,6 +31,7 @@ int      trade_log_handle = INVALID_HANDLE;
 int      log_socket = INVALID_HANDLE;
 datetime last_socket_attempt = 0;
 string   trade_log_buffer[];
+int      NextEventId = 1;
 
 // Binary search helper for sorted arrays. Returns index if found
 // or bitwise complement of insertion position if not found.
@@ -145,7 +146,7 @@ int OnInit()
       FileSeek(trade_log_handle, 0, SEEK_END);
       if(need_header)
       {
-         string header = "event_time;broker_time;local_time;action;ticket;magic;source;symbol;order_type;lots;price;sl;tp;profit;comment";
+         string header = "event_id;event_time;broker_time;local_time;action;ticket;magic;source;symbol;order_type;lots;price;sl;tp;profit;comment";
          FileWrite(trade_log_handle, header);
       }
    }
@@ -388,7 +389,9 @@ void LogTrade(string action, int ticket, int magic, string source,
 {
    if(trade_log_handle==INVALID_HANDLE)
       return;
-   string line = StringFormat("%s;%s;%s;%s;%d;%d;%s;%s;%d;%.2f;%.5f;%.5f;%.5f;%.2f;%s",
+   int id = NextEventId++;
+   string line = StringFormat("%d;%s;%s;%s;%s;%d;%d;%s;%s;%d;%.2f;%.5f;%.5f;%.5f;%.2f;%s",
+      id,
       TimeToString(time_event, TIME_DATE|TIME_SECONDS),
       TimeToString(TimeCurrent(), TIME_DATE|TIME_SECONDS),
       TimeToString(TimeLocal(), TIME_DATE|TIME_SECONDS),
@@ -408,7 +411,8 @@ void LogTrade(string action, int ticket, int magic, string source,
          FlushTradeBuffer();
    }
 
-   string json = StringFormat("{\"event_time\":\"%s\",\"broker_time\":\"%s\",\"local_time\":\"%s\",\"action\":\"%s\",\"ticket\":%d,\"magic\":%d,\"source\":\"%s\",\"symbol\":\"%s\",\"order_type\":%d,\"lots\":%.2f,\"price\":%.5f,\"sl\":%.5f,\"tp\":%.5f,\"profit\":%.2f,\"comment\":\"%s\"}",
+   string json = StringFormat("{\"event_id\":%d,\"event_time\":\"%s\",\"broker_time\":\"%s\",\"local_time\":\"%s\",\"action\":\"%s\",\"ticket\":%d,\"magic\":%d,\"source\":\"%s\",\"symbol\":\"%s\",\"order_type\":%d,\"lots\":%.2f,\"price\":%.5f,\"sl\":%.5f,\"tp\":%.5f,\"profit\":%.2f,\"comment\":\"%s\"}",
+      id,
       EscapeJson(TimeToString(time_event, TIME_DATE|TIME_SECONDS)),
       EscapeJson(TimeToString(TimeCurrent(), TIME_DATE|TIME_SECONDS)),
       EscapeJson(TimeToString(TimeLocal(), TIME_DATE|TIME_SECONDS)),

--- a/scripts/stream_listener.py
+++ b/scripts/stream_listener.py
@@ -9,6 +9,7 @@ import json
 
 
 FIELDS = [
+    "event_id",
     "event_time",
     "broker_time",
     "local_time",

--- a/scripts/train_rl_agent.py
+++ b/scripts/train_rl_agent.py
@@ -19,6 +19,7 @@ from sklearn.feature_extraction import DictVectorizer
 def _load_logs(data_dir: Path) -> List[Dict]:
     """Load raw log rows from ``data_dir``."""
     fields = [
+        "event_id",
         "event_time",
         "broker_time",
         "local_time",

--- a/scripts/train_target_clone.py
+++ b/scripts/train_target_clone.py
@@ -79,6 +79,7 @@ def _load_logs(data_dir: Path):
     """
 
     fields = [
+        "event_id",
         "event_time",
         "broker_time",
         "local_time",

--- a/tests/test_stream_listener.py
+++ b/tests/test_stream_listener.py
@@ -23,6 +23,7 @@ def test_stream_listener(tmp_path: Path):
     time.sleep(0.1)
 
     msg = {
+        "event_id": 1,
         "event_time": "t",
         "broker_time": "b",
         "local_time": "l",
@@ -52,7 +53,7 @@ def test_stream_listener(tmp_path: Path):
         lines = [l.strip() for l in f.readlines() if l.strip()]
 
     expected = [
-        "event_time;broker_time;local_time;action;ticket;magic;source;symbol;order_type;lots;price;sl;tp;profit;comment",
-        "t;b;l;OPEN;1;2;mt4;EURUSD;0;0.1;1.2345;1.0;2.0;0.0;hi",
+        "event_id;event_time;broker_time;local_time;action;ticket;magic;source;symbol;order_type;lots;price;sl;tp;profit;comment",
+        "1;t;b;l;OPEN;1;2;mt4;EURUSD;0;0.1;1.2345;1.0;2.0;0.0;hi",
     ]
     assert lines == expected

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -9,6 +9,7 @@ from scripts.train_target_clone import train, _load_logs
 
 def _write_log(file: Path):
     fields = [
+        "event_id",
         "event_time",
         "broker_time",
         "local_time",
@@ -27,6 +28,7 @@ def _write_log(file: Path):
     ]
     rows = [
         [
+            "1",
             "2024.01.01 00:00:00",
             "",
             "",
@@ -44,6 +46,7 @@ def _write_log(file: Path):
             "",
         ],
         [
+            "2",
             "2024.01.01 01:00:00",
             "",
             "",

--- a/tests/test_train_rl_agent.py
+++ b/tests/test_train_rl_agent.py
@@ -9,6 +9,7 @@ from scripts.train_rl_agent import train
 
 def _write_log(file: Path):
     fields = [
+        "event_id",
         "event_time",
         "broker_time",
         "local_time",
@@ -27,6 +28,7 @@ def _write_log(file: Path):
     ]
     rows = [
         [
+            "1",
             "2024.01.01 00:00:00",
             "",
             "",
@@ -44,6 +46,7 @@ def _write_log(file: Path):
             "",
         ],
         [
+            "2",
             "2024.01.01 00:30:00",
             "",
             "",
@@ -61,6 +64,7 @@ def _write_log(file: Path):
             "",
         ],
         [
+            "3",
             "2024.01.01 01:00:00",
             "",
             "",
@@ -78,6 +82,7 @@ def _write_log(file: Path):
             "",
         ],
         [
+            "4",
             "2024.01.01 01:30:00",
             "",
             "",


### PR DESCRIPTION
## Summary
- include an increasing `event_id` in Observer_TBot logs
- parse new column in `train_target_clone.py`
- adjust stream listener fields
- keep training scripts working and update tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882e2af3868832f8cb0d5e1680a1872