### PR TITLE
Add equity/margin features

### DIFF
--- a/scripts/generate_mql4_from_model.py
+++ b/scripts/generate_mql4_from_model.py
@@ -141,6 +141,8 @@ def generate(model_json: Path, out_dir: Path):
         'lots': 'Lots',
         'sl_dist': 'GetSLDistance()',
         'tp_dist': 'GetTPDistance()',
+        'equity': 'AccountEquity()',
+        'margin_level': 'AccountMarginLevel()',
         'day_of_week': 'TimeDayOfWeek(TimeCurrent())',
         'sma': 'iMA(SymbolToTrade, 0, 5, 0, MODE_SMA, PRICE_CLOSE, 0)',
         'rsi': 'iRSI(SymbolToTrade, 0, 14, PRICE_CLOSE, 0)',

--- a/scripts/train_target_clone.py
+++ b/scripts/train_target_clone.py
@@ -352,6 +352,8 @@ def _extract_features(
 
         spread = float(r.get("spread", 0) or 0)
         slippage = float(r.get("slippage", 0) or 0)
+        account_equity = float(r.get("equity", 0) or 0)
+        margin_level = float(r.get("margin_level", 0) or 0)
 
         feat = {
             "symbol": symbol,
@@ -362,6 +364,8 @@ def _extract_features(
             "sl_dist": sl - price,
             "tp_dist": tp - price,
             "spread": spread,
+            "equity": account_equity,
+            "margin_level": margin_level,
         }
 
         if use_slippage:

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -343,3 +343,27 @@ def test_generate_scaling_arrays(tmp_path: Path):
         content = f.read()
     assert "FeatureMean[]" in content
     assert "FeatureStd[]" in content
+
+
+def test_generate_account_features(tmp_path: Path):
+    model = {
+        "model_id": "acct",
+        "magic": 101,
+        "coefficients": [0.1, 0.2],
+        "intercept": 0.0,
+        "threshold": 0.5,
+        "feature_names": ["equity", "margin_level"],
+    }
+    model_file = tmp_path / "model.json"
+    with open(model_file, "w") as f:
+        json.dump(model, f)
+
+    out_dir = tmp_path / "out"
+    generate(model_file, out_dir)
+
+    generated = list(out_dir.glob("Generated_acct_*.mq4"))
+    assert len(generated) == 1
+    with open(generated[0]) as f:
+        content = f.read()
+    assert "AccountEquity()" in content
+    assert "AccountMarginLevel()" in content

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -167,6 +167,8 @@ def test_train(tmp_path: Path):
     assert "threshold" in data
     assert "day_of_week" in data.get("feature_names", [])
     assert "spread" in data.get("feature_names", [])
+    assert "equity" in data.get("feature_names", [])
+    assert "margin_level" in data.get("feature_names", [])
     assert data.get("weighted") is True
     assert "feature_mean" in data
     assert "feature_std" in data


### PR DESCRIPTION
## Summary
- include account equity and margin level when extracting features
- update EA generator to reference AccountEquity and AccountMarginLevel
- cover new features in generate and train tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68880e772200832f8529b152e9f3ff29