### PR TITLE
Add autoencoder pretraining and integration

### DIFF
--- a/experts/StrategyTemplate.mq4
+++ b/experts/StrategyTemplate.mq4
@@ -28,6 +28,9 @@ double LSTMDenseWeights[] = {__LSTM_DENSE_W__};
 double LSTMDenseBias = __LSTM_DENSE_B__;
 double FeatureHistory[__LSTM_SEQ_LEN__][__FEATURE_COUNT__];
 int FeatureHistorySize = 0;
+int EncoderWindow = __ENCODER_WINDOW__;
+int EncoderDim = __ENCODER_DIM__;
+double EncoderWeights[] = {__ENCODER_WEIGHTS__};
 
 int OnInit()
 {
@@ -66,6 +69,20 @@ double GetTPDistance()
             return(Ask - OrderTakeProfit());
       }
    return(0.0);
+}
+
+double GetEncodedFeature(int idx)
+{
+   if(idx >= EncoderDim)
+      return(0.0);
+   double val = 0.0;
+   int base = idx * EncoderWindow;
+   for(int i=0; i<EncoderWindow; i++)
+   {
+      double diff = iClose(SymbolToTrade, 0, i) - iClose(SymbolToTrade, 0, i+1);
+      val += EncoderWeights[base + i] * diff;
+   }
+   return(val);
 }
 
 double GetFeature(int index)

--- a/scripts/generate_mql4_from_model.py
+++ b/scripts/generate_mql4_from_model.py
@@ -76,6 +76,14 @@ def generate(model_json: Path, out_dir: Path):
     output = output.replace('__LSTM_HIDDEN_SIZE__', str(lstm_hidden))
     output = output.replace('__LSTM_SEQ_LEN__', str(seq_len))
 
+    enc_weights = model.get('encoder_weights', [])
+    enc_window = int(model.get('encoder_window', 0))
+    enc_dim = len(enc_weights[0]) if enc_weights else 0
+    enc_flat = ', '.join(_fmt(v) for row in enc_weights for v in row)
+    output = output.replace('__ENCODER_WEIGHTS__', enc_flat)
+    output = output.replace('__ENCODER_WINDOW__', str(enc_window))
+    output = output.replace('__ENCODER_DIM__', str(enc_dim))
+
     feature_names = model.get('feature_names', [])
     feature_count = len(feature_names)
 
@@ -115,6 +123,9 @@ def generate(model_json: Path, out_dir: Path):
                         f'iMA("{parts[0]}", 0, 5, 0, MODE_SMA, PRICE_CLOSE, 0) - '
                         f'iMA("{parts[1]}", 0, 5, 0, MODE_SMA, PRICE_CLOSE, 0)'
                     )
+            elif name.startswith('ae') and name[2:].isdigit():
+                idx_ae = int(name[2:])
+                expr = f'GetEncodedFeature({idx_ae})'
         if expr is None:
             expr = '0.0'
         cases.append(f"      case {idx}:\n         return({expr});")

--- a/scripts/pretrain_autoencoder.py
+++ b/scripts/pretrain_autoencoder.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Pre-train simple autoencoder on tick price changes."""
+import argparse
+import json
+import csv
+from pathlib import Path
+from typing import List
+
+import numpy as np
+
+try:
+    import tensorflow as tf  # type: ignore
+    from tensorflow import keras  # type: ignore
+    HAS_TF = True
+except Exception:
+    HAS_TF = False
+
+
+def _load_ticks(file: Path) -> List[float]:
+    """Load bid prices from TickHistoryExporter CSV."""
+    prices: List[float] = []
+    with open(file, newline="") as f:
+        reader = csv.DictReader(f, delimiter=";")
+        for r in reader:
+            try:
+                prices.append(float(r.get("bid", 0) or 0))
+            except Exception:
+                continue
+    return prices
+
+
+def train(tick_dir: Path, out_path: Path, *, window: int = 10, latent_dim: int = 4, epochs: int = 10) -> None:
+    if not HAS_TF:
+        raise ImportError("TensorFlow is required for autoencoder training")
+
+    seqs: List[np.ndarray] = []
+    for tick_file in tick_dir.glob("ticks_*.csv"):
+        prices = _load_ticks(tick_file)
+        if len(prices) <= window:
+            continue
+        diffs = np.diff(prices)
+        for i in range(len(diffs) - window):
+            seqs.append(diffs[i : i + window])
+    if not seqs:
+        raise ValueError(f"No tick sequences found in {tick_dir}")
+
+    X = np.stack(seqs).astype(np.float32)
+
+    inp = keras.Input(shape=(window,))
+    x = keras.layers.Dense(latent_dim, use_bias=False)(inp)
+    out = keras.layers.Dense(window, use_bias=False)(x)
+    model = keras.Model(inp, out)
+    model.compile(optimizer="adam", loss="mse")
+    model.fit(X, X, epochs=epochs, batch_size=32, verbose=0)
+
+    encoder_weights = model.layers[1].get_weights()[0]  # type: ignore[index]
+    data = {"window": window, "weights": encoder_weights.tolist()}
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(out_path, "w") as f:
+        json.dump(data, f, indent=2)
+    print(f"Encoder weights written to {out_path}")
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description="Pretrain autoencoder from ticks")
+    p.add_argument("tick_dir", help="directory with ticks_*.csv files")
+    p.add_argument("out_file", help="output JSON file for encoder weights")
+    p.add_argument("--window", type=int, default=10)
+    p.add_argument("--latent-dim", type=int, default=4)
+    p.add_argument("--epochs", type=int, default=10)
+    args = p.parse_args()
+    train(Path(args.tick_dir), Path(args.out_file), window=args.window, latent_dim=args.latent_dim, epochs=args.epochs)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add pretraining script for autoencoder
- allow train_target_clone to generate latent features via encoder
- include encoder weights when generating MQL4 strategies
- extend StrategyTemplate with encoder inference

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886cf36ab34832f97f525b55ef22685