### PR TITLE
Incremental training support

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,15 @@ python train_target_clone.py --data-dir "C:\\path\\to\\observer_logs" --out-dir 
 python generate_mql4_from_model.py models/model.json experts
 ```
 
+For ongoing training simply rerun the script with the ``--incremental`` flag and
+the latest log directory. The generated MQ4 file name will include the training
+timestamp so previous versions remain intact:
+
+```bash
+python train_target_clone.py --data-dir "C:\\path\\to\\observer_logs" --out-dir models --incremental
+python generate_mql4_from_model.py models/model.json experts
+```
+
 Compile the generated MQ4 file and the observer will begin evaluating predictions from that model.
 
 ## Metrics Tracking

--- a/scripts/generate_mql4_from_model.py
+++ b/scripts/generate_mql4_from_model.py
@@ -64,7 +64,17 @@ def generate(model_json: Path, out_dir: Path):
 
     threshold = model.get('threshold', 0.5)
     output = output.replace('__THRESHOLD__', _fmt(threshold))
-    out_file = out_dir / f"Generated_{model.get('model_id', 'model')}.mq4"
+    ts = model.get('trained_at')
+    if ts:
+        try:
+            from datetime import datetime
+            ts = datetime.fromisoformat(ts).strftime('%Y%m%d_%H%M%S')
+        except Exception:
+            ts = None
+    if not ts:
+        from datetime import datetime
+        ts = datetime.utcnow().strftime('%Y%m%d_%H%M%S')
+    out_file = out_dir / f"Generated_{model.get('model_id', 'model')}_{ts}.mq4"
     with open(out_file, 'w') as f:
         f.write(output)
     print(f"Strategy written to {out_file}")

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -22,9 +22,9 @@ def test_generate(tmp_path: Path):
     out_dir = tmp_path / "out"
     generate(model_file, out_dir)
 
-    out_file = out_dir / "Generated_test.mq4"
-    assert out_file.exists()
-    with open(out_file) as f:
+    generated = list(out_dir.glob("Generated_test_*.mq4"))
+    assert len(generated) == 1
+    with open(generated[0]) as f:
         content = f.read()
     assert "MagicNumber = 777" in content
     assert "double ModelCoefficients[] = {0.1, -0.2};" in content
@@ -50,9 +50,9 @@ def test_sl_tp_features(tmp_path: Path):
     out_dir = tmp_path / "out"
     generate(model_file, out_dir)
 
-    out_file = out_dir / "Generated_tp_sl.mq4"
-    assert out_file.exists()
-    with open(out_file) as f:
+    generated = list(out_dir.glob("Generated_tp_sl_*.mq4"))
+    assert len(generated) == 1
+    with open(generated[0]) as f:
         content = f.read()
     assert "GetSLDistance()" in content
     assert "GetTPDistance()" in content
@@ -74,9 +74,9 @@ def test_day_of_week_feature(tmp_path: Path):
     out_dir = tmp_path / "out"
     generate(model_file, out_dir)
 
-    out_file = out_dir / "Generated_dow.mq4"
-    assert out_file.exists()
-    with open(out_file) as f:
+    generated = list(out_dir.glob("Generated_dow_*.mq4"))
+    assert len(generated) == 1
+    with open(generated[0]) as f:
         content = f.read()
     assert "TimeDayOfWeek(TimeCurrent())" in content
 
@@ -97,8 +97,8 @@ def test_volatility_feature(tmp_path: Path):
     out_dir = tmp_path / "out"
     generate(model_file, out_dir)
 
-    out_file = out_dir / "Generated_vol.mq4"
-    assert out_file.exists()
-    with open(out_file) as f:
+    generated = list(out_dir.glob("Generated_vol_*.mq4"))
+    assert len(generated) == 1
+    with open(generated[0]) as f:
         content = f.read()
     assert "StdDevRecentTicks()" in content

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -171,3 +171,23 @@ def test_train_xgboost(tmp_path: Path):
     assert data.get("model_type") == "xgboost"
     assert "coefficients" in data
     assert len(data.get("probability_table", [])) == 24
+
+
+def test_incremental_train(tmp_path: Path):
+    data_dir = tmp_path / "logs"
+    out_dir = tmp_path / "out"
+    data_dir.mkdir()
+
+    log_file1 = data_dir / "trades_a.csv"
+    _write_log(log_file1)
+
+    train(data_dir, out_dir)
+
+    log_file2 = data_dir / "trades_b.csv"
+    _write_log(log_file2)
+
+    train(data_dir, out_dir, incremental=True)
+
+    with open(out_dir / "model.json") as f:
+        data = json.load(f)
+    assert data.get("num_samples", 0) >= 4


### PR DESCRIPTION
## Summary
- enable incremental updates to model.json via `--incremental`
- keep previous model IDs when generating MQ4 files by adding timestamps
- adjust tests for timestamped outputs and incremental training
- document retraining workflow in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885a1d6a564832fb02afe71293b22cc