### PR TITLE
Add automatic retraining helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,19 @@ one to the terminal's ``Files`` directory. An example cron entry running every
 Set ``ReloadModelInterval`` on the EA so it automatically reloads the published
 model when ``model.json`` changes.
 
+## Automatic Retraining
+
+The ``auto_retrain.py`` helper watches the most recent entries in
+``metrics.csv`` and triggers a new training run when the rolling win rate drops
+below a chosen threshold. After training completes the updated model is
+published to the terminal's ``Files`` directory.
+
+An example cron job running every 15 minutes:
+
+```cron
+*/15 * * * * /path/to/BotCopier/scripts/auto_retrain.py --log-dir /path/to/observer_logs --out-dir /path/to/BotCopier/models --files-dir /path/to/MT4/MQL4/Files --win-rate-threshold 0.4
+```
+
 ## Metrics Tracking
 
 During operation the EA records a summary line for each tracked model in

--- a/scripts/auto_retrain.py
+++ b/scripts/auto_retrain.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Automatically retrain when metrics fall below thresholds."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import sys
+from pathlib import Path
+from typing import Optional, Dict
+
+from scripts.train_target_clone import train
+from scripts.publish_model import publish
+
+
+def _load_latest_row(metrics_file: Path) -> Optional[Dict[str, str]]:
+    if not metrics_file.exists():
+        return None
+    last: Optional[Dict[str, str]] = None
+    with open(metrics_file, newline="") as f:
+        reader = csv.DictReader(f, delimiter=";")
+        for row in reader:
+            last = row
+    return last
+
+
+def retrain_if_needed(
+    log_dir: Path,
+    out_dir: Path,
+    files_dir: Path,
+    *,
+    metrics_file: Optional[Path] = None,
+    win_rate_threshold: float = 0.4,
+    incremental: bool = True,
+) -> bool:
+    metrics_path = metrics_file or (log_dir / "metrics.csv")
+    row = _load_latest_row(metrics_path)
+    if not row:
+        return False
+    try:
+        win_rate = float(row.get("win_rate", 0) or 0)
+    except Exception:
+        return False
+    if win_rate >= win_rate_threshold:
+        return False
+
+    train(log_dir, out_dir, incremental=incremental)
+    model_file = out_dir / "model.json"
+    publish(model_file, files_dir)
+    return True
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description="Retrain model when metrics degrade")
+    p.add_argument("--log-dir", required=True, help="directory with observer logs")
+    p.add_argument("--out-dir", required=True, help="output model directory")
+    p.add_argument("--files-dir", required=True, help="MT4 Files directory")
+    p.add_argument("--metrics-file", help="path to metrics.csv")
+    p.add_argument(
+        "--win-rate-threshold",
+        type=float,
+        default=0.4,
+        help="trigger retraining when win rate is below this value",
+    )
+    p.add_argument(
+        "--no-incremental",
+        action="store_true",
+        help="do not update an existing model incrementally",
+    )
+    args = p.parse_args()
+
+    retrain_if_needed(
+        Path(args.log_dir),
+        Path(args.out_dir),
+        Path(args.files_dir),
+        metrics_file=Path(args.metrics_file) if args.metrics_file else None,
+        win_rate_threshold=args.win_rate_threshold,
+        incremental=not args.no_incremental,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_auto_retrain.py
+++ b/tests/test_auto_retrain.py
@@ -1,0 +1,69 @@
+import csv
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from scripts.auto_retrain import retrain_if_needed
+
+
+def _write_metrics(file: Path, win_rate: float) -> None:
+    with open(file, "w", newline="") as f:
+        writer = csv.writer(f, delimiter=";")
+        writer.writerow(["time", "magic", "win_rate", "avg_profit", "trade_count"])
+        writer.writerow(["2024.01.01 00:00", "0", str(win_rate), "1.0", "10"])
+
+
+def test_retrain_trigger(monkeypatch, tmp_path: Path):
+    log_dir = tmp_path / "logs"
+    out_dir = tmp_path / "out"
+    files_dir = tmp_path / "files"
+    log_dir.mkdir()
+    out_dir.mkdir()
+    files_dir.mkdir()
+    metrics_file = log_dir / "metrics.csv"
+    _write_metrics(metrics_file, 0.3)
+
+    called = {}
+
+    def fake_train(ld, od, incremental=True):
+        called["train"] = (ld, od, incremental)
+
+    def fake_publish(mf, fd):
+        called["publish"] = (mf, fd)
+
+    monkeypatch.setattr("scripts.auto_retrain.train", fake_train)
+    monkeypatch.setattr("scripts.auto_retrain.publish", fake_publish)
+
+    result = retrain_if_needed(log_dir, out_dir, files_dir, win_rate_threshold=0.4)
+
+    assert result is True
+    assert called.get("train") == (log_dir, out_dir, True)
+    assert called.get("publish") == (out_dir / "model.json", files_dir)
+
+
+def test_retrain_not_triggered(monkeypatch, tmp_path: Path):
+    log_dir = tmp_path / "logs"
+    out_dir = tmp_path / "out"
+    files_dir = tmp_path / "files"
+    log_dir.mkdir()
+    out_dir.mkdir()
+    files_dir.mkdir()
+    metrics_file = log_dir / "metrics.csv"
+    _write_metrics(metrics_file, 0.7)
+
+    called = {}
+
+    def fake_train(*args, **kwargs):
+        called["train"] = True
+
+    def fake_publish(*args, **kwargs):
+        called["publish"] = True
+
+    monkeypatch.setattr("scripts.auto_retrain.train", fake_train)
+    monkeypatch.setattr("scripts.auto_retrain.publish", fake_publish)
+
+    result = retrain_if_needed(log_dir, out_dir, files_dir, win_rate_threshold=0.4)
+
+    assert result is False
+    assert "train" not in called
+    assert "publish" not in called


### PR DESCRIPTION
## Summary
- create `scripts/auto_retrain.py` for automated training based on metrics
- document how to schedule the script in `README`
- add unit tests for the new helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688986a7c258832fa3774f9a1c7d8e39