### PR TITLE
Add stable-baselines3 option

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,10 +86,11 @@ python scripts/analyze_ticks.py observer_logs/ticks_EURUSD.csv
 
 Install the Python requirements and run `pytest` from the repository root. At a
 minimum `numpy`, `scikit-learn` and `pytest` are needed.  The `xgboost` package
-is optional if you want to train XGBoost models:
+is optional if you want to train XGBoost models.  `stable-baselines3` can be
+installed to experiment with PPO or DQN agents:
 
 ```bash
-pip install numpy scikit-learn pytest xgboost
+pip install numpy scikit-learn pytest xgboost stable-baselines3
 pytest
 ```
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -6,4 +6,10 @@ try:
 except Exception:
     HAS_NUMPY = False
 
-__all__ = ["HAS_NUMPY"]
+try:
+    import stable_baselines3  # noqa: F401
+    HAS_SB3 = True
+except Exception:
+    HAS_SB3 = False
+
+__all__ = ["HAS_NUMPY", "HAS_SB3"]

--- a/tests/test_train_rl_agent.py
+++ b/tests/test_train_rl_agent.py
@@ -6,7 +6,7 @@ import sys
 import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
-from tests import HAS_NUMPY
+from tests import HAS_NUMPY, HAS_SB3
 from scripts.train_rl_agent import train
 
 pytestmark = pytest.mark.skipif(not HAS_NUMPY, reason="NumPy is required for RL training tests")
@@ -133,3 +133,23 @@ def test_train_rl_agent(tmp_path: Path):
     assert "intercept" in data
     assert "avg_reward" in data
     assert "avg_reward_per_episode" in data
+
+
+@pytest.mark.skipif(not HAS_SB3, reason="stable-baselines3 not installed")
+def test_train_rl_agent_sb3(tmp_path: Path):
+    data_dir = tmp_path / "logs"
+    out_dir = tmp_path / "out"
+    data_dir.mkdir()
+    log_file = data_dir / "trades_test.csv"
+    _write_log(log_file)
+
+    train(data_dir, out_dir, algo="ppo", episodes=1)
+
+    model_file = out_dir / "model.json"
+    weight_file = out_dir / "model_weights.zip"
+    assert model_file.exists()
+    assert weight_file.exists()
+    with open(model_file) as f:
+        data = json.load(f)
+    assert data.get("algo") == "ppo"
+    assert data.get("weights_file") == "model_weights.zip"


### PR DESCRIPTION
## Summary
- add optional dependency stable-baselines3
- allow `train_rl_agent.py` to train PPO/DQN via new `--algo` CLI argument
- write weights and algo metadata to `model.json`
- document optional RL dependency
- test PPO training path

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68857fc6fcf4832f9d5e5f41f34b6ec4