### PR TITLE
Add auto model promotion and publication

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,20 @@ seconds. When the file ``model.json`` in the terminal's ``Files`` directory is
 updated the strategy will automatically load the new coefficients and continue
 trading with minimal downtime.
 
+## Automated Promotion
+
+The ``promote_best_models.py`` helper can be scheduled to run periodically,
+copying the highest-scoring models to ``models/best`` and publishing the top
+one to the terminal's ``Files`` directory. An example cron entry running every
+30 minutes:
+
+```cron
+*/30 * * * * /path/to/BotCopier/scripts/promote_and_publish.sh
+```
+
+Set ``ReloadModelInterval`` on the EA so it automatically reloads the published
+model when ``model.json`` changes.
+
 ## Metrics Tracking
 
 During operation the EA records a summary line for each tracked model in

--- a/scripts/promote_and_publish.sh
+++ b/scripts/promote_and_publish.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+# Example cron script to promote models and publish the best one.
+
+REPO_DIR="/path/to/BotCopier"
+MODELS_DIR="$REPO_DIR/models"
+BEST_DIR="$MODELS_DIR/best"
+FILES_DIR="/path/to/MT4/MQL4/Files"
+
+python "$REPO_DIR/scripts/promote_best_models.py" "$MODELS_DIR" "$BEST_DIR" --files-dir "$FILES_DIR"

--- a/scripts/promote_best_models.py
+++ b/scripts/promote_best_models.py
@@ -4,6 +4,9 @@ import argparse
 import json
 import shutil
 from pathlib import Path
+from typing import Optional
+
+from publish_model import publish
 
 
 def _score_for_model(model_json: Path, metric: str) -> float:
@@ -49,8 +52,13 @@ def promote(
     best_dir: Path,
     max_models: int,
     metric: str,
+    files_dir: Optional[Path] = None,
 ) -> None:
-    """Copy the top ``max_models`` from ``models_dir`` to ``best_dir``."""
+    """Copy the top ``max_models`` from ``models_dir`` to ``best_dir``.
+
+    If ``files_dir`` is provided the highest ranked model is also published to
+    that directory so running strategies reload the new parameters.
+    """
 
     best_dir.mkdir(parents=True, exist_ok=True)
 
@@ -61,10 +69,12 @@ def promote(
 
     candidates.sort(key=lambda x: x[0], reverse=True)
 
-    for score, m in candidates[:max_models]:
+    for idx, (score, m) in enumerate(candidates[:max_models]):
         dest = best_dir / m.name
         shutil.copy(m, dest)
         print(f"Promoted {m} (metric={score}) to {dest}")
+        if idx == 0 and files_dir is not None:
+            publish(dest, files_dir)
 
 
 def main():
@@ -74,12 +84,14 @@ def main():
     p.add_argument('--max-models', type=int, default=3)
     p.add_argument('--metric', default='success_pct',
                    help='metric key to sort by')
+    p.add_argument('--files-dir', help='MT4 Files directory to publish model')
     args = p.parse_args()
     promote(
         Path(args.models_dir),
         Path(args.best_dir),
         args.max_models,
         args.metric,
+        Path(args.files_dir) if args.files_dir else None,
     )
 
 


### PR DESCRIPTION
## Summary
- publish the top model from `promote_best_models.py`
- provide example cron helper script
- document automated promotion and model reload settings

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886fb5eb068832f858755373f03eb34