### PR TITLE
Add SQLite logging service and database support

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,18 @@ service now uses ``asyncio`` to handle multiple connections concurrently:
 python scripts/socket_log_service.py --out stream.csv
 ```
 
+For persistent storage you can instead log directly to a SQLite database using ``sqlite_log_service.py``:
+
+```bash
+python scripts/sqlite_log_service.py --db stream.db
+```
+
+Query the logs later with the ``sqlite3`` command line tool, for example:
+
+```bash
+sqlite3 stream.db "SELECT COUNT(*) FROM logs;"
+```
+
 Start ``Observer_TBot`` with the same host and port settings and the CSV will be
 populated as trades occur.  If the connection is lost, the EA automatically
 attempts to reconnect so streaming can resume without manual intervention.

--- a/scripts/sqlite_log_service.py
+++ b/scripts/sqlite_log_service.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Service that logs JSON events to a SQLite database."""
+
+import argparse
+import asyncio
+import json
+import sqlite3
+from pathlib import Path
+from asyncio import StreamReader, StreamWriter, Queue
+
+FIELDS = [
+    "event_id",
+    "event_time",
+    "broker_time",
+    "local_time",
+    "action",
+    "ticket",
+    "magic",
+    "source",
+    "symbol",
+    "order_type",
+    "lots",
+    "price",
+    "sl",
+    "tp",
+    "profit",
+    "comment",
+    "remaining_lots",
+]
+
+
+async def _writer_task(db_file: Path, queue: Queue) -> None:
+    """Write queued rows to ``db_file``."""
+
+    db_file.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(db_file)
+    cols = ",".join(FIELDS)
+    placeholders = ",".join(["?"] * len(FIELDS))
+    conn.execute(
+        f"CREATE TABLE IF NOT EXISTS logs ({','.join([f'{c} TEXT' for c in FIELDS])})"
+    )
+    insert_sql = f"INSERT INTO logs ({cols}) VALUES ({placeholders})"
+    try:
+        while True:
+            row = await queue.get()
+            if row is None:
+                break
+            conn.execute(insert_sql, [row.get(f, "") for f in FIELDS])
+            conn.commit()
+            queue.task_done()
+    finally:
+        conn.close()
+
+
+async def _handle_conn(reader: StreamReader, writer: StreamWriter, queue: Queue) -> None:
+    """Process one connection and push rows to queue."""
+
+    try:
+        while data := await reader.readline():
+            line = data.decode("utf-8", errors="replace").strip()
+            if not line:
+                continue
+            try:
+                obj = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            await queue.put(obj)
+    finally:
+        writer.close()
+        await writer.wait_closed()
+
+
+def listen_once(host: str, port: int, db_file: Path) -> None:
+    """Accept a single connection and process it until closed."""
+
+    async def _run() -> None:
+        queue: Queue = Queue()
+        done = asyncio.Event()
+
+        async def wrapped(reader: StreamReader, writer: StreamWriter) -> None:
+            await _handle_conn(reader, writer, queue)
+            done.set()
+
+        server = await asyncio.start_server(wrapped, host, port)
+        writer_task = asyncio.create_task(_writer_task(db_file, queue))
+        async with server:
+            await done.wait()
+
+        await queue.join()
+        queue.put_nowait(None)
+        await writer_task
+
+    asyncio.run(_run())
+
+
+def serve(host: str, port: int, db_file: Path) -> None:
+    """Accept multiple connections concurrently."""
+
+    async def _run() -> None:
+        queue: Queue = Queue()
+        server = await asyncio.start_server(
+            lambda r, w: _handle_conn(r, w, queue), host, port
+        )
+        writer_task = asyncio.create_task(_writer_task(db_file, queue))
+        async with server:
+            await server.serve_forever()
+
+        await queue.join()
+        queue.put_nowait(None)
+        await writer_task
+
+    asyncio.run(_run())
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description="Listen on socket and insert into SQLite")
+    p.add_argument("--host", default="127.0.0.1")
+    p.add_argument("--port", type=int, default=9000)
+    p.add_argument("--db", required=True, help="output SQLite file")
+    args = p.parse_args()
+
+    serve(args.host, args.port, Path(args.db))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_sqlite_service.py
+++ b/tests/test_sqlite_service.py
@@ -1,0 +1,78 @@
+import socket
+import threading
+import time
+import json
+import sqlite3
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from scripts.sqlite_log_service import listen_once
+from scripts.train_target_clone import _load_logs
+
+
+def test_sqlite_log_service(tmp_path: Path):
+    host = "127.0.0.1"
+    srv_sock = socket.socket()
+    srv_sock.bind((host, 0))
+    port = srv_sock.getsockname()[1]
+    srv_sock.close()
+
+    db_file = tmp_path / "stream.db"
+
+    t = threading.Thread(target=listen_once, args=(host, port, db_file))
+    t.start()
+    time.sleep(0.1)
+
+    msg = {
+        "event_id": 1,
+        "event_time": "t",
+        "broker_time": "b",
+        "local_time": "l",
+        "action": "OPEN",
+        "ticket": 1,
+        "magic": 2,
+        "source": "mt4",
+        "symbol": "EURUSD",
+        "order_type": 0,
+        "lots": 0.1,
+        "price": 1.2345,
+        "sl": 1.0,
+        "tp": 2.0,
+        "profit": 0.0,
+        "comment": "hi",
+        "remaining_lots": 0.1,
+    }
+
+    client = socket.socket()
+    client.connect((host, port))
+    client.sendall(json.dumps(msg).encode() + b"\n")
+    client.close()
+
+    t.join(timeout=2)
+    assert not t.is_alive()
+
+    conn = sqlite3.connect(db_file)
+    try:
+        rows = conn.execute("SELECT * FROM logs").fetchall()
+    finally:
+        conn.close()
+    assert len(rows) == 1
+
+
+def test_load_logs_from_db(tmp_path: Path):
+    db_file = tmp_path / "logs.db"
+    conn = sqlite3.connect(db_file)
+    conn.execute(
+        "CREATE TABLE logs (event_id TEXT, event_time TEXT, broker_time TEXT, local_time TEXT, action TEXT, ticket TEXT, magic TEXT, source TEXT, symbol TEXT, order_type TEXT, lots TEXT, price TEXT, sl TEXT, tp TEXT, profit TEXT, comment TEXT, remaining_lots TEXT)"
+    )
+    conn.execute(
+        "INSERT INTO logs VALUES (1, '2024.01.01 00:00:00', '', '', 'OPEN', '1', '', '', 'EURUSD', '0', '0.1', '1.1000', '1.0950', '1.1100', '0', '', '0.1')"
+    )
+    conn.commit()
+    conn.close()
+
+    df = _load_logs(db_file)
+    assert not df.empty
+    assert "symbol" in df.columns
+


### PR DESCRIPTION
## Summary
- add `sqlite_log_service.py` for logging socket events to SQLite
- load log data from `.db` files in `train_target_clone.py`
- document SQLite service usage in README
- test SQLite service and DB loading

## Testing
- `pip install pandas numpy scikit-learn pytest`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886ad01d98c832f96a67b3072a010f1