### PR TITLE
Handle partial closes and parse MODIFY logs

### DIFF
--- a/experts/Observer_TBot.mq4
+++ b/experts/Observer_TBot.mq4
@@ -239,6 +239,14 @@ void OnTradeTransaction(const MqlTradeTransaction &trans,
                lots, price, sl, tp, 0.0, remaining, now, comment);
       if(!IsTracked(ticket))
          AddTicket(ticket);
+      else if(entry==DEAL_ENTRY_INOUT && remaining>0.0 && OrderSelect(ticket, SELECT_BY_TICKET, MODE_TRADES))
+      {
+         double cur_price = OrderOpenPrice();
+         double cur_sl    = OrderStopLoss();
+         double cur_tp    = OrderTakeProfit();
+         LogTrade("MODIFY", ticket, magic, "mt4", symbol, order_type,
+                  0.0, cur_price, cur_sl, cur_tp, 0.0, remaining, now, comment);
+      }
    }
    else if(entry==DEAL_ENTRY_OUT || entry==DEAL_ENTRY_OUT_BY)
    {
@@ -246,6 +254,14 @@ void OnTradeTransaction(const MqlTradeTransaction &trans,
                lots, price, sl, tp, profit, remaining, now, comment);
       if(IsTracked(ticket) && remaining==0.0)
          RemoveTicket(ticket);
+      else if(remaining>0.0 && OrderSelect(ticket, SELECT_BY_TICKET, MODE_TRADES))
+      {
+         double cur_price = OrderOpenPrice();
+         double cur_sl    = OrderStopLoss();
+         double cur_tp    = OrderTakeProfit();
+         LogTrade("MODIFY", ticket, magic, "mt4", symbol, order_type,
+                  0.0, cur_price, cur_sl, cur_tp, 0.0, remaining, now, comment);
+      }
    }
 }
 


### PR DESCRIPTION
## Summary
- add MODIFY log entries for partial closes in Observer_TBot
- ignore unknown actions when loading logs and recognise MODIFY
- clarify load_logs docstring about MODIFY

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688415203138832f96e5cd443863ef69