### PR TITLE
Add spread feature support

### DIFF
--- a/scripts/train_target_clone.py
+++ b/scripts/train_target_clone.py
@@ -111,6 +111,7 @@ def _load_logs(data_dir: Path) -> pd.DataFrame:
         "sl",
         "tp",
         "profit",
+        "spread",
         "comment",
         "remaining_lots",
     ]
@@ -198,6 +199,8 @@ def _extract_features(
         tp = float(r.get("tp", 0) or 0)
         lots = float(r.get("lots", 0) or 0)
 
+        spread = float(r.get("spread", 0) or 0)
+
         feat = {
             "symbol": r.get("symbol", ""),
             "hour": t.hour,
@@ -205,6 +208,7 @@ def _extract_features(
             "lots": lots,
             "sl_dist": sl - price,
             "tp_dist": tp - price,
+            "spread": spread,
         }
 
         if volatility is not None:

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -29,6 +29,7 @@ def _write_log(file: Path):
         "sl",
         "tp",
         "profit",
+        "spread",
         "comment",
         "remaining_lots",
     ]
@@ -49,6 +50,7 @@ def _write_log(file: Path):
             "1.0950",
             "1.1100",
             "0",
+            "2",
             "",
             "0.1",
         ],
@@ -68,6 +70,7 @@ def _write_log(file: Path):
             "1.1950",
             "1.2100",
             "0",
+            "3",
             "",
             "0.1",
         ],
@@ -107,6 +110,7 @@ def test_train(tmp_path: Path):
     assert "coefficients" in data
     assert "threshold" in data
     assert "day_of_week" in data.get("feature_names", [])
+    assert "spread" in data.get("feature_names", [])
 
 
 def test_train_with_indicators(tmp_path: Path):
@@ -152,6 +156,7 @@ def test_load_logs_with_metrics(tmp_path: Path):
 
     df = _load_logs(data_dir)
     assert "win_rate" in df.columns
+    assert "spread" in df.columns
 
 
 def test_train_xgboost(tmp_path: Path):


### PR DESCRIPTION
## Summary
- include spread column in Observer_TBot CSV logs
- log spread to socket and file outputs
- parse spread in training script
- output spread feature during feature extraction
- update training tests for spread column

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885a6795d9c832f874f132a72cccab8