### PR TITLE
Implement open order management

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ The EA records trade openings and closings using the `OnTradeTransaction` callba
   - `Observer_TBot.mq4` – main observer EA.
   - `StrategyTemplate.mq4` – template used for generated strategies.
     Trade volume is automatically scaled between `MinLots` and `MaxLots`
-    based on the model probability.
+    based on the model probability. Stop management can move the
+    stop loss to break-even after `BreakEvenPips` profit and optionally
+    trail by `TrailingPips`.
   - `model_interface.mqh` – shared structures.
 - `scripts/` – helper Python scripts.
   - `train_target_clone.py` – trains a model from exported logs.

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -494,3 +494,26 @@ def test_generate_volume_feature(tmp_path: Path):
     with open(generated[0]) as f:
         content = f.read()
     assert "iVolume(SymbolToTrade, 0, 0)" in content
+
+
+def test_manage_open_orders_included(tmp_path: Path):
+    model = {
+        "model_id": "manage",
+        "magic": 111,
+        "coefficients": [0.1],
+        "intercept": 0.0,
+        "threshold": 0.5,
+        "feature_names": ["hour"],
+    }
+    model_file = tmp_path / "model.json"
+    with open(model_file, "w") as f:
+        json.dump(model, f)
+
+    out_dir = tmp_path / "out"
+    generate(model_file, out_dir)
+
+    generated = list(out_dir.glob("Generated_manage_*.mq4"))
+    assert len(generated) == 1
+    with open(generated[0]) as f:
+        content = f.read()
+    assert "ManageOpenOrders()" in content


### PR DESCRIPTION
## Summary
- manage open orders in StrategyTemplate via new `ManageOpenOrders()`
- expose `BreakEvenPips` and `TrailingPips` inputs
- document the stop management parameters
- test generated EA includes call to `ManageOpenOrders`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688982965044832f9b36b328a1a9104e