### PR TITLE
Add rolling drawdown and Sharpe metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ The EA records trade openings and closings using the `OnTradeTransaction` callba
   - `generate_mql4_from_model.py` – renders a new EA from a trained model description.
   - `evaluate_predictions.py` – basic log evaluation utility.
   - `promote_best_models.py` – selects top models by metric and copies them to a best directory.
+  - `plot_metrics.py` – plot metric history using Matplotlib.
 - `models/` – location for generated models.
 - `config.json` – example configuration file.
 
@@ -41,9 +42,11 @@ Compile the generated MQ4 file and the observer will begin evaluating prediction
 
 During operation the EA records a summary line for each tracked model in
 `observer_logs/metrics.csv`. Each entry contains the time of capture, the model
-identifier (its magic number), the hit rate and the profit factor calculated
-over the last `MetricsRollingDays` days. Old entries beyond
-`MetricsDaysToKeep` days are pruned automatically.
+identifier (its magic number), the rolling win rate, average profit, trade
+count, drawdown and Sharpe ratio calculated over the last
+`MetricsRollingDays` days. Old entries beyond `MetricsDaysToKeep` days are
+pruned automatically.
+The ``plot_metrics.py`` script can be used to visualise these values.
 
 ## Maintenance
 
@@ -53,9 +56,10 @@ Metrics entries older than the number of days specified by `MetricsDaysToKeep` (
 
 ## Real-time Streaming
 
-When `EnableSocketLogging` is enabled the observer EA emits each trade event as a JSON
-line over a TCP socket. The helper script ``stream_listener.py`` can convert these
-messages into a CSV log in real time:
+When `EnableSocketLogging` is enabled the observer EA emits each trade event and
+periodic metric summary as newline separated JSON over a TCP socket. The helper
+script ``stream_listener.py`` can convert these messages into a CSV log in real
+time:
 
 ```bash
 python scripts/stream_listener.py --out stream.csv

--- a/scripts/plot_metrics.py
+++ b/scripts/plot_metrics.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Plot metrics over time from metrics.csv."""
+
+import argparse
+import csv
+from datetime import datetime
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+
+
+def _load_metrics(path: Path):
+    rows = []
+    with open(path, newline="") as f:
+        reader = csv.DictReader(f, delimiter=";")
+        for r in reader:
+            try:
+                ts = datetime.strptime(r["time"], "%Y.%m.%d %H:%M")
+            except Exception:
+                continue
+            try:
+                magic = int(float(r.get("magic") or r.get("model_id") or 0))
+            except Exception:
+                magic = 0
+            rows.append(
+                {
+                    "time": ts,
+                    "magic": magic,
+                    "win_rate": float(r.get("win_rate", 0) or 0),
+                    "avg_profit": float(r.get("avg_profit", 0) or 0),
+                    "trade_count": int(float(r.get("trade_count", 0) or 0)),
+                    "drawdown": float(r.get("drawdown", 0) or 0),
+                    "sharpe": float(r.get("sharpe", 0) or 0),
+                }
+            )
+    return rows
+
+
+def _plot(rows, magic=None):
+    if magic is not None:
+        rows = [r for r in rows if r["magic"] == magic]
+    if not rows:
+        print("No matching rows")
+        return
+    rows.sort(key=lambda r: r["time"])
+    times = [r["time"] for r in rows]
+    win_rate = [r["win_rate"] for r in rows]
+    drawdown = [r["drawdown"] for r in rows]
+    sharpe = [r["sharpe"] for r in rows]
+
+    fig, ax1 = plt.subplots()
+    ax1.plot(times, win_rate, label="Win Rate")
+    ax1.set_ylabel("Win Rate")
+    ax1.set_xlabel("Time")
+
+    ax2 = ax1.twinx()
+    ax2.plot(times, drawdown, color="r", label="Drawdown")
+    ax2.plot(times, sharpe, color="g", label="Sharpe")
+    ax2.set_ylabel("Drawdown / Sharpe")
+
+    ax1.legend(loc="upper left")
+    ax2.legend(loc="upper right")
+    plt.show()
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description="Plot metrics over time")
+    p.add_argument("metrics_file", help="Path to metrics.csv")
+    p.add_argument("--magic", type=int, help="Filter by magic/model id")
+    args = p.parse_args()
+
+    rows = _load_metrics(Path(args.metrics_file))
+    _plot(rows, args.magic)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- expand metric calculations in `Observer_TBot.mq4`
- emit metric lines over socket
- script for plotting metric history
- document new metrics and helper script

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882ee8c5afc832f971ec306ae5c5e42