### PR TITLE
Add stochastic oscillator and ADX features

### DIFF
--- a/scripts/generate_mql4_from_model.py
+++ b/scripts/generate_mql4_from_model.py
@@ -95,6 +95,9 @@ def generate(model_json: Path, out_dir: Path):
         'bollinger_upper': 'iBands(SymbolToTrade, 0, 20, 2, 0, PRICE_CLOSE, MODE_UPPER, 0)',
         'bollinger_middle': 'iBands(SymbolToTrade, 0, 20, 2, 0, PRICE_CLOSE, MODE_MAIN, 0)',
         'bollinger_lower': 'iBands(SymbolToTrade, 0, 20, 2, 0, PRICE_CLOSE, MODE_LOWER, 0)',
+        'stochastic_k': 'iStochastic(SymbolToTrade, 0, 14, 3, 3, MODE_SMA, 0, MODE_MAIN, 0)',
+        'stochastic_d': 'iStochastic(SymbolToTrade, 0, 14, 3, 3, MODE_SMA, 0, MODE_SIGNAL, 0)',
+        'adx': 'iADX(SymbolToTrade, 0, 14, PRICE_CLOSE, MODE_MAIN, 0)',
     }
 
     cases = []

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -133,6 +133,30 @@ def test_atr_bollinger_features(tmp_path: Path):
     assert "iBands(SymbolToTrade" in content
 
 
+def test_stochastic_adx_features(tmp_path: Path):
+    model = {
+        "model_id": "stoch",
+        "magic": 654,
+        "coefficients": [0.1] * 3,
+        "intercept": 0.0,
+        "threshold": 0.5,
+        "feature_names": ["stochastic_k", "stochastic_d", "adx"],
+    }
+    model_file = tmp_path / "model.json"
+    with open(model_file, "w") as f:
+        json.dump(model, f)
+
+    out_dir = tmp_path / "out"
+    generate(model_file, out_dir)
+
+    generated = list(out_dir.glob("Generated_stoch_*.mq4"))
+    assert len(generated) == 1
+    with open(generated[0]) as f:
+        content = f.read()
+    assert "iStochastic(SymbolToTrade" in content
+    assert "iADX(SymbolToTrade" in content
+
+
 def test_generate_nn(tmp_path: Path):
     model = {
         "model_id": "nn",

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -198,6 +198,25 @@ def test_train_with_atr_bollinger(tmp_path: Path):
     assert any(n.startswith("bollinger_") for n in feats)
 
 
+def test_train_with_stochastic_adx(tmp_path: Path):
+    data_dir = tmp_path / "logs"
+    out_dir = tmp_path / "out"
+    data_dir.mkdir()
+    log_file = data_dir / "trades_test.csv"
+    _write_log(log_file)
+
+    train(data_dir, out_dir, use_stochastic=True, use_adx=True)
+
+    model_file = out_dir / "model.json"
+    assert model_file.exists()
+    with open(model_file) as f:
+        data = json.load(f)
+    feats = data.get("feature_names", [])
+    assert "stochastic_k" in feats
+    assert "stochastic_d" in feats
+    assert "adx" in feats
+
+
 def test_train_with_volatility(tmp_path: Path):
     data_dir = tmp_path / "logs"
     out_dir = tmp_path / "out"


### PR DESCRIPTION
## Summary
- extend feature extraction with stochastic oscillator and ADX helpers
- expose `--use-stochastic` and `--use-adx` flags in training CLI
- map new indicators when generating MQL4
- test that new features appear in models and generated MQ4

## Testing
- `pytest -q tests/test_train.py::test_train_with_stochastic_adx`
- `pytest -q tests/test_generate.py::test_stochastic_adx_features`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886c4a667dc832f9aaff2e13f1a2811