### PR TITLE
Add LSTM model option

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -12,4 +12,10 @@ try:
 except Exception:
     HAS_SB3 = False
 
-__all__ = ["HAS_NUMPY", "HAS_SB3"]
+try:
+    import tensorflow  # noqa: F401
+    HAS_TF = True
+except Exception:
+    HAS_TF = False
+
+__all__ = ["HAS_NUMPY", "HAS_SB3", "HAS_TF"]

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -160,3 +160,32 @@ def test_generate_nn(tmp_path: Path):
         content = f.read()
     assert "NNLayer1Weights" in content
     assert "MagicNumber = 222" in content
+
+
+def test_generate_lstm(tmp_path: Path):
+    model = {
+        "model_id": "lstm",
+        "magic": 333,
+        "feature_names": ["hour", "spread"],
+        "sequence_length": 2,
+        "lstm_weights": [
+            [[0.1, 0.2, 0.3, 0.4], [0.5, 0.6, 0.7, 0.8]],
+            [[0.9, 1.0, 1.1, 1.2]],
+            [0.0, 0.1, 0.2, 0.3],
+            [[1.3], [1.4]],
+            [0.5],
+        ],
+    }
+    model_file = tmp_path / "model.json"
+    with open(model_file, "w") as f:
+        json.dump(model, f)
+
+    out_dir = tmp_path / "out"
+    generate(model_file, out_dir)
+
+    generated = list(out_dir.glob("Generated_lstm_*.mq4"))
+    assert len(generated) == 1
+    with open(generated[0]) as f:
+        content = f.read()
+    assert "LSTMSequenceLength" in content
+    assert "MagicNumber = 333" in content

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -6,7 +6,7 @@ import sys
 import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
-from tests import HAS_NUMPY
+from tests import HAS_NUMPY, HAS_TF
 from scripts.train_target_clone import train, _load_logs
 
 pytestmark = pytest.mark.skipif(not HAS_NUMPY, reason="NumPy is required for training tests")
@@ -212,6 +212,25 @@ def test_train_nn(tmp_path: Path):
     assert data.get("model_type") == "nn"
     assert "nn_weights" in data
     assert data.get("hidden_size", 0) > 0
+
+
+@pytest.mark.skipif(not HAS_TF, reason="TensorFlow required")
+def test_train_lstm(tmp_path: Path):
+    data_dir = tmp_path / "logs"
+    out_dir = tmp_path / "out"
+    data_dir.mkdir()
+    log_file = data_dir / "trades_test.csv"
+    _write_log(log_file)
+
+    train(data_dir, out_dir, model_type="lstm", sequence_length=3)
+
+    model_file = out_dir / "model.json"
+    assert model_file.exists()
+    with open(model_file) as f:
+        data = json.load(f)
+    assert data.get("model_type") == "lstm"
+    assert "lstm_weights" in data
+    assert data.get("sequence_length") == 3
 
 
 def test_incremental_train(tmp_path: Path):


### PR DESCRIPTION
## Summary
- support LSTM classifier in train script and export weights
- include LSTM placeholders in strategy template and generation script
- add detection of TensorFlow for tests
- test training and code generation for LSTM models

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885ad85f254832f96048160fab1fd86