### PR TITLE
Enable concurrent socket log streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,8 @@ Metrics entries older than the number of days specified by `MetricsDaysToKeep` (
 
 When `EnableSocketLogging` is enabled the observer EA emits each trade event and
 periodic metric summary as newline separated JSON over a TCP socket. Run the
-``socket_log_service.py`` helper to capture these messages into a CSV file:
+``socket_log_service.py`` helper to capture these messages into a CSV file. The
+service now uses ``asyncio`` to handle multiple connections concurrently:
 
 ```bash
 python scripts/socket_log_service.py --out stream.csv

--- a/scripts/socket_log_service.py
+++ b/scripts/socket_log_service.py
@@ -2,10 +2,11 @@
 """Service that listens for JSON log events and appends them to a CSV file."""
 
 import argparse
-import socket
-from pathlib import Path
+import asyncio
 import csv
 import json
+from pathlib import Path
+from asyncio import StreamReader, StreamWriter, Queue
 
 FIELDS = [
     "event_id",
@@ -28,54 +29,84 @@ FIELDS = [
 ]
 
 
-def _write_lines(conn: socket.socket, out_file: Path) -> None:
-    """Read newline-delimited JSON messages from ``conn`` and append rows."""
+async def _writer_task(out_file: Path, queue: Queue) -> None:
+    """Write rows from ``queue`` to ``out_file``."""
 
     out_file.parent.mkdir(parents=True, exist_ok=True)
     with open(out_file, "a", newline="") as f:
         writer = csv.writer(f, delimiter=";")
-        need_header = f.tell() == 0
-        if need_header:
+        if f.tell() == 0:
             writer.writerow(FIELDS)
-        buffer = b""
+
         while True:
-            data = conn.recv(4096)
-            if not data:
+            row = await queue.get()
+            if row is None:
                 break
-            buffer += data
-            while b"\n" in buffer:
-                line, buffer = buffer.split(b"\n", 1)
-                line = line.decode("utf-8", errors="replace").strip()
-                if not line:
-                    continue
-                try:
-                    obj = json.loads(line)
-                except json.JSONDecodeError:
-                    continue
-                row = [str(obj.get(field, "")) for field in FIELDS]
-                writer.writerow(row)
-                f.flush()
+            writer.writerow(row)
+            f.flush()
+            queue.task_done()
+
+
+async def _handle_conn(reader: StreamReader, writer: StreamWriter, queue: Queue) -> None:
+    """Process a single connection and push rows to ``queue``."""
+
+    try:
+        while data := await reader.readline():
+            line = data.decode("utf-8", errors="replace").strip()
+            if not line:
+                continue
+            try:
+                obj = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            row = [str(obj.get(field, "")) for field in FIELDS]
+            await queue.put(row)
+    finally:
+        writer.close()
+        await writer.wait_closed()
 
 
 def listen_once(host: str, port: int, out_file: Path) -> None:
     """Accept a single connection and process it until closed."""
 
-    srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    srv.bind((host, port))
-    srv.listen(1)
-    try:
-        conn, _ = srv.accept()
-        with conn:
-            _write_lines(conn, out_file)
-    finally:
-        srv.close()
+    async def _run() -> None:
+        queue: Queue = Queue()
+        done = asyncio.Event()
+
+        async def wrapped(reader: StreamReader, writer: StreamWriter) -> None:
+            await _handle_conn(reader, writer, queue)
+            done.set()
+
+        server = await asyncio.start_server(wrapped, host, port)
+        writer_task = asyncio.create_task(_writer_task(out_file, queue))
+        async with server:
+            await done.wait()
+
+        await queue.join()
+        queue.put_nowait(None)
+        await writer_task
+
+    asyncio.run(_run())
 
 
 def serve(host: str, port: int, out_file: Path) -> None:
-    """Continually accept connections and append incoming lines."""
+    """Accept multiple connections concurrently and append lines."""
 
-    while True:
-        listen_once(host, port, out_file)
+    async def _run() -> None:
+        queue: Queue = Queue()
+
+        server = await asyncio.start_server(
+            lambda r, w: _handle_conn(r, w, queue), host, port
+        )
+        writer_task = asyncio.create_task(_writer_task(out_file, queue))
+        async with server:
+            await server.serve_forever()
+
+        await queue.join()
+        queue.put_nowait(None)
+        await writer_task
+
+    asyncio.run(_run())
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary
- rewrite `socket_log_service.py` using asyncio so multiple clients can stream simultaneously
- keep `listen_once` for tests, now backed by async server
- document running the async service in the README

## Testing
- `pytest -k stream_listener -vv`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688595503e90832f8dab0bb0beaf8e3b