### PR TITLE
Add XGBoost option for target clone training

### DIFF
--- a/scripts/generate_mql4_from_model.py
+++ b/scripts/generate_mql4_from_model.py
@@ -26,7 +26,7 @@ def generate(model_json: Path, out_dir: Path):
         f"MagicNumber = {model.get('magic', 9999)}",
     )
 
-    coeffs = model.get('coefficients', [])
+    coeffs = model.get('coefficients') or model.get('coef_vector', [])
     coeff_str = ', '.join(_fmt(c) for c in coeffs)
     output = output.replace('__COEFFICIENTS__', coeff_str)
 

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -129,3 +129,20 @@ def test_load_logs_with_metrics(tmp_path: Path):
 
     rows = _load_logs(data_dir)
     assert all("win_rate" in r for r in rows)
+
+
+def test_train_xgboost(tmp_path: Path):
+    data_dir = tmp_path / "logs"
+    out_dir = tmp_path / "out"
+    data_dir.mkdir()
+    log_file = data_dir / "trades_test.csv"
+    _write_log(log_file)
+
+    train(data_dir, out_dir, model_type="xgboost", n_estimators=10)
+
+    model_file = out_dir / "model.json"
+    assert model_file.exists()
+    with open(model_file) as f:
+        data = json.load(f)
+    assert data.get("model_type") == "xgboost"
+    assert "coefficients" in data


### PR DESCRIPTION
## Summary
- support optional XGBoost classifier in `train_target_clone.py`
- include hyperparameters for tree depth, estimator count and learning rate
- approximate tree ensemble to linear coefficients for export
- allow `generate_mql4_from_model.py` to read alternative coefficient field
- test training workflow with XGBoost

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68841aeb178c832fac1c532f204dc571