### PR TITLE
Add tick history export and analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,20 @@ will be populated as trades occur.
 If the connection is lost, the EA will automatically attempt to reconnect
 periodically so streaming can resume without manual intervention.
 
+## Tick History Export
+
+Historical tick data can be exported for all symbols that appear in the account
+history using the ``TickHistoryExporter`` script.  Copy
+``experts/TickHistoryExporter.mq4`` to your ``MQL4\Scripts`` directory and run
+it from the terminal.  CSV files named ``ticks_SYMBOL.csv`` will be written to
+the ``Files`` folder inside ``OutDir`` for the period spanning your trading
+activity.  The helper script ``analyze_ticks.py`` can then compute basic
+statistics from these files:
+
+```bash
+python scripts/analyze_ticks.py observer_logs/ticks_EURUSD.csv
+```
+
 ## Running Tests
 
 Install the Python requirements and run `pytest` from the repository root:

--- a/experts/TickHistoryExporter.mq4
+++ b/experts/TickHistoryExporter.mq4
@@ -1,0 +1,96 @@
+#property strict
+#property script_show_inputs
+
+input string OutDir = "observer_logs"; // Directory inside MQL4/Files
+input string Symbols = "";            // Optional comma separated symbol list
+
+struct SymbolRange
+{
+   string   symbol;
+   datetime start;
+   datetime end;
+};
+
+int OnStart()
+{
+   HistorySelect(0, TimeCurrent());
+   int deals = HistoryDealsTotal();
+   SymbolRange ranges[];
+   string filter[];
+   int filter_count = 0;
+   if(StringLen(Symbols) > 0)
+      filter_count = StringSplit(Symbols, ',', filter);
+
+   for(int i=0; i<deals; i++)
+   {
+      ulong ticket = HistoryDealGetTicket(i);
+      if(!HistoryDealSelect(ticket))
+         continue;
+      string sym = HistoryDealGetString(ticket, DEAL_SYMBOL);
+      datetime tm = (datetime)HistoryDealGetInteger(ticket, DEAL_TIME);
+      bool match = (filter_count == 0);
+      if(!match)
+      {
+         for(int j=0; j<filter_count; j++)
+            if(StringCompare(filter[j], sym, true)==0) { match=true; break; }
+      }
+      if(!match) continue;
+      int idx = -1;
+      for(int r=0; r<ArraySize(ranges); r++)
+         if(StringCompare(ranges[r].symbol, sym, true)==0) { idx=r; break; }
+      if(idx < 0)
+      {
+         SymbolRange sr;
+         sr.symbol = sym;
+         sr.start = tm;
+         sr.end = tm;
+         int n = ArraySize(ranges);
+         ArrayResize(ranges, n+1);
+         ranges[n] = sr;
+      }
+      else
+      {
+         if(tm < ranges[idx].start) ranges[idx].start = tm;
+         if(tm > ranges[idx].end)   ranges[idx].end   = tm;
+      }
+   }
+
+   for(int i=0; i<ArraySize(ranges); i++)
+      ExportTicks(ranges[i].symbol, ranges[i].start, ranges[i].end);
+
+   return(INIT_SUCCEEDED);
+}
+
+void ExportTicks(string symbol, datetime from, datetime to)
+{
+   MqlTick ticks[];
+   string fname = StringFormat("%s/ticks_%s.csv", OutDir, symbol);
+   int fh = FileOpen(fname, FILE_WRITE|FILE_CSV|FILE_TXT|FILE_SHARE_WRITE, ';');
+   if(fh==INVALID_HANDLE)
+   {
+      Print("Failed to open ", fname, " : ", GetLastError());
+      return;
+   }
+   FileWrite(fh, "time;bid;ask;last;volume");
+   datetime cur = from;
+   long total = 0;
+   while(cur <= to)
+   {
+      int copied = CopyTicksRange(symbol, ticks, cur, to, COPY_TICKS_ALL);
+      if(copied <= 0)
+         break;
+      for(int i=0; i<copied; i++)
+      {
+         FileWrite(fh,
+                   TimeToString(ticks[i].time, TIME_DATE|TIME_SECONDS),
+                   DoubleToString(ticks[i].bid, _Digits),
+                   DoubleToString(ticks[i].ask, _Digits),
+                   DoubleToString(ticks[i].last, _Digits),
+                   DoubleToString(ticks[i].volume, 2));
+         cur = ticks[i].time + 1;
+         total++;
+      }
+   }
+   FileClose(fh);
+   Print(StringFormat("Exported %d ticks for %s", total, symbol));
+}

--- a/scripts/analyze_ticks.py
+++ b/scripts/analyze_ticks.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Compute basic metrics from exported tick history."""
+import argparse
+import csv
+from pathlib import Path
+from typing import Dict, List
+
+
+def load_ticks(file: Path) -> List[Dict]:
+    with open(file, newline="") as f:
+        reader = csv.DictReader(f, delimiter=";")
+        rows = []
+        for r in reader:
+            rows.append(
+                {
+                    "time": r.get("time"),
+                    "bid": float(r.get("bid", 0) or 0),
+                    "ask": float(r.get("ask", 0) or 0),
+                }
+            )
+        return rows
+
+
+def compute_metrics(rows: List[Dict]) -> Dict:
+    if not rows:
+        return {"tick_count": 0, "avg_spread": 0.0, "price_change": 0.0}
+    spreads = [r["ask"] - r["bid"] for r in rows]
+    avg_spread = sum(spreads) / len(spreads)
+    price_change = rows[-1]["bid"] - rows[0]["bid"]
+    return {
+        "tick_count": len(rows),
+        "avg_spread": avg_spread,
+        "price_change": price_change,
+    }
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("tick_file")
+    p.add_argument("--out", help="Output JSON file")
+    args = p.parse_args()
+
+    rows = load_ticks(Path(args.tick_file))
+    stats = compute_metrics(rows)
+    if args.out:
+        import json
+
+        with open(args.out, "w") as f:
+            json.dump(stats, f)
+    else:
+        print(stats)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_analyze_ticks.py
+++ b/tests/test_analyze_ticks.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+import sys
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from scripts.analyze_ticks import load_ticks, compute_metrics
+import pytest
+
+
+def _write_ticks(file: Path):
+    with open(file, "w") as f:
+        f.write("time;bid;ask;last;volume\n")
+        f.write("2024.01.01 00:00:00;1.1000;1.1002;0;0\n")
+        f.write("2024.01.01 00:00:01;1.1001;1.1003;0;0\n")
+        f.write("2024.01.01 00:00:02;1.1002;1.1004;0;0\n")
+
+
+def test_metrics(tmp_path: Path):
+    tick_file = tmp_path / "ticks.csv"
+    _write_ticks(tick_file)
+
+    rows = load_ticks(tick_file)
+    stats = compute_metrics(rows)
+
+    assert stats["tick_count"] == 3
+    assert stats["avg_spread"] == pytest.approx(0.0002)
+    assert stats["price_change"] == pytest.approx(0.0002)


### PR DESCRIPTION
## Summary
- add `TickHistoryExporter.mq4` script to dump tick history for traded symbols
- provide `analyze_ticks.py` helper to compute basic tick metrics
- document tick export workflow in README
- test tick analysis logic

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6883121d3f68832f906ee943bf5a220d