### PR TITLE
Add additional SB3 algorithms

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,9 @@ Install the Python requirements and run `pytest` from the repository root. At a
 minimum `numpy`, `scikit-learn` and `pytest` are needed.  The `xgboost` and
 `lightgbm` packages are optional if you want to train XGBoost or LightGBM models.
 `stable-baselines3` can be
-installed to experiment with PPO or DQN agents:
+installed to experiment with PPO, DQN, A2C or DDPG agents. Continuous-action
+methods like DDPG require an environment using a `Box` action space – the
+included discrete environment must be adapted for such algorithms:
 
 ```bash
 pip install numpy scikit-learn pytest xgboost lightgbm stable-baselines3 shap

--- a/scripts/train_rl_agent.py
+++ b/scripts/train_rl_agent.py
@@ -203,7 +203,12 @@ def train(
                 return obs, reward, done, False, {}
 
         env = TradeEnv(states, rewards)
-        algo_map = {"ppo": sb3.PPO, "dqn": sb3.DQN}
+        algo_map = {
+            "ppo": sb3.PPO,
+            "dqn": sb3.DQN,
+            "a2c": sb3.A2C,
+            "ddpg": sb3.DDPG,
+        }
         algo_key = algo.lower()
         if algo_key not in algo_map:
             raise ValueError(f"Unsupported algorithm: {algo}")
@@ -361,7 +366,10 @@ def main() -> None:
     p.add_argument(
         "--algo",
         default="qlearn",
-        help="RL algorithm: qlearn (default), ppo or dqn if stable-baselines3 is installed",
+        help=(
+            "RL algorithm: qlearn (default), ppo, dqn, a2c or ddpg if stable-baselines3"
+            " is installed"
+        ),
     )
     p.add_argument("--start-model", help="path to initial model coefficients")
     args = p.parse_args()

--- a/tests/test_train_rl_agent.py
+++ b/tests/test_train_rl_agent.py
@@ -169,7 +169,7 @@ def test_train_rl_agent_sb3(tmp_path: Path):
     log_file = data_dir / "trades_test.csv"
     _write_log(log_file)
 
-    train(data_dir, out_dir, algo="ppo", episodes=1)
+    train(data_dir, out_dir, algo="a2c", episodes=1)
 
     model_file = out_dir / "model.json"
     weight_file = out_dir / "model_weights.zip"
@@ -177,5 +177,5 @@ def test_train_rl_agent_sb3(tmp_path: Path):
     assert weight_file.exists()
     with open(model_file) as f:
         data = json.load(f)
-    assert data.get("algo") == "ppo"
+    assert data.get("algo") == "a2c"
     assert data.get("weights_file") == "model_weights.zip"


### PR DESCRIPTION
## Summary
- expose more stable-baselines3 algorithms
- clarify continuous-action requirements in README
- unit test now covers A2C when SB3 is present

## Testing
- `pytest tests/test_train_rl_agent.py::test_train_rl_agent_sb3 -q` *(fails: ModuleNotFoundError: No module named 'sklearn')*

------
https://chatgpt.com/codex/tasks/task_e_68898aab1854832fadda2ca91b6be20a