### PR TITLE
Add SL/TP regression outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ python train_target_clone.py --data-dir "C:\\path\\to\\observer_logs" --out-dir 
 python generate_mql4_from_model.py models/model.json experts
 ```
 
+Pass ``--regress-sl-tp`` to also fit linear models predicting stop loss and take
+profit distances. The coefficients are saved in ``model.json`` and generated
+strategies will automatically place orders with these predicted values.
+
 Hyperparameters can be optimised automatically when `optuna` is installed:
 
 ```bash

--- a/scripts/generate_mql4_from_model.py
+++ b/scripts/generate_mql4_from_model.py
@@ -46,6 +46,16 @@ def generate(model_json: Path, out_dir: Path):
     thr_str = ', '.join(_fmt(t) for t in hourly_thr)
     output = output.replace('__HOURLY_THRESHOLDS__', thr_str)
 
+    sl_coeff = model.get('sl_coefficients', [])
+    sl_str = ', '.join(_fmt(c) for c in sl_coeff)
+    output = output.replace('__SL_COEFFICIENTS__', sl_str)
+    output = output.replace('__SL_INTERCEPT__', _fmt(model.get('sl_intercept', 0.0)))
+
+    tp_coeff = model.get('tp_coefficients', [])
+    tp_str = ', '.join(_fmt(c) for c in tp_coeff)
+    output = output.replace('__TP_COEFFICIENTS__', tp_str)
+    output = output.replace('__TP_INTERCEPT__', _fmt(model.get('tp_intercept', 0.0)))
+
     nn_weights = model.get('nn_weights', [])
     if nn_weights:
         l1_w = ', '.join(_fmt(v) for row in nn_weights[0] for v in row)

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -58,6 +58,35 @@ def test_sl_tp_features(tmp_path: Path):
     assert "GetTPDistance()" in content
 
 
+def test_generate_sl_tp_coeffs(tmp_path: Path):
+    model = {
+        "model_id": "slcoeff",
+        "magic": 999,
+        "coefficients": [0.1],
+        "intercept": 0.0,
+        "threshold": 0.5,
+        "feature_names": ["hour"],
+        "sl_coefficients": [0.2],
+        "sl_intercept": 0.01,
+        "tp_coefficients": [0.3],
+        "tp_intercept": 0.02,
+    }
+    model_file = tmp_path / "model.json"
+    with open(model_file, "w") as f:
+        json.dump(model, f)
+
+    out_dir = tmp_path / "out"
+    generate(model_file, out_dir)
+
+    generated = list(out_dir.glob("Generated_slcoeff_*.mq4"))
+    assert len(generated) == 1
+    with open(generated[0]) as f:
+        content = f.read()
+    assert "SLModelCoefficients" in content
+    assert "TPModelCoefficients" in content
+    assert "GetNewSL(" in content
+
+
 def test_day_of_week_feature(tmp_path: Path):
     model = {
         "model_id": "dow",

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -503,3 +503,18 @@ def test_higher_timeframe_features(tmp_path: Path):
     assert "sma_H1" in feats
     assert "rsi_H1" in feats
     assert "macd_H1" in feats
+
+
+def test_train_regress_sl_tp(tmp_path: Path):
+    data_dir = tmp_path / "logs"
+    out_dir = tmp_path / "out"
+    data_dir.mkdir()
+    log_file = data_dir / "trades_reg_sl.csv"
+    _write_log(log_file)
+
+    train(data_dir, out_dir, regress_sl_tp=True)
+
+    with open(out_dir / "model.json") as f:
+        data = json.load(f)
+    assert "sl_coefficients" in data
+    assert "tp_coefficients" in data


### PR DESCRIPTION
## Summary
- extend training pipeline to optionally fit SL/TP distance regressors
- embed regressor coefficients when generating MQL4 strategies
- expose helper functions in StrategyTemplate for predicted SL/TP
- document new `--regress-sl-tp` flag
- test exported coefficients

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688979bd3d04832fa17f9d39cca3b685