### PR TITLE
Add higher timeframe indicator support

### DIFF
--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -319,6 +319,29 @@ def test_generate_rl_fused(tmp_path: Path):
     assert "ModelCoefficients" in content
 
 
+def test_generate_higher_tf(tmp_path: Path):
+    model = {
+        "model_id": "hft",
+        "magic": 1111,
+        "coefficients": [0.1, 0.2, 0.3, 0.4],
+        "intercept": 0.0,
+        "threshold": 0.5,
+        "feature_names": ["sma_H1", "rsi_H1", "macd_H1", "macd_signal_H1"],
+    }
+    model_file = tmp_path / "model.json"
+    with open(model_file, "w") as f:
+        json.dump(model, f)
+
+    out_dir = tmp_path / "out"
+    generate(model_file, out_dir)
+
+    generated = list(out_dir.glob("Generated_hft_*.mq4"))
+    assert len(generated) == 1
+    with open(generated[0]) as f:
+        content = f.read()
+    assert "PERIOD_H1" in content
+
+
 def test_generate_scaling_arrays(tmp_path: Path):
     model = {
         "model_id": "scale",

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -430,3 +430,28 @@ def test_encoder_regime(tmp_path: Path):
     feats = data.get("feature_names", [])
     assert "regime" in feats
     assert "encoder_centers" in data
+
+
+def test_higher_timeframe_features(tmp_path: Path):
+    data_dir = tmp_path / "logs"
+    out_dir = tmp_path / "out"
+    data_dir.mkdir()
+    log_file = data_dir / "trades_many.csv"
+    _write_log_many(log_file, count=6)
+
+    train(
+        data_dir,
+        out_dir,
+        use_sma=True,
+        use_rsi=True,
+        use_macd=True,
+        use_higher_timeframe=True,
+        higher_timeframe="H1",
+    )
+
+    with open(out_dir / "model.json") as f:
+        data = json.load(f)
+    feats = data.get("feature_names", [])
+    assert "sma_H1" in feats
+    assert "rsi_H1" in feats
+    assert "macd_H1" in feats


### PR DESCRIPTION
## Summary
- support SMA/RSI/MACD from a higher timeframe in `train_target_clone.py`
- export higher timeframe feature names in generated MQL4 strategies
- handle timeframe-specific indicators in MQL4 generator
- test training with higher timeframe features
- test generator output for higher timeframe indicators

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888408af378832f9aecf46a922ff8dc