### PR TITLE
Add volatility feature support

### DIFF
--- a/scripts/analyze_ticks.py
+++ b/scripts/analyze_ticks.py
@@ -4,6 +4,8 @@ import argparse
 import csv
 from pathlib import Path
 from typing import Dict, List
+from datetime import datetime
+import statistics
 
 
 def load_ticks(file: Path) -> List[Dict]:
@@ -34,13 +36,54 @@ def compute_metrics(rows: List[Dict]) -> Dict:
     }
 
 
+def compute_volatility(rows: List[Dict], interval: str = "hourly") -> Dict[str, float]:
+    """Return standard deviation of tick returns per interval.
+
+    Parameters
+    ----------
+    rows : list of dict
+        Tick rows as returned by :func:`load_ticks`.
+    interval : str, optional
+        ``"hourly"`` or ``"daily"`` grouping. Default is hourly.
+    """
+
+    if len(rows) < 2:
+        return {}
+
+    rets: Dict[str, List[float]] = {}
+    prev_price = rows[0]["bid"]
+    for r in rows[1:]:
+        price = r["bid"]
+        ts = datetime.strptime(r["time"], "%Y.%m.%d %H:%M:%S")
+        key = ts.strftime("%Y-%m-%d %H" if interval.startswith("h") else "%Y-%m-%d")
+        rets.setdefault(key, []).append(price - prev_price)
+        prev_price = price
+
+    vols = {}
+    for key, vals in rets.items():
+        if len(vals) > 1:
+            vols[key] = float(statistics.pstdev(vals))
+        else:
+            vols[key] = 0.0
+    return vols
+
+
 def main():
     p = argparse.ArgumentParser()
     p.add_argument("tick_file")
     p.add_argument("--out", help="Output JSON file")
+    p.add_argument("--vol-out", help="Write volatility JSON file")
+    p.add_argument("--interval", choices=["daily", "hourly"], default="hourly")
     args = p.parse_args()
 
     rows = load_ticks(Path(args.tick_file))
+    if args.vol_out:
+        import json
+
+        vols = compute_volatility(rows, interval=args.interval)
+        with open(args.vol_out, "w") as f:
+            json.dump(vols, f)
+
     stats = compute_metrics(rows)
     if args.out:
         import json

--- a/scripts/generate_mql4_from_model.py
+++ b/scripts/generate_mql4_from_model.py
@@ -47,6 +47,7 @@ def generate(model_json: Path, out_dir: Path):
         'rsi': 'iRSI(SymbolToTrade, 0, 14, PRICE_CLOSE, 0)',
         'macd': 'iMACD(SymbolToTrade, 0, 12, 26, 9, PRICE_CLOSE, MODE_MAIN, 0)',
         'macd_signal': 'iMACD(SymbolToTrade, 0, 12, 26, 9, PRICE_CLOSE, MODE_SIGNAL, 0)',
+        'volatility': 'StdDevRecentTicks()',
     }
 
     cases = []

--- a/tests/test_analyze_ticks.py
+++ b/tests/test_analyze_ticks.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 import sys
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
-from scripts.analyze_ticks import load_ticks, compute_metrics
+from scripts.analyze_ticks import load_ticks, compute_metrics, compute_volatility
 import pytest
 
 
@@ -11,6 +11,17 @@ def _write_ticks(file: Path):
         f.write("2024.01.01 00:00:00;1.1000;1.1002;0;0\n")
         f.write("2024.01.01 00:00:01;1.1001;1.1003;0;0\n")
         f.write("2024.01.01 00:00:02;1.1002;1.1004;0;0\n")
+
+
+def _write_vol_ticks(file: Path):
+    with open(file, "w") as f:
+        f.write("time;bid;ask;last;volume\n")
+        f.write("2024.01.01 00:00:00;1.1000;1.1002;0;0\n")
+        f.write("2024.01.01 00:00:01;1.1002;1.1004;0;0\n")
+        f.write("2024.01.01 00:00:02;1.1003;1.1005;0;0\n")
+        f.write("2024.01.01 01:00:00;1.1010;1.1012;0;0\n")
+        f.write("2024.01.01 01:00:01;1.1015;1.1017;0;0\n")
+        f.write("2024.01.01 01:00:02;1.1017;1.1019;0;0\n")
 
 
 def test_metrics(tmp_path: Path):
@@ -23,3 +34,15 @@ def test_metrics(tmp_path: Path):
     assert stats["tick_count"] == 3
     assert stats["avg_spread"] == pytest.approx(0.0002)
     assert stats["price_change"] == pytest.approx(0.0002)
+
+
+def test_compute_volatility(tmp_path: Path):
+    tick_file = tmp_path / "ticks.csv"
+    _write_vol_ticks(tick_file)
+
+    rows = load_ticks(tick_file)
+    vols = compute_volatility(rows, interval="hourly")
+
+    assert "2024-01-01 00" in vols
+    assert "2024-01-01 01" in vols
+    assert vols["2024-01-01 00"] == pytest.approx(5e-05)

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -79,3 +79,26 @@ def test_day_of_week_feature(tmp_path: Path):
     with open(out_file) as f:
         content = f.read()
     assert "TimeDayOfWeek(TimeCurrent())" in content
+
+
+def test_volatility_feature(tmp_path: Path):
+    model = {
+        "model_id": "vol",
+        "magic": 123,
+        "coefficients": [0.1],
+        "intercept": 0.0,
+        "threshold": 0.5,
+        "feature_names": ["volatility"],
+    }
+    model_file = tmp_path / "model.json"
+    with open(model_file, "w") as f:
+        json.dump(model, f)
+
+    out_dir = tmp_path / "out"
+    generate(model_file, out_dir)
+
+    out_file = out_dir / "Generated_vol.mq4"
+    assert out_file.exists()
+    with open(out_file) as f:
+        content = f.read()
+    assert "StdDevRecentTicks()" in content

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -125,6 +125,23 @@ def test_train_with_indicators(tmp_path: Path):
     assert any(name in data.get("feature_names", []) for name in ["sma", "rsi", "macd"])
 
 
+def test_train_with_volatility(tmp_path: Path):
+    data_dir = tmp_path / "logs"
+    out_dir = tmp_path / "out"
+    data_dir.mkdir()
+    log_file = data_dir / "trades_test.csv"
+    _write_log(log_file)
+
+    vols = {"2024-01-01 00": 0.1, "2024-01-01 01": 0.2}
+    train(data_dir, out_dir, volatility_series=vols)
+
+    model_file = out_dir / "model.json"
+    assert model_file.exists()
+    with open(model_file) as f:
+        data = json.load(f)
+    assert "volatility" in data.get("feature_names", [])
+
+
 def test_load_logs_with_metrics(tmp_path: Path):
     data_dir = tmp_path / "logs"
     data_dir.mkdir()


### PR DESCRIPTION
## Summary
- generate hourly/daily volatility from tick data
- allow `train_target_clone` to use a precomputed volatility series
- map `volatility` in generated MQL4 code to `StdDevRecentTicks()`
- add tests for volatility calculations and training

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68859ec1b090832f95479d85e9763920