### PR TITLE
Add volatility feature support

### DIFF
--- a/scripts/generate_mql4_from_model.py
+++ b/scripts/generate_mql4_from_model.py
@@ -46,6 +46,7 @@ def generate(model_json: Path, out_dir: Path):
         'rsi': 'iRSI(SymbolToTrade, 0, 14, PRICE_CLOSE, 0)',
         'macd': 'iMACD(SymbolToTrade, 0, 12, 26, 9, PRICE_CLOSE, MODE_MAIN, 0)',
         'macd_signal': 'iMACD(SymbolToTrade, 0, 12, 26, 9, PRICE_CLOSE, MODE_SIGNAL, 0)',
+        'volatility': 'iStdDev(SymbolToTrade, 0, 20, 0, MODE_SMA, PRICE_CLOSE, 0)',
     }
 
     cases = []

--- a/tests/test_analyze_ticks.py
+++ b/tests/test_analyze_ticks.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 import sys
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
-from scripts.analyze_ticks import load_ticks, compute_metrics
+from scripts.analyze_ticks import load_ticks, compute_metrics, compute_volatility
 import pytest
 
 
@@ -23,3 +23,15 @@ def test_metrics(tmp_path: Path):
     assert stats["tick_count"] == 3
     assert stats["avg_spread"] == pytest.approx(0.0002)
     assert stats["price_change"] == pytest.approx(0.0002)
+
+
+def test_volatility(tmp_path: Path):
+    tick_file = tmp_path / "ticks.csv"
+    _write_ticks(tick_file)
+
+    rows = load_ticks(tick_file)
+    vols = compute_volatility(rows, period="hourly")
+
+    key = "2024-01-01 00"
+    assert key in vols
+    assert isinstance(vols[key], float)

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -56,3 +56,26 @@ def test_sl_tp_features(tmp_path: Path):
         content = f.read()
     assert "GetSLDistance()" in content
     assert "GetTPDistance()" in content
+
+
+def test_volatility_feature(tmp_path: Path):
+    model = {
+        "model_id": "vol",
+        "magic": 111,
+        "coefficients": [0.3],
+        "intercept": 0.0,
+        "threshold": 0.5,
+        "feature_names": ["volatility"],
+    }
+    model_file = tmp_path / "model.json"
+    with open(model_file, "w") as f:
+        json.dump(model, f)
+
+    out_dir = tmp_path / "out"
+    generate(model_file, out_dir)
+
+    out_file = out_dir / "Generated_vol.mq4"
+    assert out_file.exists()
+    with open(out_file) as f:
+        content = f.read()
+    assert "iStdDev" in content

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -124,6 +124,26 @@ def test_train_with_indicators(tmp_path: Path):
     assert any(name in data.get("feature_names", []) for name in ["sma", "rsi", "macd"])
 
 
+def test_train_with_volatility(tmp_path: Path):
+    data_dir = tmp_path / "logs"
+    out_dir = tmp_path / "out"
+    data_dir.mkdir()
+    log_file = data_dir / "trades_test.csv"
+    _write_log(log_file)
+
+    vol_file = tmp_path / "vol.json"
+    with open(vol_file, "w") as f:
+        json.dump({"2024-01-01": 0.5}, f)
+
+    train(data_dir, out_dir, volatility=json.load(open(vol_file)))
+
+    model_file = out_dir / "model.json"
+    assert model_file.exists()
+    with open(model_file) as f:
+        data = json.load(f)
+    assert "volatility" in data.get("feature_names", [])
+
+
 def test_load_logs_with_metrics(tmp_path: Path):
     data_dir = tmp_path / "logs"
     data_dir.mkdir()


### PR DESCRIPTION
## Summary
- add optional volatility mapping to `train_target_clone.py`
- calculate volatility series in `analyze_ticks.py`
- export volatility as an indicator in generated MQL4 code
- update tests for new functionality

## Testing
- `pip install numpy pandas scikit-learn`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68859d4a4bfc832fb95ebc7a8c344bd4