### PR TITLE
Add RL warm start support

### DIFF
--- a/scripts/generate_mql4_from_model.py
+++ b/scripts/generate_mql4_from_model.py
@@ -27,6 +27,14 @@ def generate(model_json: Path, out_dir: Path):
     )
 
     coeffs = model.get('coefficients') or model.get('coef_vector', [])
+    if not coeffs:
+        q_w = model.get('q_weights')
+        if isinstance(q_w, list) and len(q_w) >= 2:
+            try:
+                import numpy as np
+                coeffs = (np.array(q_w[0]) - np.array(q_w[1])).tolist()
+            except Exception:
+                coeffs = []
     coeff_str = ', '.join(_fmt(c) for c in coeffs)
     output = output.replace('__COEFFICIENTS__', coeff_str)
 
@@ -135,7 +143,13 @@ def generate(model_json: Path, out_dir: Path):
     output = output.replace('__FEATURE_CASES__', case_block)
     output = output.replace('__FEATURE_COUNT__', str(feature_count))
 
-    intercept = model.get('intercept', 0.0)
+    intercept = model.get('intercept')
+    if intercept is None:
+        q_int = model.get('q_intercepts')
+        if isinstance(q_int, list) and len(q_int) >= 2:
+            intercept = float(q_int[0]) - float(q_int[1])
+        else:
+            intercept = 0.0
     output = output.replace('__INTERCEPT__', _fmt(intercept))
 
     threshold = model.get('threshold', 0.5)

--- a/scripts/train_target_clone.py
+++ b/scripts/train_target_clone.py
@@ -792,6 +792,22 @@ def train(
         json.dump(model, f, indent=2)
 
     print(f"Model written to {out_dir / 'model.json'}")
+
+    if "coefficients" in model and "intercept" in model:
+        w = np.array(model["coefficients"], dtype=float)
+        b = float(model["intercept"])
+        init = {
+            "weights": [
+                (w / 2.0).tolist(),
+                (-w / 2.0).tolist(),
+            ],
+            "intercepts": [b / 2.0, -b / 2.0],
+            "feature_names": model.get("feature_names", []),
+        }
+        with open(out_dir / "policy_init.json", "w") as f:
+            json.dump(init, f, indent=2)
+        print(f"Initial policy written to {out_dir / 'policy_init.json'}")
+
     print(f"Validation accuracy: {val_acc:.3f}")
 
 

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -261,3 +261,25 @@ def test_generate_ratio_feature(tmp_path: Path):
     with open(generated[0]) as f:
         content = f.read()
     assert 'iClose("EURUSD", 0, 0) / iClose("USDCHF", 0, 0)' in content
+
+
+def test_generate_rl_fused(tmp_path: Path):
+    model = {
+        "model_id": "rl_fused",
+        "q_weights": [[0.2, -0.1], [-0.2, 0.1]],
+        "q_intercepts": [0.1, -0.1],
+        "threshold": 0.5,
+        "feature_names": ["hour", "spread"],
+    }
+    model_file = tmp_path / "model.json"
+    with open(model_file, "w") as f:
+        json.dump(model, f)
+
+    out_dir = tmp_path / "out"
+    generate(model_file, out_dir)
+
+    generated = list(out_dir.glob("Generated_rl_fused_*.mq4"))
+    assert len(generated) == 1
+    with open(generated[0]) as f:
+        content = f.read()
+    assert "ModelCoefficients" in content

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -163,6 +163,13 @@ def test_train(tmp_path: Path):
     assert "day_of_week" in data.get("feature_names", [])
     assert "spread" in data.get("feature_names", [])
 
+    init_file = out_dir / "policy_init.json"
+    assert init_file.exists()
+    with open(init_file) as f:
+        init = json.load(f)
+    assert "weights" in init
+    assert "intercepts" in init
+
 
 def test_train_with_indicators(tmp_path: Path):
     data_dir = tmp_path / "logs"

--- a/tests/test_train_rl_agent.py
+++ b/tests/test_train_rl_agent.py
@@ -135,6 +135,32 @@ def test_train_rl_agent(tmp_path: Path):
     assert "avg_reward_per_episode" in data
 
 
+def test_train_rl_agent_start_model(tmp_path: Path):
+    data_dir = tmp_path / "logs"
+    out_dir = tmp_path / "out"
+    data_dir.mkdir()
+    log_file = data_dir / "trades_test.csv"
+    _write_log(log_file)
+
+    start_model = out_dir / "start.json"
+    start = {
+        "model_id": "sup_model",
+        "coefficients": [0.1, -0.1],
+        "intercept": 0.05,
+        "feature_names": ["hour", "lots"],
+    }
+    out_dir.mkdir()
+    with open(start_model, "w") as f:
+        json.dump(start, f)
+
+    train(data_dir, out_dir, start_model=start_model)
+
+    with open(out_dir / "model.json") as f:
+        data = json.load(f)
+    assert data.get("training_type") == "supervised+rl"
+    assert data.get("init_model_id") == "sup_model"
+
+
 @pytest.mark.skipif(not HAS_SB3, reason="stable-baselines3 not installed")
 def test_train_rl_agent_sb3(tmp_path: Path):
     data_dir = tmp_path / "logs"


### PR DESCRIPTION
## Summary
- export RL policy init from `train_target_clone.py`
- allow RL agent to start from a provided model and save metadata
- support fused RL models in MQL4 generator
- test new RL initialization workflow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886d5b1e690832fbeec67eb7ef19885