### PR TITLE
Add slippage feature support

### DIFF
--- a/experts/Observer_TBot.mq4
+++ b/experts/Observer_TBot.mq4
@@ -101,7 +101,7 @@ int OnInit()
          FileSeek(trade_log_handle, 0, SEEK_END);
          if(need_header)
          {
-           string header = "event_id;event_time;broker_time;local_time;action;ticket;magic;source;symbol;order_type;lots;price;sl;tp;profit;spread;comment;remaining_lots";
+           string header = "event_id;event_time;broker_time;local_time;action;ticket;magic;source;symbol;order_type;lots;price;sl;tp;profit;spread;comment;remaining_lots;slippage";
             int _wr = FileWrite(trade_log_handle, header);
             if(_wr <= 0)
                FileWriteErrors++;
@@ -234,6 +234,10 @@ void OnTradeTransaction(const MqlTradeTransaction &trans,
    string comment    = HistoryDealGetString(trans.deal, DEAL_COMMENT);
    int    ticket     = (int)trans.order;
 
+   double slippage = 0.0;
+   if(entry==DEAL_ENTRY_IN || entry==DEAL_ENTRY_OUT)
+      slippage = res.price - req.price;
+
    if(!MagicMatches(magic) || !SymbolMatches(symbol))
       return;
 
@@ -245,7 +249,7 @@ void OnTradeTransaction(const MqlTradeTransaction &trans,
    {
       LogTrade("OPEN", ticket, magic, "mt4", symbol, order_type,
                lots, price, sl, tp, 0.0, MarketInfo(symbol, MODE_SPREAD),
-               remaining, now, comment);
+               remaining, now, comment, slippage);
       if(!IsTracked(ticket))
          AddTicket(ticket);
       else if(entry==DEAL_ENTRY_INOUT && remaining>0.0 && OrderSelect(ticket, SELECT_BY_TICKET, MODE_TRADES))
@@ -255,14 +259,14 @@ void OnTradeTransaction(const MqlTradeTransaction &trans,
          double cur_tp    = OrderTakeProfit();
          LogTrade("MODIFY", ticket, magic, "mt4", symbol, order_type,
                   0.0, cur_price, cur_sl, cur_tp, 0.0,
-                  MarketInfo(symbol, MODE_SPREAD), remaining, now, comment);
+                  MarketInfo(symbol, MODE_SPREAD), remaining, now, comment, 0.0);
       }
    }
    else if(entry==DEAL_ENTRY_OUT || entry==DEAL_ENTRY_OUT_BY)
    {
       LogTrade("CLOSE", ticket, magic, "mt4", symbol, order_type,
                lots, price, sl, tp, profit, MarketInfo(symbol, MODE_SPREAD),
-               remaining, now, comment);
+               remaining, now, comment, slippage);
       if(IsTracked(ticket) && remaining==0.0)
          RemoveTicket(ticket);
       else if(remaining>0.0 && OrderSelect(ticket, SELECT_BY_TICKET, MODE_TRADES))
@@ -272,7 +276,7 @@ void OnTradeTransaction(const MqlTradeTransaction &trans,
          double cur_tp    = OrderTakeProfit();
          LogTrade("MODIFY", ticket, magic, "mt4", symbol, order_type,
                   0.0, cur_price, cur_sl, cur_tp, 0.0,
-                  MarketInfo(symbol, MODE_SPREAD), remaining, now, comment);
+                  MarketInfo(symbol, MODE_SPREAD), remaining, now, comment, 0.0);
       }
    }
 }
@@ -301,7 +305,7 @@ void OnTick()
          LogTrade("OPEN", ticket, OrderMagicNumber(), "mt4", OrderSymbol(), OrderType(),
                   OrderLots(), OrderOpenPrice(), OrderStopLoss(), OrderTakeProfit(),
                   0.0, MarketInfo(OrderSymbol(), MODE_SPREAD),
-                  OrderLots(), now, OrderComment());
+                  OrderLots(), now, OrderComment(), 0.0);
          AddTicket(ticket);
       }
    }
@@ -316,11 +320,11 @@ void OnTick()
       {
          if(OrderSelect(ticket, SELECT_BY_TICKET, MODE_HISTORY))
          {
-              LogTrade("CLOSE", ticket, OrderMagicNumber(), "mt4", OrderSymbol(),
+             LogTrade("CLOSE", ticket, OrderMagicNumber(), "mt4", OrderSymbol(),
                        OrderType(), OrderLots(), OrderClosePrice(), OrderStopLoss(),
                        OrderTakeProfit(), OrderProfit()+OrderSwap()+OrderCommission(),
                        MarketInfo(OrderSymbol(), MODE_SPREAD),
-                       0.0, now, OrderComment());
+                       0.0, now, OrderComment(), 0.0);
          }
          RemoveTicket(ticket);
          t--; // adjust index after removal
@@ -380,15 +384,16 @@ string EscapeJson(string s)
 void LogTrade(string action, int ticket, int magic, string source,
               string symbol, int order_type, double lots, double price,
               double sl, double tp, double profit, double spread,
-              double remaining, datetime time_event, string comment)
+              double remaining, datetime time_event, string comment,
+              double slippage)
 {
    int id = NextEventId++;
-   string line = StringFormat("%d;%s;%s;%s;%s;%d;%d;%s;%s;%d;%.2f;%.5f;%.5f;%.5f;%.2f;%d;%s;%.2f",
+   string line = StringFormat("%d;%s;%s;%s;%s;%d;%d;%s;%s;%d;%.2f;%.5f;%.5f;%.5f;%.2f;%d;%s;%.2f;%.5f",
       id,
       TimeToString(time_event, TIME_DATE|TIME_SECONDS),
       TimeToString(TimeCurrent(), TIME_DATE|TIME_SECONDS),
       TimeToString(TimeLocal(), TIME_DATE|TIME_SECONDS),
-      action, ticket, magic, source, symbol, order_type, lots, price, sl, tp, profit, spread, comment, remaining);
+      action, ticket, magic, source, symbol, order_type, lots, price, sl, tp, profit, spread, comment, remaining, slippage);
 
    if(!EnableSocketLogging)
    {
@@ -412,13 +417,13 @@ void LogTrade(string action, int ticket, int magic, string source,
       }
    }
 
-   string json = StringFormat("{\"event_id\":%d,\"event_time\":\"%s\",\"broker_time\":\"%s\",\"local_time\":\"%s\",\"action\":\"%s\",\"ticket\":%d,\"magic\":%d,\"source\":\"%s\",\"symbol\":\"%s\",\"order_type\":%d,\"lots\":%.2f,\"price\":%.5f,\"sl\":%.5f,\"tp\":%.5f,\"profit\":%.2f,\"spread\":%d,\"comment\":\"%s\",\"remaining_lots\":%.2f}",
+   string json = StringFormat("{\"event_id\":%d,\"event_time\":\"%s\",\"broker_time\":\"%s\",\"local_time\":\"%s\",\"action\":\"%s\",\"ticket\":%d,\"magic\":%d,\"source\":\"%s\",\"symbol\":\"%s\",\"order_type\":%d,\"lots\":%.2f,\"price\":%.5f,\"sl\":%.5f,\"tp\":%.5f,\"profit\":%.2f,\"spread\":%d,\"comment\":\"%s\",\"remaining_lots\":%.2f,\"slippage\":%.5f}",
       id,
       EscapeJson(TimeToString(time_event, TIME_DATE|TIME_SECONDS)),
       EscapeJson(TimeToString(TimeCurrent(), TIME_DATE|TIME_SECONDS)),
       EscapeJson(TimeToString(TimeLocal(), TIME_DATE|TIME_SECONDS)),
       EscapeJson(action), ticket, magic, EscapeJson(source), EscapeJson(symbol), order_type,
-      lots, price, sl, tp, profit, spread, EscapeJson(comment), remaining);
+      lots, price, sl, tp, profit, spread, EscapeJson(comment), remaining, slippage);
 
    if(log_socket!=INVALID_HANDLE)
    {

--- a/scripts/sqlite_log_service.py
+++ b/scripts/sqlite_log_service.py
@@ -26,6 +26,7 @@ FIELDS = [
     "profit",
     "comment",
     "remaining_lots",
+    "slippage",
 ]
 
 

--- a/scripts/train_target_clone.py
+++ b/scripts/train_target_clone.py
@@ -243,6 +243,7 @@ def _load_logs(data_dir: Path) -> pd.DataFrame:
         "spread",
         "comment",
         "remaining_lots",
+        "slippage",
     ]
 
     dfs: List[pd.DataFrame] = []
@@ -303,6 +304,7 @@ def _extract_features(
     boll_window=20,
     use_stochastic=False,
     use_adx=False,
+    use_slippage=False,
     volatility=None,
     *,
     corr_pairs=None,
@@ -349,6 +351,7 @@ def _extract_features(
         sym_prices = price_map.setdefault(symbol, [])
 
         spread = float(r.get("spread", 0) or 0)
+        slippage = float(r.get("slippage", 0) or 0)
 
         feat = {
             "symbol": symbol,
@@ -360,6 +363,9 @@ def _extract_features(
             "tp_dist": tp - price,
             "spread": spread,
         }
+
+        if use_slippage:
+            feat["slippage"] = slippage
 
         if volatility is not None:
             key = t.strftime("%Y-%m-%d %H")
@@ -453,6 +459,7 @@ def train(
     boll_window: int = 20,
     use_stochastic: bool = False,
     use_adx: bool = False,
+    use_slippage: bool = False,
     volatility_series=None,
     grid_search: bool = False,
     c_values=None,
@@ -488,6 +495,7 @@ def train(
         boll_window=boll_window,
         use_stochastic=use_stochastic,
         use_adx=use_adx,
+        use_slippage=use_slippage,
         volatility=volatility_series,
         corr_pairs=corr_pairs,
         corr_window=corr_window,
@@ -847,6 +855,7 @@ def main():
     p.add_argument('--use-bollinger', action='store_true', help='include Bollinger Bands feature')
     p.add_argument('--use-stochastic', action='store_true', help='include Stochastic Oscillator feature')
     p.add_argument('--use-adx', action='store_true', help='include ADX feature')
+    p.add_argument('--use-slippage', action='store_true', help='include slippage feature')
     p.add_argument('--volatility-file', help='JSON file with precomputed volatility')
     p.add_argument('--grid-search', action='store_true', help='enable grid search with cross-validation')
     p.add_argument('--c-values', type=float, nargs='*')
@@ -884,6 +893,7 @@ def main():
         use_bollinger=args.use_bollinger,
         use_stochastic=args.use_stochastic,
         use_adx=args.use_adx,
+        use_slippage=args.use_slippage,
         volatility_series=vol_data,
         grid_search=args.grid_search,
         c_values=args.c_values,

--- a/tests/test_sqlite_service.py
+++ b/tests/test_sqlite_service.py
@@ -42,6 +42,7 @@ def test_sqlite_log_service(tmp_path: Path):
         "profit": 0.0,
         "comment": "hi",
         "remaining_lots": 0.1,
+        "slippage": 0.0,
     }
 
     client = socket.socket()
@@ -64,10 +65,10 @@ def test_load_logs_from_db(tmp_path: Path):
     db_file = tmp_path / "logs.db"
     conn = sqlite3.connect(db_file)
     conn.execute(
-        "CREATE TABLE logs (event_id TEXT, event_time TEXT, broker_time TEXT, local_time TEXT, action TEXT, ticket TEXT, magic TEXT, source TEXT, symbol TEXT, order_type TEXT, lots TEXT, price TEXT, sl TEXT, tp TEXT, profit TEXT, comment TEXT, remaining_lots TEXT)"
+        "CREATE TABLE logs (event_id TEXT, event_time TEXT, broker_time TEXT, local_time TEXT, action TEXT, ticket TEXT, magic TEXT, source TEXT, symbol TEXT, order_type TEXT, lots TEXT, price TEXT, sl TEXT, tp TEXT, profit TEXT, comment TEXT, remaining_lots TEXT, slippage TEXT)"
     )
     conn.execute(
-        "INSERT INTO logs VALUES (1, '2024.01.01 00:00:00', '', '', 'OPEN', '1', '', '', 'EURUSD', '0', '0.1', '1.1000', '1.0950', '1.1100', '0', '', '0.1')"
+        "INSERT INTO logs VALUES (1, '2024.01.01 00:00:00', '', '', 'OPEN', '1', '', '', 'EURUSD', '0', '0.1', '1.1000', '1.0950', '1.1100', '0', '', '0.1', '0.0')"
     )
     conn.commit()
     conn.close()
@@ -75,4 +76,5 @@ def test_load_logs_from_db(tmp_path: Path):
     df = _load_logs(db_file)
     assert not df.empty
     assert "symbol" in df.columns
+    assert "slippage" in df.columns
 

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -32,6 +32,7 @@ def _write_log(file: Path):
         "spread",
         "comment",
         "remaining_lots",
+        "slippage",
     ]
     rows = [
         [
@@ -53,6 +54,7 @@ def _write_log(file: Path):
             "2",
             "",
             "0.1",
+            "0.0001",
         ],
         [
             "2",
@@ -73,6 +75,7 @@ def _write_log(file: Path):
             "3",
             "",
             "0.1",
+            "0.0002",
         ],
     ]
     with open(file, "w", newline="") as f:
@@ -101,6 +104,7 @@ def _write_log_many(file: Path, count: int = 10):
         "spread",
         "comment",
         "remaining_lots",
+        "slippage",
     ]
     rows = []
     for i in range(count):
@@ -125,6 +129,7 @@ def _write_log_many(file: Path, count: int = 10):
             "2",
             "",
             "0.1",
+            "0.0001",
         ])
     with open(file, "w", newline="") as f:
         writer = csv.writer(f, delimiter=";")
@@ -255,6 +260,7 @@ def test_load_logs_with_metrics(tmp_path: Path):
     df = _load_logs(data_dir)
     assert "win_rate" in df.columns
     assert "spread" in df.columns
+    assert "slippage" in df.columns
 
 
 def test_train_xgboost(tmp_path: Path):
@@ -366,3 +372,18 @@ def test_corr_features(tmp_path: Path):
     feats = data.get("feature_names", [])
     assert "ratio_EURUSD_USDCHF" in feats
     assert "corr_EURUSD_USDCHF" in feats
+
+
+def test_slippage_feature(tmp_path: Path):
+    data_dir = tmp_path / "logs"
+    out_dir = tmp_path / "out"
+    data_dir.mkdir()
+    log_file = data_dir / "trades_slip.csv"
+    _write_log(log_file)
+
+    train(data_dir, out_dir, use_slippage=True)
+
+    with open(out_dir / "model.json") as f:
+        data = json.load(f)
+    feats = data.get("feature_names", [])
+    assert "slippage" in feats


### PR DESCRIPTION
## Summary
- log slippage for trade events in Observer_TBot and emit in JSON
- include slippage column when parsing logs and allow as model feature
- expose `--use-slippage` option in training script
- capture slippage in SQLite service
- update tests for new column and feature

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886f86ea048832f9a97c128f7719197