### PR TITLE
Implement socket log service

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,24 +51,23 @@ The ``plot_metrics.py`` script can be used to visualise these values.
 ## Maintenance
 
 Logs are written to the directory specified by the EA parameter `LogDirectoryName` (default `observer_logs`).  Periodically archive or clean this directory to avoid large disk usage.  Models placed in the `models/best` folder can be retained for future analysis.
-Trade events are stored in a small in-memory buffer before being flushed to `trades_raw.csv` on each timer tick or when the buffer reaches `LogBufferSize` lines.  Set `EnableDebugLogging` to `true` to enable verbose output and force immediate writes for easier debugging.
+Trade events are streamed as JSON over a socket and can be persisted by running the Python service `trade_log_service.py`.  The EA keeps a small in-memory buffer that is only flushed to `trades_raw.csv` if the socket connection fails.  Set `EnableDebugLogging` to `true` to print extra messages.
 Metrics entries older than the number of days specified by `MetricsDaysToKeep` (default 30) are removed automatically during log export.
 
 ## Real-time Streaming
 
 When `EnableSocketLogging` is enabled the observer EA emits each trade event and
-periodic metric summary as newline separated JSON over a TCP socket. The helper
-script ``stream_listener.py`` can convert these messages into a CSV log in real
-time:
+periodic metric summary as newline separated JSON over a TCP socket. Run
+``trade_log_service.py`` to write these messages to a CSV file:
 
 ```bash
-python scripts/stream_listener.py --out stream.csv
+python scripts/trade_log_service.py --out observer_logs/trades_raw.csv
 ```
 
-Attach ``Observer_TBot`` in MT4 with the same host and port parameters and the CSV
-will be populated as trades occur.
-If the connection is lost, the EA will automatically attempt to reconnect
-periodically so streaming can resume without manual intervention.
+Attach ``Observer_TBot`` in MT4 with the same host and port parameters and the
+CSV will be populated as trades occur. If the connection is lost, the EA
+automatically attempts to reconnect so streaming can resume without manual
+intervention.
 
 ## Tick History Export
 

--- a/scripts/trade_log_service.py
+++ b/scripts/trade_log_service.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Service to write JSON socket messages from the observer EA to disk."""
+
+import argparse
+import socket
+from pathlib import Path
+import csv
+import json
+
+FIELDS = [
+    "event_id",
+    "event_time",
+    "broker_time",
+    "local_time",
+    "action",
+    "ticket",
+    "magic",
+    "source",
+    "symbol",
+    "order_type",
+    "lots",
+    "price",
+    "sl",
+    "tp",
+    "profit",
+    "comment",
+    "remaining_lots",
+]
+
+
+def _write_lines(conn: socket.socket, out_file: Path) -> None:
+    """Read newline-delimited JSON messages from ``conn`` and append rows."""
+
+    out_file.parent.mkdir(parents=True, exist_ok=True)
+    with open(out_file, "a", newline="") as f:
+        writer = csv.writer(f, delimiter=";")
+        need_header = f.tell() == 0
+        if need_header:
+            writer.writerow(FIELDS)
+        buffer = b""
+        while True:
+            data = conn.recv(4096)
+            if not data:
+                break
+            buffer += data
+            while b"\n" in buffer:
+                line, buffer = buffer.split(b"\n", 1)
+                line = line.decode("utf-8", errors="replace").strip()
+                if not line:
+                    continue
+                try:
+                    obj = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                row = [str(obj.get(field, "")) for field in FIELDS]
+                writer.writerow(row)
+                f.flush()
+
+
+def listen_once(host: str, port: int, out_file: Path) -> None:
+    """Accept a single connection and process it until closed."""
+
+    srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    srv.bind((host, port))
+    srv.listen(1)
+    try:
+        conn, _ = srv.accept()
+        with conn:
+            _write_lines(conn, out_file)
+    finally:
+        srv.close()
+
+
+def serve(host: str, port: int, out_file: Path) -> None:
+    """Continually accept connections and append incoming lines."""
+
+    while True:
+        listen_once(host, port, out_file)
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description="Write observer socket messages to CSV")
+    p.add_argument("--host", default="127.0.0.1")
+    p.add_argument("--port", type=int, default=9000)
+    p.add_argument("--out", default="observer_logs/trades_raw.csv", help="output CSV file")
+    args = p.parse_args()
+
+    serve(args.host, args.port, Path(args.out))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_stream_listener.py
+++ b/tests/test_stream_listener.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import sys
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
-from scripts.stream_listener import listen_once
+from scripts.trade_log_service import listen_once
 
 
 def test_stream_listener(tmp_path: Path):


### PR DESCRIPTION
## Summary
- add a Python service that listens to the observer socket and writes logs to CSV
- update README with service instructions
- send JSON first in `LogTrade` and only write to disk when socket fails
- adjust tests for the new service

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68841aea636c832f8e186b3160a245c2