### PR TITLE
Add LightGBM model option

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,12 +159,13 @@ python scripts/analyze_ticks.py observer_logs/ticks_EURUSD.csv
 ## Running Tests
 
 Install the Python requirements and run `pytest` from the repository root. At a
-minimum `numpy`, `scikit-learn` and `pytest` are needed.  The `xgboost` package
-is optional if you want to train XGBoost models.  `stable-baselines3` can be
+minimum `numpy`, `scikit-learn` and `pytest` are needed.  The `xgboost` and
+`lightgbm` packages are optional if you want to train XGBoost or LightGBM models.
+`stable-baselines3` can be
 installed to experiment with PPO or DQN agents:
 
 ```bash
-pip install numpy scikit-learn pytest xgboost stable-baselines3 shap
+pip install numpy scikit-learn pytest xgboost lightgbm stable-baselines3 shap
 pytest
 ```
 

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -294,6 +294,26 @@ def test_train_xgboost(tmp_path: Path):
     assert data.get("weighted") is False
 
 
+def test_train_lightgbm(tmp_path: Path):
+    pytest.importorskip("lightgbm")
+    data_dir = tmp_path / "logs"
+    out_dir = tmp_path / "out"
+    data_dir.mkdir()
+    log_file = data_dir / "trades_test.csv"
+    _write_log(log_file)
+
+    train(data_dir, out_dir, model_type="lgbm", n_estimators=10)
+
+    model_file = out_dir / "model.json"
+    assert model_file.exists()
+    with open(model_file) as f:
+        data = json.load(f)
+    assert data.get("model_type") == "lgbm"
+    assert "coefficients" in data
+    assert len(data.get("probability_table", [])) == 24
+    assert data.get("weighted") is False
+
+
 def test_train_nn(tmp_path: Path):
     data_dir = tmp_path / "logs"
     out_dir = tmp_path / "out"


### PR DESCRIPTION
## Summary
- import `LGBMClassifier`
- allow `lgbm` as a model type
- train and export LightGBM models
- document optional LightGBM dependency
- add regression test for LightGBM

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889549f2b9c832fb965554a71b72e53