### PR TITLE
Implement indicator caching in MQL template

### DIFF
--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -393,6 +393,7 @@ def test_generate_higher_tf(tmp_path: Path):
     with open(generated[0]) as f:
         content = f.read()
     assert "PERIOD_H1" in content
+    assert "CachedSMA" in content
 
 
 def test_generate_scaling_arrays(tmp_path: Path):


### PR DESCRIPTION
## Summary
- cache indicator values on each timeframe used by features
- refresh caches when a new bar forms or the chart timeframe changes
- generate feature code that references cached values
- update higher timeframe generation test

## Testing
- `pytest -k generate -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68897f24876c832fa1ca1b9ddd48d18b