### PR TITLE
Add cross symbol feature support

### DIFF
--- a/scripts/generate_mql4_from_model.py
+++ b/scripts/generate_mql4_from_model.py
@@ -102,7 +102,21 @@ def generate(model_json: Path, out_dir: Path):
 
     cases = []
     for idx, name in enumerate(feature_names):
-        expr = feature_map.get(name, '0.0')
+        expr = feature_map.get(name)
+        if expr is None:
+            if name.startswith('ratio_'):
+                parts = name[6:].split('_')
+                if len(parts) == 2:
+                    expr = f'iClose("{parts[0]}", 0, 0) / iClose("{parts[1]}", 0, 0)'
+            elif name.startswith('corr_'):
+                parts = name[5:].split('_')
+                if len(parts) == 2:
+                    expr = (
+                        f'iMA("{parts[0]}", 0, 5, 0, MODE_SMA, PRICE_CLOSE, 0) - '
+                        f'iMA("{parts[1]}", 0, 5, 0, MODE_SMA, PRICE_CLOSE, 0)'
+                    )
+        if expr is None:
+            expr = '0.0'
         cases.append(f"      case {idx}:\n         return({expr});")
     case_block = "\n".join(cases)
     if case_block:

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -238,3 +238,26 @@ def test_generate_hourly_thresholds(tmp_path: Path):
         content = f.read()
     assert "HourlyThresholds" in content
     assert "GetTradeThreshold()" in content
+
+
+def test_generate_ratio_feature(tmp_path: Path):
+    model = {
+        "model_id": "ratio",
+        "magic": 999,
+        "coefficients": [0.1],
+        "intercept": 0.0,
+        "threshold": 0.5,
+        "feature_names": ["ratio_EURUSD_USDCHF"],
+    }
+    model_file = tmp_path / "model.json"
+    with open(model_file, "w") as f:
+        json.dump(model, f)
+
+    out_dir = tmp_path / "out"
+    generate(model_file, out_dir)
+
+    generated = list(out_dir.glob("Generated_ratio_*.mq4"))
+    assert len(generated) == 1
+    with open(generated[0]) as f:
+        content = f.read()
+    assert 'iClose("EURUSD", 0, 0) / iClose("USDCHF", 0, 0)' in content

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -337,3 +337,19 @@ def test_hourly_thresholds(tmp_path: Path):
     ht = data.get("hourly_thresholds")
     assert isinstance(ht, list)
     assert len(ht) == 24
+
+
+def test_corr_features(tmp_path: Path):
+    data_dir = tmp_path / "logs"
+    out_dir = tmp_path / "out"
+    data_dir.mkdir()
+    log_file = data_dir / "trades_corr.csv"
+    _write_log(log_file)
+
+    train(data_dir, out_dir, corr_pairs=[("EURUSD", "USDCHF")])
+
+    with open(out_dir / "model.json") as f:
+        data = json.load(f)
+    feats = data.get("feature_names", [])
+    assert "ratio_EURUSD_USDCHF" in feats
+    assert "corr_EURUSD_USDCHF" in feats


### PR DESCRIPTION
## Summary
- calculate rolling correlation and ratio between symbol pairs when training
- export correlated/ratio features using iClose/iMA in MQL templates
- allow `--corr-symbols` CLI option for train script
- add tests covering new functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886ca907cd0832fa300cbb0cc611bff