### PR TITLE
Add sine/cosine time features

### DIFF
--- a/scripts/generate_mql4_from_model.py
+++ b/scripts/generate_mql4_from_model.py
@@ -142,6 +142,10 @@ def generate(model_json: Path, out_dir: Path):
 
     feature_map = {
         'hour': 'TimeHour(TimeCurrent())',
+        'hour_sin': 'MathSin(2*M_PI*TimeHour(TimeCurrent())/24)',
+        'hour_cos': 'MathCos(2*M_PI*TimeHour(TimeCurrent())/24)',
+        'dow_sin': 'MathSin(2*M_PI*TimeDayOfWeek(TimeCurrent())/7)',
+        'dow_cos': 'MathCos(2*M_PI*TimeDayOfWeek(TimeCurrent())/7)',
         'spread': 'MarketInfo(SymbolToTrade, MODE_SPREAD)',
         'lots': 'Lots',
         'sl_dist': 'GetSLDistance()',

--- a/scripts/train_target_clone.py
+++ b/scripts/train_target_clone.py
@@ -10,6 +10,7 @@ by other helper scripts.
 import argparse
 import json
 from datetime import datetime
+import math
 from pathlib import Path
 from typing import List, Optional
 import sqlite3
@@ -392,10 +393,19 @@ def _extract_features(
         account_equity = float(r.get("equity", 0) or 0)
         margin_level = float(r.get("margin_level", 0) or 0)
 
+        hour_sin = math.sin(2 * math.pi * t.hour / 24)
+        hour_cos = math.cos(2 * math.pi * t.hour / 24)
+        dow_sin = math.sin(2 * math.pi * t.weekday() / 7)
+        dow_cos = math.cos(2 * math.pi * t.weekday() / 7)
+
         feat = {
             "symbol": symbol,
             "hour": t.hour,
             "day_of_week": t.weekday(),
+            "hour_sin": hour_sin,
+            "hour_cos": hour_cos,
+            "dow_sin": dow_sin,
+            "dow_cos": dow_cos,
             "lots": lots,
             "profit": profit,
             "sl_dist": sl - price,

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -81,6 +81,30 @@ def test_day_of_week_feature(tmp_path: Path):
     assert "TimeDayOfWeek(TimeCurrent())" in content
 
 
+def test_sin_cos_features(tmp_path: Path):
+    model = {
+        "model_id": "sc",
+        "magic": 777,
+        "coefficients": [0.1] * 4,
+        "intercept": 0.0,
+        "threshold": 0.5,
+        "feature_names": ["hour_sin", "hour_cos", "dow_sin", "dow_cos"],
+    }
+    model_file = tmp_path / "model.json"
+    with open(model_file, "w") as f:
+        json.dump(model, f)
+
+    out_dir = tmp_path / "out"
+    generate(model_file, out_dir)
+
+    generated = list(out_dir.glob("Generated_sc_*.mq4"))
+    assert len(generated) == 1
+    with open(generated[0]) as f:
+        content = f.read()
+    assert "MathSin(2*M_PI*TimeHour(TimeCurrent())/24)" in content
+    assert "MathCos(2*M_PI*TimeDayOfWeek(TimeCurrent())/7)" in content
+
+
 def test_volatility_feature(tmp_path: Path):
     model = {
         "model_id": "vol",

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -166,6 +166,10 @@ def test_train(tmp_path: Path):
     assert "coefficients" in data
     assert "threshold" in data
     assert "day_of_week" in data.get("feature_names", [])
+    assert "hour_sin" in data.get("feature_names", [])
+    assert "hour_cos" in data.get("feature_names", [])
+    assert "dow_sin" in data.get("feature_names", [])
+    assert "dow_cos" in data.get("feature_names", [])
     assert "spread" in data.get("feature_names", [])
     assert "equity" in data.get("feature_names", [])
     assert "margin_level" in data.get("feature_names", [])


### PR DESCRIPTION
## Summary
- compute sine/cosine features for hour and day-of-week in training
- export same calculations in generated strategies
- test that model and MQ4 output include the new features

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888484c1110832f9fa899c41e2115ca