### PR TITLE
Add volume tracking to logs and features

### DIFF
--- a/experts/Observer_TBot.mq4
+++ b/experts/Observer_TBot.mq4
@@ -101,7 +101,7 @@ int OnInit()
          FileSeek(trade_log_handle, 0, SEEK_END);
          if(need_header)
          {
-           string header = "event_id;event_time;broker_time;local_time;action;ticket;magic;source;symbol;order_type;lots;price;sl;tp;profit;spread;comment;remaining_lots;slippage";
+          string header = "event_id;event_time;broker_time;local_time;action;ticket;magic;source;symbol;order_type;lots;price;sl;tp;profit;spread;comment;remaining_lots;slippage;volume";
             int _wr = FileWrite(trade_log_handle, header);
             if(_wr <= 0)
                FileWriteErrors++;
@@ -249,7 +249,7 @@ void OnTradeTransaction(const MqlTradeTransaction &trans,
    {
       LogTrade("OPEN", ticket, magic, "mt4", symbol, order_type,
                lots, price, sl, tp, 0.0, MarketInfo(symbol, MODE_SPREAD),
-               remaining, now, comment, slippage);
+               remaining, now, comment, slippage, iVolume(symbol, 0, 0));
       if(!IsTracked(ticket))
          AddTicket(ticket);
       else if(entry==DEAL_ENTRY_INOUT && remaining>0.0 && OrderSelect(ticket, SELECT_BY_TICKET, MODE_TRADES))
@@ -259,14 +259,15 @@ void OnTradeTransaction(const MqlTradeTransaction &trans,
          double cur_tp    = OrderTakeProfit();
          LogTrade("MODIFY", ticket, magic, "mt4", symbol, order_type,
                   0.0, cur_price, cur_sl, cur_tp, 0.0,
-                  MarketInfo(symbol, MODE_SPREAD), remaining, now, comment, 0.0);
+                  MarketInfo(symbol, MODE_SPREAD), remaining, now, comment, 0.0,
+                  iVolume(symbol, 0, 0));
       }
    }
    else if(entry==DEAL_ENTRY_OUT || entry==DEAL_ENTRY_OUT_BY)
    {
       LogTrade("CLOSE", ticket, magic, "mt4", symbol, order_type,
                lots, price, sl, tp, profit, MarketInfo(symbol, MODE_SPREAD),
-               remaining, now, comment, slippage);
+               remaining, now, comment, slippage, iVolume(symbol, 0, 0));
       if(IsTracked(ticket) && remaining==0.0)
          RemoveTicket(ticket);
       else if(remaining>0.0 && OrderSelect(ticket, SELECT_BY_TICKET, MODE_TRADES))
@@ -276,7 +277,8 @@ void OnTradeTransaction(const MqlTradeTransaction &trans,
          double cur_tp    = OrderTakeProfit();
          LogTrade("MODIFY", ticket, magic, "mt4", symbol, order_type,
                   0.0, cur_price, cur_sl, cur_tp, 0.0,
-                  MarketInfo(symbol, MODE_SPREAD), remaining, now, comment, 0.0);
+                  MarketInfo(symbol, MODE_SPREAD), remaining, now, comment, 0.0,
+                  iVolume(symbol, 0, 0));
       }
    }
 }
@@ -305,7 +307,8 @@ void OnTick()
          LogTrade("OPEN", ticket, OrderMagicNumber(), "mt4", OrderSymbol(), OrderType(),
                   OrderLots(), OrderOpenPrice(), OrderStopLoss(), OrderTakeProfit(),
                   0.0, MarketInfo(OrderSymbol(), MODE_SPREAD),
-                  OrderLots(), now, OrderComment(), 0.0);
+                  OrderLots(), now, OrderComment(), 0.0,
+                  iVolume(OrderSymbol(), 0, 0));
          AddTicket(ticket);
       }
    }
@@ -324,7 +327,8 @@ void OnTick()
                        OrderType(), OrderLots(), OrderClosePrice(), OrderStopLoss(),
                        OrderTakeProfit(), OrderProfit()+OrderSwap()+OrderCommission(),
                        MarketInfo(OrderSymbol(), MODE_SPREAD),
-                       0.0, now, OrderComment(), 0.0);
+                       0.0, now, OrderComment(), 0.0,
+                       iVolume(OrderSymbol(), 0, 0));
          }
          RemoveTicket(ticket);
          t--; // adjust index after removal
@@ -385,15 +389,15 @@ void LogTrade(string action, int ticket, int magic, string source,
               string symbol, int order_type, double lots, double price,
               double sl, double tp, double profit, double spread,
               double remaining, datetime time_event, string comment,
-              double slippage)
+              double slippage, double volume)
 {
    int id = NextEventId++;
-   string line = StringFormat("%d;%s;%s;%s;%s;%d;%d;%s;%s;%d;%.2f;%.5f;%.5f;%.5f;%.2f;%d;%s;%.2f;%.5f",
+   string line = StringFormat("%d;%s;%s;%s;%s;%d;%d;%s;%s;%d;%.2f;%.5f;%.5f;%.5f;%.2f;%d;%s;%.2f;%.5f;%d",
       id,
       TimeToString(time_event, TIME_DATE|TIME_SECONDS),
       TimeToString(TimeCurrent(), TIME_DATE|TIME_SECONDS),
       TimeToString(TimeLocal(), TIME_DATE|TIME_SECONDS),
-      action, ticket, magic, source, symbol, order_type, lots, price, sl, tp, profit, spread, comment, remaining, slippage);
+      action, ticket, magic, source, symbol, order_type, lots, price, sl, tp, profit, spread, comment, remaining, slippage, (int)volume);
 
    if(!EnableSocketLogging)
    {
@@ -417,13 +421,13 @@ void LogTrade(string action, int ticket, int magic, string source,
       }
    }
 
-   string json = StringFormat("{\"event_id\":%d,\"event_time\":\"%s\",\"broker_time\":\"%s\",\"local_time\":\"%s\",\"action\":\"%s\",\"ticket\":%d,\"magic\":%d,\"source\":\"%s\",\"symbol\":\"%s\",\"order_type\":%d,\"lots\":%.2f,\"price\":%.5f,\"sl\":%.5f,\"tp\":%.5f,\"profit\":%.2f,\"spread\":%d,\"comment\":\"%s\",\"remaining_lots\":%.2f,\"slippage\":%.5f}",
+   string json = StringFormat("{\"event_id\":%d,\"event_time\":\"%s\",\"broker_time\":\"%s\",\"local_time\":\"%s\",\"action\":\"%s\",\"ticket\":%d,\"magic\":%d,\"source\":\"%s\",\"symbol\":\"%s\",\"order_type\":%d,\"lots\":%.2f,\"price\":%.5f,\"sl\":%.5f,\"tp\":%.5f,\"profit\":%.2f,\"spread\":%d,\"comment\":\"%s\",\"remaining_lots\":%.2f,\"slippage\":%.5f,\"volume\":%d}",
       id,
       EscapeJson(TimeToString(time_event, TIME_DATE|TIME_SECONDS)),
       EscapeJson(TimeToString(TimeCurrent(), TIME_DATE|TIME_SECONDS)),
       EscapeJson(TimeToString(TimeLocal(), TIME_DATE|TIME_SECONDS)),
       EscapeJson(action), ticket, magic, EscapeJson(source), EscapeJson(symbol), order_type,
-      lots, price, sl, tp, profit, spread, EscapeJson(comment), remaining, slippage);
+      lots, price, sl, tp, profit, spread, EscapeJson(comment), remaining, slippage, (int)volume);
 
    if(log_socket!=INVALID_HANDLE)
    {

--- a/scripts/generate_mql4_from_model.py
+++ b/scripts/generate_mql4_from_model.py
@@ -166,6 +166,7 @@ def generate(model_json: Path, out_dir: Path):
         'stochastic_d': 'iStochastic(SymbolToTrade, 0, 14, 3, 3, MODE_SMA, 0, MODE_SIGNAL, 0)',
         'adx': 'iADX(SymbolToTrade, 0, 14, PRICE_CLOSE, MODE_MAIN, 0)',
         'regime': 'GetRegime()',
+        'volume': 'iVolume(SymbolToTrade, 0, 0)',
     }
 
     tf_const = {

--- a/scripts/train_target_clone.py
+++ b/scripts/train_target_clone.py
@@ -245,6 +245,7 @@ def _load_logs(data_dir: Path) -> pd.DataFrame:
         "comment",
         "remaining_lots",
         "slippage",
+        "volume",
     ]
 
     dfs: List[pd.DataFrame] = []
@@ -306,6 +307,7 @@ def _extract_features(
     use_stochastic=False,
     use_adx=False,
     use_slippage=False,
+    use_volume=False,
     volatility=None,
     use_higher_timeframe=False,
     higher_timeframe="H1",
@@ -418,6 +420,9 @@ def _extract_features(
         if use_slippage:
             feat["slippage"] = slippage
 
+        if use_volume:
+            feat["volume"] = float(r.get("volume", 0) or 0)
+
         if volatility is not None:
             key = t.strftime("%Y-%m-%d %H")
             vol = volatility.get(key)
@@ -523,6 +528,7 @@ def train(
     use_stochastic: bool = False,
     use_adx: bool = False,
     use_slippage: bool = False,
+    use_volume: bool = False,
     volatility_series=None,
     use_higher_timeframe: bool = False,
     higher_timeframe: str = "H1",
@@ -561,6 +567,7 @@ def train(
         use_stochastic=use_stochastic,
         use_adx=use_adx,
         use_slippage=use_slippage,
+        use_volume=use_volume,
         volatility=volatility_series,
         use_higher_timeframe=use_higher_timeframe,
         higher_timeframe=higher_timeframe,

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -441,3 +441,26 @@ def test_generate_regime_feature(tmp_path: Path):
         content = f.read()
     assert "EncoderCenters" in content
     assert "GetRegime()" in content
+
+
+def test_generate_volume_feature(tmp_path: Path):
+    model = {
+        "model_id": "volfeat",
+        "magic": 303,
+        "coefficients": [0.1],
+        "intercept": 0.0,
+        "threshold": 0.5,
+        "feature_names": ["volume"],
+    }
+    model_file = tmp_path / "model.json"
+    with open(model_file, "w") as f:
+        json.dump(model, f)
+
+    out_dir = tmp_path / "out"
+    generate(model_file, out_dir)
+
+    generated = list(out_dir.glob("Generated_volfeat_*.mq4"))
+    assert len(generated) == 1
+    with open(generated[0]) as f:
+        content = f.read()
+    assert "iVolume(SymbolToTrade, 0, 0)" in content

--- a/tests/test_sqlite_service.py
+++ b/tests/test_sqlite_service.py
@@ -43,6 +43,7 @@ def test_sqlite_log_service(tmp_path: Path):
         "comment": "hi",
         "remaining_lots": 0.1,
         "slippage": 0.0,
+        "volume": 123,
     }
 
     client = socket.socket()
@@ -65,10 +66,10 @@ def test_load_logs_from_db(tmp_path: Path):
     db_file = tmp_path / "logs.db"
     conn = sqlite3.connect(db_file)
     conn.execute(
-        "CREATE TABLE logs (event_id TEXT, event_time TEXT, broker_time TEXT, local_time TEXT, action TEXT, ticket TEXT, magic TEXT, source TEXT, symbol TEXT, order_type TEXT, lots TEXT, price TEXT, sl TEXT, tp TEXT, profit TEXT, comment TEXT, remaining_lots TEXT, slippage TEXT)"
+        "CREATE TABLE logs (event_id TEXT, event_time TEXT, broker_time TEXT, local_time TEXT, action TEXT, ticket TEXT, magic TEXT, source TEXT, symbol TEXT, order_type TEXT, lots TEXT, price TEXT, sl TEXT, tp TEXT, profit TEXT, comment TEXT, remaining_lots TEXT, slippage TEXT, volume TEXT)"
     )
     conn.execute(
-        "INSERT INTO logs VALUES (1, '2024.01.01 00:00:00', '', '', 'OPEN', '1', '', '', 'EURUSD', '0', '0.1', '1.1000', '1.0950', '1.1100', '0', '', '0.1', '0.0')"
+        "INSERT INTO logs VALUES (1, '2024.01.01 00:00:00', '', '', 'OPEN', '1', '', '', 'EURUSD', '0', '0.1', '1.1000', '1.0950', '1.1100', '0', '', '0.1', '0.0', '123')"
     )
     conn.commit()
     conn.close()
@@ -77,4 +78,5 @@ def test_load_logs_from_db(tmp_path: Path):
     assert not df.empty
     assert "symbol" in df.columns
     assert "slippage" in df.columns
+    assert int(df["volume"].iloc[0]) == 123
 

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -33,6 +33,7 @@ def _write_log(file: Path):
         "comment",
         "remaining_lots",
         "slippage",
+        "volume",
     ]
     rows = [
         [
@@ -55,6 +56,7 @@ def _write_log(file: Path):
             "",
             "0.1",
             "0.0001",
+            "100",
         ],
         [
             "2",
@@ -76,6 +78,7 @@ def _write_log(file: Path):
             "",
             "0.1",
             "0.0002",
+            "200",
         ],
     ]
     with open(file, "w", newline="") as f:
@@ -105,6 +108,7 @@ def _write_log_many(file: Path, count: int = 10):
         "comment",
         "remaining_lots",
         "slippage",
+        "volume",
     ]
     rows = []
     for i in range(count):
@@ -130,6 +134,7 @@ def _write_log_many(file: Path, count: int = 10):
             "",
             "0.1",
             "0.0001",
+            str(100 + i),
         ])
     with open(file, "w", newline="") as f:
         writer = csv.writer(f, delimiter=";")
@@ -413,6 +418,25 @@ def test_slippage_feature(tmp_path: Path):
         data = json.load(f)
     feats = data.get("feature_names", [])
     assert "slippage" in feats
+
+
+def test_volume_feature(tmp_path: Path):
+    data_dir = tmp_path / "logs"
+    out_dir = tmp_path / "out"
+    data_dir.mkdir()
+    log_file = data_dir / "trades_vol.csv"
+    _write_log(log_file)
+
+    df = _load_logs(data_dir)
+    assert "volume" in df.columns
+    assert int(df["volume"].iloc[0]) == 100
+
+    train(data_dir, out_dir, use_volume=True)
+
+    with open(out_dir / "model.json") as f:
+        data = json.load(f)
+    feats = data.get("feature_names", [])
+    assert "volume" in feats
 
 
 def test_encoder_regime(tmp_path: Path):


### PR DESCRIPTION
## Summary
- record tick volume in Observer_TBot trade logs
- extend `LogTrade` to handle volume
- parse volume field when loading logs and allow feature extraction
- map volume feature to `iVolume` in MQL generator
- test new volume functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68884a814094832fa93a174d03229e5f