### PR TITLE
Add probability-based lot scaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ The EA records trade openings and closings using the `OnTradeTransaction` callba
 - `experts/` – MQL4 source files.
   - `Observer_TBot.mq4` – main observer EA.
   - `StrategyTemplate.mq4` – template used for generated strategies.
+    Trade volume is automatically scaled between `MinLots` and `MaxLots`
+    based on the model probability.
   - `model_interface.mqh` – shared structures.
 - `scripts/` – helper Python scripts.
   - `train_target_clone.py` – trains a model from exported logs.
@@ -25,7 +27,8 @@ The EA records trade openings and closings using the `OnTradeTransaction` callba
 2. Copy the contents of `experts/` to your terminal's `MQL4\Experts` folder.
 3. Copy the `scripts/` directory somewhere accessible with Python 3 installed.
 4. Restart the MT4 terminal and compile `Observer_TBot.mq4` using MetaEditor.
-5. Attach `Observer_TBot` to a single chart and adjust the extern inputs as needed (magic numbers to observe, log directory, etc.).
+5. Attach `Observer_TBot` to a single chart and adjust the extern inputs as needed
+   (magic numbers to observe, log directory, lot bounds, etc.).
 
 ## External Training
 

--- a/experts/StrategyTemplate.mq4
+++ b/experts/StrategyTemplate.mq4
@@ -5,6 +5,8 @@ extern string SymbolToTrade = "EURUSD";
 extern double Lots = 0.1;
 extern int MagicNumber = 1234;
 extern bool EnableDebugLogging = false;
+extern double MinLots = 0.01;
+extern double MaxLots = 0.1;
 
 double ModelCoefficients[] = {__COEFFICIENTS__};
 double ModelIntercept = __INTERCEPT__;
@@ -80,6 +82,13 @@ double GetProbability()
    return(ComputeLogisticScore());
 }
 
+double GetTradeLots(double prob)
+{
+   double x = 1.0 / (1.0 + MathExp(-10.0*(prob - 0.5)));
+   double lots = MinLots + (MaxLots - MinLots) * x;
+   return(lots);
+}
+
 bool HasOpenOrders()
 {
    for(int i = OrdersTotal() - 1; i >= 0; i--)
@@ -109,15 +118,16 @@ void OnTick()
    }
 
    // Open buy if probability exceeds threshold else sell
+   double tradeLots = GetTradeLots(prob);
    int ticket;
    if(prob > ModelThreshold)
    {
-      ticket = OrderSend(SymbolToTrade, OP_BUY, Lots, Ask, 3, 0, 0,
+      ticket = OrderSend(SymbolToTrade, OP_BUY, tradeLots, Ask, 3, 0, 0,
                          "model", MagicNumber, 0, clrBlue);
    }
    else
    {
-      ticket = OrderSend(SymbolToTrade, OP_SELL, Lots, Bid, 3, 0, 0,
+      ticket = OrderSend(SymbolToTrade, OP_SELL, tradeLots, Bid, 3, 0, 0,
                          "model", MagicNumber, 0, clrRed);
    }
 


### PR DESCRIPTION
## Summary
- adjust `StrategyTemplate.mq4` to size trades with a logistic curve
- bound the lot size with new `MinLots` and `MaxLots` extern variables
- mention the new parameters in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885a0798dc8832fb817462e1ccc5828