### PR TITLE
Add market regime classification

### DIFF
--- a/experts/StrategyTemplate.mq4
+++ b/experts/StrategyTemplate.mq4
@@ -45,6 +45,8 @@ int FeatureHistorySize = 0;
 int EncoderWindow = __ENCODER_WINDOW__;
 int EncoderDim = __ENCODER_DIM__;
 double EncoderWeights[] = {__ENCODER_WEIGHTS__};
+int EncoderCenterCount = __ENCODER_CENTER_COUNT__;
+double EncoderCenters[] = {__ENCODER_CENTERS__};
 datetime LastModelLoad = 0;
 
 //----------------------------------------------------------------------
@@ -189,6 +191,33 @@ double GetEncodedFeature(int idx)
       val += EncoderWeights[base + i] * diff;
    }
    return(val);
+}
+
+int GetRegime()
+{
+   if(EncoderCenterCount <= 0)
+      return(0);
+   double enc[100];
+   for(int i=0; i<EncoderDim && i<100; i++)
+      enc[i] = GetEncodedFeature(i);
+   int best = 0;
+   double bestDist = 0.0;
+   for(int c=0; c<EncoderCenterCount; c++)
+   {
+      double d = 0.0;
+      int base = c * EncoderDim;
+      for(int j=0; j<EncoderDim; j++)
+      {
+         double diff = enc[j] - EncoderCenters[base + j];
+         d += diff * diff;
+      }
+      if(c == 0 || d < bestDist)
+      {
+         bestDist = d;
+         best = c;
+      }
+   }
+   return(best);
 }
 
 double GetFeature(int index)

--- a/scripts/generate_mql4_from_model.py
+++ b/scripts/generate_mql4_from_model.py
@@ -125,6 +125,11 @@ def generate(model_json: Path, out_dir: Path):
     output = output.replace('__ENCODER_WINDOW__', str(enc_window))
     output = output.replace('__ENCODER_DIM__', str(enc_dim))
 
+    centers = model.get('encoder_centers', [])
+    center_flat = ', '.join(_fmt(v) for row in centers for v in row)
+    output = output.replace('__ENCODER_CENTERS__', center_flat)
+    output = output.replace('__ENCODER_CENTER_COUNT__', str(len(centers)))
+
     feature_mean = model.get('feature_mean', [])
     mean_str = ', '.join(_fmt(v) for v in feature_mean)
     output = output.replace('__FEATURE_MEAN__', mean_str)
@@ -156,6 +161,7 @@ def generate(model_json: Path, out_dir: Path):
         'stochastic_k': 'iStochastic(SymbolToTrade, 0, 14, 3, 3, MODE_SMA, 0, MODE_MAIN, 0)',
         'stochastic_d': 'iStochastic(SymbolToTrade, 0, 14, 3, 3, MODE_SMA, 0, MODE_SIGNAL, 0)',
         'adx': 'iADX(SymbolToTrade, 0, 14, PRICE_CLOSE, MODE_MAIN, 0)',
+        'regime': 'GetRegime()',
     }
 
     cases = []

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -367,3 +367,30 @@ def test_generate_account_features(tmp_path: Path):
         content = f.read()
     assert "AccountEquity()" in content
     assert "AccountMarginLevel()" in content
+
+
+def test_generate_regime_feature(tmp_path: Path):
+    model = {
+        "model_id": "regime",
+        "magic": 202,
+        "coefficients": [0.1],
+        "intercept": 0.0,
+        "threshold": 0.5,
+        "feature_names": ["regime"],
+        "encoder_weights": [[1.0]],
+        "encoder_window": 1,
+        "encoder_centers": [[0.0], [1.0]],
+    }
+    model_file = tmp_path / "model.json"
+    with open(model_file, "w") as f:
+        json.dump(model, f)
+
+    out_dir = tmp_path / "out"
+    generate(model_file, out_dir)
+
+    generated = list(out_dir.glob("Generated_regime_*.mq4"))
+    assert len(generated) == 1
+    with open(generated[0]) as f:
+        content = f.read()
+    assert "EncoderCenters" in content
+    assert "GetRegime()" in content

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -409,3 +409,24 @@ def test_slippage_feature(tmp_path: Path):
         data = json.load(f)
     feats = data.get("feature_names", [])
     assert "slippage" in feats
+
+
+def test_encoder_regime(tmp_path: Path):
+    data_dir = tmp_path / "logs"
+    out_dir = tmp_path / "out"
+    data_dir.mkdir()
+    log_file = data_dir / "trades_reg.csv"
+    _write_log(log_file)
+
+    enc = {"window": 1, "weights": [[1.0]], "centers": [[0.0], [1.0]]}
+    enc_file = tmp_path / "enc.json"
+    with open(enc_file, "w") as f:
+        json.dump(enc, f)
+
+    train(data_dir, out_dir, encoder_file=enc_file)
+
+    with open(out_dir / "model.json") as f:
+        data = json.load(f)
+    feats = data.get("feature_names", [])
+    assert "regime" in feats
+    assert "encoder_centers" in data


### PR DESCRIPTION
## Summary
- cluster encoded tick sequences with KMeans during autoencoder pretraining
- store encoder centers and compute regime IDs when extracting features
- include regime calculation in MQL generator and template
- test regime support in training and MQ4 generation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68883e95d2bc832f874543cb349e4ffa