### PR TITLE
Add prioritized replay buffer and avg reward per episode

### DIFF
--- a/tests/test_train_rl_agent.py
+++ b/tests/test_train_rl_agent.py
@@ -127,3 +127,4 @@ def test_train_rl_agent(tmp_path: Path):
     assert "coefficients" in data
     assert "intercept" in data
     assert "avg_reward" in data
+    assert "avg_reward_per_episode" in data


### PR DESCRIPTION
## Summary
- extend RL training buffer with priority weights
- sample experience by priority and update weights based on TD error
- store average reward per episode
- test `avg_reward_per_episode` field

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68841c764388832f8deae032e832fd35