### PR TITLE
Add transformer model support

### DIFF
--- a/scripts/generate_mql4_from_model.py
+++ b/scripts/generate_mql4_from_model.py
@@ -84,6 +84,39 @@ def generate(model_json: Path, out_dir: Path):
     output = output.replace('__LSTM_HIDDEN_SIZE__', str(lstm_hidden))
     output = output.replace('__LSTM_SEQ_LEN__', str(seq_len))
 
+    trans_weights = model.get('transformer_weights', [])
+    def _flat(a):
+        if isinstance(a, list):
+            r = []
+            for x in a:
+                r.extend(_flat(x))
+            return r
+        return [a]
+    if trans_weights:
+        qk = ', '.join(_fmt(v) for v in _flat(trans_weights[0]))
+        qb = ', '.join(_fmt(v) for v in _flat(trans_weights[1]))
+        kk = ', '.join(_fmt(v) for v in _flat(trans_weights[2]))
+        kb = ', '.join(_fmt(v) for v in _flat(trans_weights[3]))
+        vk = ', '.join(_fmt(v) for v in _flat(trans_weights[4]))
+        vb = ', '.join(_fmt(v) for v in _flat(trans_weights[5]))
+        ok = ', '.join(_fmt(v) for v in _flat(trans_weights[6]))
+        ob = ', '.join(_fmt(v) for v in _flat(trans_weights[7]))
+        dw = ', '.join(_fmt(v) for v in _flat(trans_weights[8]))
+        db = _fmt(trans_weights[9][0] if isinstance(trans_weights[9], list) else trans_weights[9])
+    else:
+        qk = qb = kk = kb = vk = vb = ok = ob = dw = ''
+        db = '0'
+    output = output.replace('__TRANS_QK__', qk)
+    output = output.replace('__TRANS_QB__', qb)
+    output = output.replace('__TRANS_KK__', kk)
+    output = output.replace('__TRANS_KB__', kb)
+    output = output.replace('__TRANS_VK__', vk)
+    output = output.replace('__TRANS_VB__', vb)
+    output = output.replace('__TRANS_OK__', ok)
+    output = output.replace('__TRANS_OB__', ob)
+    output = output.replace('__TRANS_DENSE_W__', dw)
+    output = output.replace('__TRANS_DENSE_B__', db)
+
     enc_weights = model.get('encoder_weights', [])
     enc_window = int(model.get('encoder_window', 0))
     enc_dim = len(enc_weights[0]) if enc_weights else 0

--- a/scripts/train_target_clone.py
+++ b/scripts/train_target_clone.py
@@ -693,6 +693,41 @@ def train(
         train_proba = model_nn.predict(X_train_seq).reshape(-1)
         val_proba = model_nn.predict(X_val_seq).reshape(-1) if len(y_val) > 0 else np.empty(0)
         clf = model_nn
+    elif model_type == "transformer":
+        if not HAS_TF:
+            raise ImportError("TensorFlow is required for transformer model")
+        seq_len = sequence_length
+        X_all = vec.fit_transform(features) if existing_model is None else vec.transform(features)
+        sequences = []
+        for i in range(len(X_all)):
+            start = max(0, i - seq_len + 1)
+            seq = X_all[start : i + 1]
+            if seq.shape[0] < seq_len:
+                pad = np.zeros((seq_len - seq.shape[0], X_all.shape[1]))
+                seq = np.vstack([pad, seq])
+            sequences.append(seq)
+        X_all_seq = np.array(sequences)
+        if len(labels) < 5 or len(np.unique(labels)) < 2:
+            X_train_seq, y_train = X_all_seq, labels
+            X_val_seq, y_val = np.empty((0, seq_len, X_all.shape[1])), np.array([])
+        else:
+            X_train_seq, X_val_seq, y_train, y_val = train_test_split(
+                X_all_seq,
+                labels,
+                test_size=0.2,
+                random_state=42,
+                stratify=labels,
+            )
+        inp = keras.layers.Input(shape=(seq_len, X_all.shape[1]))
+        att = keras.layers.MultiHeadAttention(num_heads=1, key_dim=X_all.shape[1])(inp, inp)
+        pooled = keras.layers.GlobalAveragePooling1D()(att)
+        out = keras.layers.Dense(1, activation="sigmoid")(pooled)
+        model_nn = keras.Model(inp, out)
+        model_nn.compile(optimizer="adam", loss="binary_crossentropy")
+        model_nn.fit(X_train_seq, y_train, epochs=50, verbose=0)
+        train_proba = model_nn.predict(X_train_seq).reshape(-1)
+        val_proba = model_nn.predict(X_val_seq).reshape(-1) if len(y_val) > 0 else np.empty(0)
+        clf = model_nn
     else:
         if grid_search:
             if c_values is None:
@@ -818,6 +853,10 @@ def train(
         model["lstm_weights"] = weights
         model["sequence_length"] = sequence_length
         model["hidden_size"] = len(weights[1]) // 4 if weights else 0
+    elif model_type == "transformer":
+        weights = [w.tolist() for w in clf.get_weights()]
+        model["transformer_weights"] = weights
+        model["sequence_length"] = sequence_length
 
     with open(out_dir / "model.json", "w") as f:
         json.dump(model, f, indent=2)
@@ -859,9 +898,9 @@ def main():
     p.add_argument('--volatility-file', help='JSON file with precomputed volatility')
     p.add_argument('--grid-search', action='store_true', help='enable grid search with cross-validation')
     p.add_argument('--c-values', type=float, nargs='*')
-    p.add_argument('--model-type', choices=['logreg', 'random_forest', 'xgboost', 'nn', 'lstm'], default='logreg',
+    p.add_argument('--model-type', choices=['logreg', 'random_forest', 'xgboost', 'nn', 'lstm', 'transformer'], default='logreg',
                    help='classifier type')
-    p.add_argument('--sequence-length', type=int, default=5, help='LSTM sequence length')
+    p.add_argument('--sequence-length', type=int, default=5, help='sequence length for LSTM/transformer models')
     p.add_argument('--n-estimators', type=int, default=100, help='xgboost trees')
     p.add_argument('--learning-rate', type=float, default=0.1, help='xgboost learning rate')
     p.add_argument('--max-depth', type=int, default=3, help='xgboost tree depth')

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -215,6 +215,40 @@ def test_generate_lstm(tmp_path: Path):
     assert "MagicNumber = 333" in content
 
 
+def test_generate_transformer(tmp_path: Path):
+    model = {
+        "model_id": "trans",
+        "magic": 444,
+        "feature_names": ["hour", "spread"],
+        "sequence_length": 2,
+        "transformer_weights": [
+            [[[0.1, 0.2]], [[0.3, 0.4]]],
+            [[0.0, 0.0]],
+            [[[0.5, 0.6]], [[0.7, 0.8]]],
+            [[0.0, 0.0]],
+            [[[0.9, 1.0]], [[1.1, 1.2]]],
+            [[0.0, 0.0]],
+            [[[1.3, 1.4]], [[1.5, 1.6]]],
+            [0.0, 0.1],
+            [[1.7], [1.8]],
+            [0.2],
+        ],
+    }
+    model_file = tmp_path / "model.json"
+    with open(model_file, "w") as f:
+        json.dump(model, f)
+
+    out_dir = tmp_path / "out"
+    generate(model_file, out_dir)
+
+    generated = list(out_dir.glob("Generated_trans_*.mq4"))
+    assert len(generated) == 1
+    with open(generated[0]) as f:
+        content = f.read()
+    assert "TransformerDenseWeights" in content
+    assert "MagicNumber = 444" in content
+
+
 def test_generate_hourly_thresholds(tmp_path: Path):
     model = {
         "model_id": "hour", 

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -322,6 +322,26 @@ def test_train_lstm(tmp_path: Path):
     assert data.get("weighted") is False
 
 
+@pytest.mark.skipif(not HAS_TF, reason="TensorFlow required")
+def test_train_transformer(tmp_path: Path):
+    data_dir = tmp_path / "logs"
+    out_dir = tmp_path / "out"
+    data_dir.mkdir()
+    log_file = data_dir / "trades_test.csv"
+    _write_log(log_file)
+
+    train(data_dir, out_dir, model_type="transformer", sequence_length=3)
+
+    model_file = out_dir / "model.json"
+    assert model_file.exists()
+    with open(model_file) as f:
+        data = json.load(f)
+    assert data.get("model_type") == "transformer"
+    assert "transformer_weights" in data
+    assert data.get("sequence_length") == 3
+    assert data.get("weighted") is False
+
+
 def test_incremental_train(tmp_path: Path):
     data_dir = tmp_path / "logs"
     out_dir = tmp_path / "out"


### PR DESCRIPTION
## Summary
- implement `--model-type transformer` in training script
- export transformer weights and sequence length
- extend code generation to include transformer parameters
- update strategy template to run transformer inference
- cover new transformer flow in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688802823818832fbc7064cccd9b9a91