### PR TITLE
Add day_of_week feature

### DIFF
--- a/scripts/generate_mql4_from_model.py
+++ b/scripts/generate_mql4_from_model.py
@@ -42,6 +42,7 @@ def generate(model_json: Path, out_dir: Path):
         'lots': 'Lots',
         'sl_dist': 'GetSLDistance()',
         'tp_dist': 'GetTPDistance()',
+        'day_of_week': 'TimeDayOfWeek(TimeCurrent())',
         'sma': 'iMA(SymbolToTrade, 0, 5, 0, MODE_SMA, PRICE_CLOSE, 0)',
         'rsi': 'iRSI(SymbolToTrade, 0, 14, PRICE_CLOSE, 0)',
         'macd': 'iMACD(SymbolToTrade, 0, 12, 26, 9, PRICE_CLOSE, MODE_MAIN, 0)',

--- a/scripts/train_target_clone.py
+++ b/scripts/train_target_clone.py
@@ -192,6 +192,7 @@ def _extract_features(
         feat = {
             "symbol": r.get("symbol", ""),
             "hour": t.hour,
+            "day_of_week": t.weekday(),
             "lots": lots,
             "sl_dist": sl - price,
             "tp_dist": tp - price,

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -56,3 +56,26 @@ def test_sl_tp_features(tmp_path: Path):
         content = f.read()
     assert "GetSLDistance()" in content
     assert "GetTPDistance()" in content
+
+
+def test_day_of_week_feature(tmp_path: Path):
+    model = {
+        "model_id": "dow",
+        "magic": 888,
+        "coefficients": [0.1],
+        "intercept": 0.0,
+        "threshold": 0.5,
+        "feature_names": ["day_of_week"],
+    }
+    model_file = tmp_path / "model.json"
+    with open(model_file, "w") as f:
+        json.dump(model, f)
+
+    out_dir = tmp_path / "out"
+    generate(model_file, out_dir)
+
+    out_file = out_dir / "Generated_dow.mq4"
+    assert out_file.exists()
+    with open(out_file) as f:
+        content = f.read()
+    assert "TimeDayOfWeek(TimeCurrent())" in content

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -106,6 +106,7 @@ def test_train(tmp_path: Path):
         data = json.load(f)
     assert "coefficients" in data
     assert "threshold" in data
+    assert "day_of_week" in data.get("feature_names", [])
 
 
 def test_train_with_indicators(tmp_path: Path):


### PR DESCRIPTION
## Summary
- extract `day_of_week` feature when parsing trade logs
- export `day_of_week` feature in generated MQL4 EA
- cover new feature in unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68859d27a020832f926dd96d2e0a32fc