### PR TITLE
Add numpy availability check for tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,9 +86,12 @@ python scripts/analyze_ticks.py observer_logs/ticks_EURUSD.csv
 
 ## Running Tests
 
-Install the Python requirements and run `pytest` from the repository root:
+Install the Python requirements and run `pytest` from the repository root. At a
+minimum `numpy`, `scikit-learn` and `pytest` are needed.  The `xgboost` package
+is optional if you want to train XGBoost models:
 
 ```bash
+pip install numpy scikit-learn pytest xgboost
 pytest
 ```
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,9 @@
+import pytest
+
+try:
+    import numpy  # noqa: F401
+    HAS_NUMPY = True
+except Exception:
+    HAS_NUMPY = False
+
+__all__ = ["HAS_NUMPY"]

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -3,8 +3,13 @@ import json
 from pathlib import Path
 import sys
 
+import pytest
+
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from tests import HAS_NUMPY
 from scripts.train_target_clone import train, _load_logs
+
+pytestmark = pytest.mark.skipif(not HAS_NUMPY, reason="NumPy is required for training tests")
 
 
 def _write_log(file: Path):
@@ -132,6 +137,7 @@ def test_load_logs_with_metrics(tmp_path: Path):
 
 
 def test_train_xgboost(tmp_path: Path):
+    pytest.importorskip("xgboost")
     data_dir = tmp_path / "logs"
     out_dir = tmp_path / "out"
     data_dir.mkdir()

--- a/tests/test_train_rl_agent.py
+++ b/tests/test_train_rl_agent.py
@@ -3,8 +3,13 @@ import json
 from pathlib import Path
 import sys
 
+import pytest
+
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from tests import HAS_NUMPY
 from scripts.train_rl_agent import train
+
+pytestmark = pytest.mark.skipif(not HAS_NUMPY, reason="NumPy is required for RL training tests")
 
 
 def _write_log(file: Path):


### PR DESCRIPTION
## Summary
- skip training tests when NumPy isn't installed
- mark XGBoost test optional
- list required packages in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68841c76db68832f8b096f8e98d6d24b