### PR TITLE
Add JSON schema versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,56 @@ will be populated as trades occur.
 If the connection is lost, the EA will automatically attempt to reconnect
 periodically so streaming can resume without manual intervention.
 
+### Streaming Message Schema
+
+Each JSON message includes a ``schema_version`` field so downstream
+consumers can detect incompatible changes.  The current implementation
+emits ``schema_version`` ``1``.
+
+Trade event messages contain the following keys:
+
+```
+{
+  "event_id": int,
+  "event_time": "YYYY.MM.DD HH:MM:SS",
+  "broker_time": "YYYY.MM.DD HH:MM:SS",
+  "local_time": "YYYY.MM.DD HH:MM:SS",
+  "action": "OPEN|CLOSE|MODIFY",
+  "ticket": int,
+  "magic": int,
+  "source": "mt4",
+  "symbol": str,
+  "order_type": int,
+  "lots": float,
+  "price": float,
+  "sl": float,
+  "tp": float,
+  "profit": float,
+  "comment": str,
+  "remaining_lots": float,
+  "schema_version": 1
+}
+```
+
+Metrics summaries have keys:
+
+```
+{
+  "type": "metrics",
+  "time": "YYYY.MM.DD HH:MM",
+  "magic": int,
+  "win_rate": float,
+  "avg_profit": float,
+  "trade_count": int,
+  "drawdown": float,
+  "sharpe": float,
+  "schema_version": 1
+}
+```
+
+The ``stream_listener.py`` script validates this field and warns if the
+version differs from the one it expects.
+
 ## Tick History Export
 
 Historical tick data can be exported for all symbols that appear in the account

--- a/experts/Observer_TBot.mq4
+++ b/experts/Observer_TBot.mq4
@@ -32,6 +32,7 @@ int      log_socket = INVALID_HANDLE;
 datetime last_socket_attempt = 0;
 string   trade_log_buffer[];
 int      NextEventId = 1;
+int const JSON_SCHEMA_VERSION = 1;
 
 int MapGet(int key)
 {
@@ -392,13 +393,13 @@ void LogTrade(string action, int ticket, int magic, string source,
          FlushTradeBuffer();
    }
 
-   string json = StringFormat("{\"event_id\":%d,\"event_time\":\"%s\",\"broker_time\":\"%s\",\"local_time\":\"%s\",\"action\":\"%s\",\"ticket\":%d,\"magic\":%d,\"source\":\"%s\",\"symbol\":\"%s\",\"order_type\":%d,\"lots\":%.2f,\"price\":%.5f,\"sl\":%.5f,\"tp\":%.5f,\"profit\":%.2f,\"comment\":\"%s\",\"remaining_lots\":%.2f}",
+   string json = StringFormat("{\"event_id\":%d,\"event_time\":\"%s\",\"broker_time\":\"%s\",\"local_time\":\"%s\",\"action\":\"%s\",\"ticket\":%d,\"magic\":%d,\"source\":\"%s\",\"symbol\":\"%s\",\"order_type\":%d,\"lots\":%.2f,\"price\":%.5f,\"sl\":%.5f,\"tp\":%.5f,\"profit\":%.2f,\"comment\":\"%s\",\"remaining_lots\":%.2f,\"schema_version\":%d}",
       id,
       EscapeJson(TimeToString(time_event, TIME_DATE|TIME_SECONDS)),
       EscapeJson(TimeToString(TimeCurrent(), TIME_DATE|TIME_SECONDS)),
       EscapeJson(TimeToString(TimeLocal(), TIME_DATE|TIME_SECONDS)),
       EscapeJson(action), ticket, magic, EscapeJson(source), EscapeJson(symbol), order_type,
-      lots, price, sl, tp, profit, EscapeJson(comment), remaining);
+      lots, price, sl, tp, profit, EscapeJson(comment), remaining, JSON_SCHEMA_VERSION);
 
    if(log_socket!=INVALID_HANDLE)
    {
@@ -503,8 +504,8 @@ void WriteMetrics(datetime ts)
 
       if(log_socket!=INVALID_HANDLE)
       {
-         string json = StringFormat("{\"type\":\"metrics\",\"time\":\"%s\",\"magic\":%d,\"win_rate\":%.3f,\"avg_profit\":%.2f,\"trade_count\":%d,\"drawdown\":%.2f,\"sharpe\":%.3f}",
-            EscapeJson(TimeToString(ts, TIME_DATE|TIME_MINUTES)), magic, win_rate, avg_profit, trades, max_dd, sharpe);
+         string json = StringFormat("{\"type\":\"metrics\",\"time\":\"%s\",\"magic\":%d,\"win_rate\":%.3f,\"avg_profit\":%.2f,\"trade_count\":%d,\"drawdown\":%.2f,\"sharpe\":%.3f,\"schema_version\":%d}",
+            EscapeJson(TimeToString(ts, TIME_DATE|TIME_MINUTES)), magic, win_rate, avg_profit, trades, max_dd, sharpe, JSON_SCHEMA_VERSION);
          uchar bytes[];
          StringToCharArray(json+"\n", bytes);
          if(SocketSend(log_socket, bytes, ArraySize(bytes)-1)==-1)

--- a/scripts/stream_listener.py
+++ b/scripts/stream_listener.py
@@ -6,6 +6,7 @@ import socket
 from pathlib import Path
 import csv
 import json
+import warnings
 
 
 FIELDS = [
@@ -27,6 +28,8 @@ FIELDS = [
     "comment",
     "remaining_lots",
 ]
+
+SCHEMA_VERSION = 1
 
 
 def _write_lines(conn: socket.socket, out_file: Path) -> None:
@@ -53,6 +56,10 @@ def _write_lines(conn: socket.socket, out_file: Path) -> None:
                     obj = json.loads(line)
                 except json.JSONDecodeError:
                     continue
+                if obj.get("schema_version") != SCHEMA_VERSION:
+                    warnings.warn(
+                        f"Unexpected schema_version {obj.get('schema_version')} (expected {SCHEMA_VERSION})"
+                    )
                 row = [str(obj.get(field, "")) for field in FIELDS]
                 writer.writerow(row)
                 f.flush()

--- a/tests/test_stream_listener.py
+++ b/tests/test_stream_listener.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import sys
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
-from scripts.stream_listener import listen_once
+from scripts.stream_listener import listen_once, SCHEMA_VERSION
 
 
 def test_stream_listener(tmp_path: Path):
@@ -40,6 +40,7 @@ def test_stream_listener(tmp_path: Path):
         "profit": 0.0,
         "comment": "hi",
         "remaining_lots": 0.1,
+        "schema_version": SCHEMA_VERSION,
     }
 
     client = socket.socket()


### PR DESCRIPTION
## Summary
- append a `schema_version` to socket JSON messages from `Observer_TBot`
- warn on mismatched schema versions in `stream_listener.py`
- document streaming JSON schema in README
- update tests for the new message field

## Testing
- `pip install numpy`
- `pip install scikit-learn`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68841aedb8a0832f8e094989b244e06d