### PR TITLE
Add error counters to metrics

### DIFF
--- a/scripts/plot_metrics.py
+++ b/scripts/plot_metrics.py
@@ -31,6 +31,8 @@ def _load_metrics(path: Path):
                     "trade_count": int(float(r.get("trade_count", 0) or 0)),
                     "drawdown": float(r.get("drawdown", 0) or 0),
                     "sharpe": float(r.get("sharpe", 0) or 0),
+                    "write_errors": int(float(r.get("write_errors", 0) or 0)),
+                    "socket_errors": int(float(r.get("socket_errors", 0) or 0)),
                 }
             )
     return rows
@@ -47,11 +49,12 @@ def _plot(rows, magic=None):
     win_rate = [r["win_rate"] for r in rows]
     drawdown = [r["drawdown"] for r in rows]
     sharpe = [r["sharpe"] for r in rows]
+    write_err = [r["write_errors"] for r in rows]
+    socket_err = [r["socket_errors"] for r in rows]
 
-    fig, ax1 = plt.subplots()
+    fig, (ax1, ax3) = plt.subplots(2, 1, sharex=True)
     ax1.plot(times, win_rate, label="Win Rate")
     ax1.set_ylabel("Win Rate")
-    ax1.set_xlabel("Time")
 
     ax2 = ax1.twinx()
     ax2.plot(times, drawdown, color="r", label="Drawdown")
@@ -60,6 +63,13 @@ def _plot(rows, magic=None):
 
     ax1.legend(loc="upper left")
     ax2.legend(loc="upper right")
+
+    ax3.plot(times, write_err, label="Write Errors", color="purple")
+    ax3.plot(times, socket_err, label="Socket Errors", color="orange")
+    ax3.set_ylabel("Error Count")
+    ax3.set_xlabel("Time")
+    ax3.legend()
+    plt.tight_layout()
     plt.show()
 
 


### PR DESCRIPTION
## Summary
- track write and socket error counts in Observer_TBot
- emit the new counters in WriteMetrics
- show write/socket errors in plot_metrics

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68841aed31b8832f815db3fc93487f40