### PR TITLE
Add ATR and Bollinger features

### DIFF
--- a/scripts/generate_mql4_from_model.py
+++ b/scripts/generate_mql4_from_model.py
@@ -65,6 +65,10 @@ def generate(model_json: Path, out_dir: Path):
         'macd': 'iMACD(SymbolToTrade, 0, 12, 26, 9, PRICE_CLOSE, MODE_MAIN, 0)',
         'macd_signal': 'iMACD(SymbolToTrade, 0, 12, 26, 9, PRICE_CLOSE, MODE_SIGNAL, 0)',
         'volatility': 'StdDevRecentTicks()',
+        'atr': 'iATR(SymbolToTrade, 0, 14, 0)',
+        'bollinger_upper': 'iBands(SymbolToTrade, 0, 20, 2, 0, PRICE_CLOSE, MODE_UPPER, 0)',
+        'bollinger_middle': 'iBands(SymbolToTrade, 0, 20, 2, 0, PRICE_CLOSE, MODE_MAIN, 0)',
+        'bollinger_lower': 'iBands(SymbolToTrade, 0, 20, 2, 0, PRICE_CLOSE, MODE_LOWER, 0)',
     }
 
     cases = []

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -104,6 +104,35 @@ def test_volatility_feature(tmp_path: Path):
     assert "StdDevRecentTicks()" in content
 
 
+def test_atr_bollinger_features(tmp_path: Path):
+    model = {
+        "model_id": "ind",
+        "magic": 321,
+        "coefficients": [0.1] * 4,
+        "intercept": 0.0,
+        "threshold": 0.5,
+        "feature_names": [
+            "atr",
+            "bollinger_upper",
+            "bollinger_middle",
+            "bollinger_lower",
+        ],
+    }
+    model_file = tmp_path / "model.json"
+    with open(model_file, "w") as f:
+        json.dump(model, f)
+
+    out_dir = tmp_path / "out"
+    generate(model_file, out_dir)
+
+    generated = list(out_dir.glob("Generated_ind_*.mq4"))
+    assert len(generated) == 1
+    with open(generated[0]) as f:
+        content = f.read()
+    assert "iATR(SymbolToTrade" in content
+    assert "iBands(SymbolToTrade" in content
+
+
 def test_generate_nn(tmp_path: Path):
     model = {
         "model_id": "nn",

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -129,6 +129,24 @@ def test_train_with_indicators(tmp_path: Path):
     assert any(name in data.get("feature_names", []) for name in ["sma", "rsi", "macd"])
 
 
+def test_train_with_atr_bollinger(tmp_path: Path):
+    data_dir = tmp_path / "logs"
+    out_dir = tmp_path / "out"
+    data_dir.mkdir()
+    log_file = data_dir / "trades_test.csv"
+    _write_log(log_file)
+
+    train(data_dir, out_dir, use_atr=True, use_bollinger=True)
+
+    model_file = out_dir / "model.json"
+    assert model_file.exists()
+    with open(model_file) as f:
+        data = json.load(f)
+    feats = data.get("feature_names", [])
+    assert "atr" in feats
+    assert any(n.startswith("bollinger_") for n in feats)
+
+
 def test_train_with_volatility(tmp_path: Path):
     data_dir = tmp_path / "logs"
     out_dir = tmp_path / "out"


### PR DESCRIPTION
## Summary
- compute ATR and Bollinger Bands in training
- expose `--use-atr` and `--use-bollinger` flags
- emit these indicators in generated MQL4 code
- test training and generation using the new indicators

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885aab65470832f93e7b6d196482e1c