### PR TITLE
Add neural network mode

### DIFF
--- a/scripts/generate_mql4_from_model.py
+++ b/scripts/generate_mql4_from_model.py
@@ -34,6 +34,23 @@ def generate(model_json: Path, out_dir: Path):
     prob_str = ', '.join(_fmt(p) for p in prob_table)
     output = output.replace('__PROBABILITY_TABLE__', prob_str)
 
+    nn_weights = model.get('nn_weights', [])
+    if nn_weights:
+        l1_w = ', '.join(_fmt(v) for row in nn_weights[0] for v in row)
+        l1_b = ', '.join(_fmt(v) for v in nn_weights[1])
+        l2_w = ', '.join(_fmt(v) for row in nn_weights[2] for v in (row if isinstance(row, list) else [row]))
+        l2_b = _fmt(nn_weights[3][0] if isinstance(nn_weights[3], list) else nn_weights[3])
+        hidden_size = len(nn_weights[1])
+    else:
+        l1_w = l1_b = l2_w = ''
+        l2_b = '0'
+        hidden_size = 0
+    output = output.replace('__NN_L1_WEIGHTS__', l1_w)
+    output = output.replace('__NN_L1_BIAS__', l1_b)
+    output = output.replace('__NN_L2_WEIGHTS__', l2_w)
+    output = output.replace('__NN_L2_BIAS__', l2_b)
+    output = output.replace('__NN_HIDDEN_SIZE__', str(hidden_size))
+
     feature_names = model.get('feature_names', [])
 
     feature_map = {

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -102,3 +102,32 @@ def test_volatility_feature(tmp_path: Path):
     with open(generated[0]) as f:
         content = f.read()
     assert "StdDevRecentTicks()" in content
+
+
+def test_generate_nn(tmp_path: Path):
+    model = {
+        "model_id": "nn",
+        "magic": 222,
+        "hidden_size": 2,
+        "nn_weights": [
+            [[0.1, 0.2], [0.3, 0.4]],
+            [0.0, 0.1],
+            [[0.5], [0.6]],
+            [0.2],
+        ],
+        "threshold": 0.5,
+        "feature_names": ["hour", "spread"],
+    }
+    model_file = tmp_path / "model.json"
+    with open(model_file, "w") as f:
+        json.dump(model, f)
+
+    out_dir = tmp_path / "out"
+    generate(model_file, out_dir)
+
+    generated = list(out_dir.glob("Generated_nn_*.mq4"))
+    assert len(generated) == 1
+    with open(generated[0]) as f:
+        content = f.read()
+    assert "NNLayer1Weights" in content
+    assert "MagicNumber = 222" in content

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -173,6 +173,24 @@ def test_train_xgboost(tmp_path: Path):
     assert len(data.get("probability_table", [])) == 24
 
 
+def test_train_nn(tmp_path: Path):
+    data_dir = tmp_path / "logs"
+    out_dir = tmp_path / "out"
+    data_dir.mkdir()
+    log_file = data_dir / "trades_test.csv"
+    _write_log(log_file)
+
+    train(data_dir, out_dir, model_type="nn")
+
+    model_file = out_dir / "model.json"
+    assert model_file.exists()
+    with open(model_file) as f:
+        data = json.load(f)
+    assert data.get("model_type") == "nn"
+    assert "nn_weights" in data
+    assert data.get("hidden_size", 0) > 0
+
+
 def test_incremental_train(tmp_path: Path):
     data_dir = tmp_path / "logs"
     out_dir = tmp_path / "out"


### PR DESCRIPTION
## Summary
- add `nn` model option using sklearn MLP or TensorFlow
- export NN weights and hidden size in generated EA
- implement NN inference in StrategyTemplate
- support new options in generate script
- test neural network training and EA generation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885a39aea44832f9ec15dd0c662b446