### PR TITLE
Add feature scaling to model export

### DIFF
--- a/experts/StrategyTemplate.mq4
+++ b/experts/StrategyTemplate.mq4
@@ -28,6 +28,8 @@ double LSTMRecurrent[] = {__LSTM_RECURRENT__};
 double LSTMBias[] = {__LSTM_BIAS__};
 double LSTMDenseWeights[] = {__LSTM_DENSE_W__};
 double LSTMDenseBias = __LSTM_DENSE_B__;
+double FeatureMean[] = {__FEATURE_MEAN__};
+double FeatureStd[] = {__FEATURE_STD__};
 double FeatureHistory[__LSTM_SEQ_LEN__][__FEATURE_COUNT__];
 int FeatureHistorySize = 0;
 int EncoderWindow = __ENCODER_WINDOW__;
@@ -82,6 +84,8 @@ bool ParseModelJson(string json)
    ExtractJsonArray(json, "\"coefficients\"", ModelCoefficients);
    ExtractJsonArray(json, "\"hourly_thresholds\"", HourlyThresholds);
    ExtractJsonArray(json, "\"probability_table\"", ProbabilityLookup);
+   ExtractJsonArray(json, "\"feature_mean\"", FeatureMean);
+   ExtractJsonArray(json, "\"feature_std\"", FeatureStd);
    ModelIntercept = ExtractJsonNumber(json, "\"intercept\"");
    ModelThreshold = ExtractJsonNumber(json, "\"threshold\"");
    return(true);
@@ -183,11 +187,16 @@ double GetFeature(int index)
       Feature mapping is intentionally minimal and should be kept in
       sync with the Python training script.  Unknown indices default
       to zero. */
+   double val = 0.0;
    switch(index)
    {
 __FEATURE_CASES__      default:
-         return(0.0);
+         val = 0.0;
+         break;
    }
+   if(index < ArraySize(FeatureMean) && index < ArraySize(FeatureStd) && FeatureStd[index] != 0)
+      val = (val - FeatureMean[index]) / FeatureStd[index];
+   return(val);
 }
 
 double ComputeLogisticScore()

--- a/scripts/generate_mql4_from_model.py
+++ b/scripts/generate_mql4_from_model.py
@@ -92,6 +92,13 @@ def generate(model_json: Path, out_dir: Path):
     output = output.replace('__ENCODER_WINDOW__', str(enc_window))
     output = output.replace('__ENCODER_DIM__', str(enc_dim))
 
+    feature_mean = model.get('feature_mean', [])
+    mean_str = ', '.join(_fmt(v) for v in feature_mean)
+    output = output.replace('__FEATURE_MEAN__', mean_str)
+    feature_std = model.get('feature_std', [])
+    std_str = ', '.join(_fmt(v) for v in feature_std)
+    output = output.replace('__FEATURE_STD__', std_str)
+
     feature_names = model.get('feature_names', [])
     feature_count = len(feature_names)
 
@@ -136,7 +143,7 @@ def generate(model_json: Path, out_dir: Path):
                 expr = f'GetEncodedFeature({idx_ae})'
         if expr is None:
             expr = '0.0'
-        cases.append(f"      case {idx}:\n         return({expr});")
+        cases.append(f"      case {idx}:\n         val = ({expr});\n         break;")
     case_block = "\n".join(cases)
     if case_block:
         case_block += "\n"

--- a/scripts/train_target_clone.py
+++ b/scripts/train_target_clone.py
@@ -725,6 +725,12 @@ def train(
                 t = threshold
             hourly_thresholds.append(float(t))
 
+    # statistics for feature scaling
+    X_stats = vec.transform(feat_train)
+    feature_mean = X_stats.mean(axis=0)
+    feature_std = X_stats.std(axis=0)
+    feature_std[feature_std == 0] = 1.0
+
     # Compute SHAP feature importance on the training set
     try:
         import shap  # type: ignore
@@ -753,6 +759,8 @@ def train(
         "accuracy": val_acc,
         "num_samples": int(labels.shape[0]) + (int(existing_model.get("num_samples", 0)) if existing_model else 0),
         "feature_importance": feature_importance,
+        "feature_mean": feature_mean.tolist(),
+        "feature_std": feature_std.tolist(),
     }
     if encoder is not None:
         model["encoder_weights"] = encoder.get("weights")

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -283,3 +283,29 @@ def test_generate_rl_fused(tmp_path: Path):
     with open(generated[0]) as f:
         content = f.read()
     assert "ModelCoefficients" in content
+
+
+def test_generate_scaling_arrays(tmp_path: Path):
+    model = {
+        "model_id": "scale",
+        "magic": 111,
+        "coefficients": [0.1],
+        "intercept": 0.0,
+        "threshold": 0.5,
+        "feature_names": ["hour"],
+        "feature_mean": [12.0],
+        "feature_std": [3.0],
+    }
+    model_file = tmp_path / "model.json"
+    with open(model_file, "w") as f:
+        json.dump(model, f)
+
+    out_dir = tmp_path / "out"
+    generate(model_file, out_dir)
+
+    generated = list(out_dir.glob("Generated_scale_*.mq4"))
+    assert len(generated) == 1
+    with open(generated[0]) as f:
+        content = f.read()
+    assert "FeatureMean[]" in content
+    assert "FeatureStd[]" in content

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -163,6 +163,8 @@ def test_train(tmp_path: Path):
     assert "day_of_week" in data.get("feature_names", [])
     assert "spread" in data.get("feature_names", [])
     assert data.get("weighted") is True
+    assert "feature_mean" in data
+    assert "feature_std" in data
 
     init_file = out_dir / "policy_init.json"
     assert init_file.exists()


### PR DESCRIPTION
## Summary
- compute feature scaling statistics when training
- include scaling arrays in generated MQL4 strategies
- parse scaling values in StrategyTemplate
- adjust feature case generation and scaling logic
- add regression tests for scaling data

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886e8713604832fbb6fb68b9c50f424