### PR TITLE
Use pandas for log loading

### DIFF
--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -132,8 +132,8 @@ def test_load_logs_with_metrics(tmp_path: Path):
     metrics_file = data_dir / "metrics.csv"
     _write_metrics(metrics_file)
 
-    rows = _load_logs(data_dir)
-    assert all("win_rate" in r for r in rows)
+    df = _load_logs(data_dir)
+    assert "win_rate" in df.columns
 
 
 def test_train_xgboost(tmp_path: Path):


### PR DESCRIPTION
## Summary
- use pandas.read_csv for loading CSV logs
- normalize column names and filter invalid actions with pandas
- return DataFrame from `_load_logs`
- adapt training utilities to new DataFrame workflow
- adjust unit tests for DataFrame output

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68859341eb20832f8559fef7f7262e54