### PR TITLE
Add remaining lots tracking

### DIFF
--- a/scripts/stream_listener.py
+++ b/scripts/stream_listener.py
@@ -25,6 +25,7 @@ FIELDS = [
     "tp",
     "profit",
     "comment",
+    "remaining_lots",
 ]
 
 

--- a/scripts/train_rl_agent.py
+++ b/scripts/train_rl_agent.py
@@ -35,6 +35,7 @@ def _load_logs(data_dir: Path) -> List[Dict]:
         "tp",
         "profit",
         "comment",
+        "remaining_lots",
     ]
 
     rows: List[Dict] = []

--- a/scripts/train_target_clone.py
+++ b/scripts/train_target_clone.py
@@ -95,6 +95,7 @@ def _load_logs(data_dir: Path):
         "tp",
         "profit",
         "comment",
+        "remaining_lots",
     ]
 
     rows = []

--- a/tests/test_stream_listener.py
+++ b/tests/test_stream_listener.py
@@ -39,6 +39,7 @@ def test_stream_listener(tmp_path: Path):
         "tp": 2.0,
         "profit": 0.0,
         "comment": "hi",
+        "remaining_lots": 0.1,
     }
 
     client = socket.socket()
@@ -53,7 +54,7 @@ def test_stream_listener(tmp_path: Path):
         lines = [l.strip() for l in f.readlines() if l.strip()]
 
     expected = [
-        "event_id;event_time;broker_time;local_time;action;ticket;magic;source;symbol;order_type;lots;price;sl;tp;profit;comment",
-        "1;t;b;l;OPEN;1;2;mt4;EURUSD;0;0.1;1.2345;1.0;2.0;0.0;hi",
+        "event_id;event_time;broker_time;local_time;action;ticket;magic;source;symbol;order_type;lots;price;sl;tp;profit;comment;remaining_lots",
+        "1;t;b;l;OPEN;1;2;mt4;EURUSD;0;0.1;1.2345;1.0;2.0;0.0;hi;0.1",
     ]
     assert lines == expected

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -25,6 +25,7 @@ def _write_log(file: Path):
         "tp",
         "profit",
         "comment",
+        "remaining_lots",
     ]
     rows = [
         [
@@ -44,6 +45,7 @@ def _write_log(file: Path):
             "1.1100",
             "0",
             "",
+            "0.1",
         ],
         [
             "2",
@@ -62,6 +64,7 @@ def _write_log(file: Path):
             "1.2100",
             "0",
             "",
+            "0.1",
         ],
     ]
     with open(file, "w", newline="") as f:

--- a/tests/test_train_rl_agent.py
+++ b/tests/test_train_rl_agent.py
@@ -25,6 +25,7 @@ def _write_log(file: Path):
         "tp",
         "profit",
         "comment",
+        "remaining_lots",
     ]
     rows = [
         [
@@ -44,6 +45,7 @@ def _write_log(file: Path):
             "1.1100",
             "0",
             "",
+            "0.1",
         ],
         [
             "2",
@@ -62,6 +64,7 @@ def _write_log(file: Path):
             "1.1100",
             "5",
             "",
+            "0",
         ],
         [
             "3",
@@ -80,6 +83,7 @@ def _write_log(file: Path):
             "1.2100",
             "0",
             "",
+            "0.1",
         ],
         [
             "4",
@@ -98,6 +102,7 @@ def _write_log(file: Path):
             "1.2100",
             "-3",
             "",
+            "0",
         ],
     ]
     with open(file, "w", newline="") as f:


### PR DESCRIPTION
## Summary
- handle partial closes in Observer EA
- include `remaining_lots` in trade log header and JSON output
- update Python log readers and stream listener for new column
- adjust unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883044e15e4832fa773653d2fb412ca