### PR TITLE
Add optional Optuna tuning to training script

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,13 @@ python train_target_clone.py --data-dir "C:\\path\\to\\observer_logs" --out-dir 
 python generate_mql4_from_model.py models/model.json experts
 ```
 
+Hyperparameters can be optimised automatically when `optuna` is installed:
+
+```bash
+pip install optuna
+python train_target_clone.py --data-dir "C:\\path\\to\\observer_logs" --out-dir models --optuna-trials 50
+```
+
 For ongoing training simply rerun the script with the ``--incremental`` flag and
 the latest log directory. The generated MQ4 file name will include the training
 timestamp so previous versions remain intact:


### PR DESCRIPTION
## Summary
- add optional optuna dependency
- allow `--optuna-trials` parameter in `train_target_clone.py`
- record best hyperparameters in `model.json`
- document hyperparameter optimization in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886cd12190c832f8be7d9a088ffc15f