### PR TITLE
feat: add catboost model option

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ python train_target_clone.py --data-dir "C:\\path\\to\\observer_logs" --out-dir 
 python generate_mql4_from_model.py models/model.json experts
 ```
 
+Pass `--model-type catboost` to train a CatBoost model when the `catboost`
+package is installed.
+
 Pass ``--regress-sl-tp`` to also fit linear models predicting stop loss and take
 profit distances. The coefficients are saved in ``model.json`` and generated
 strategies will automatically place orders with these predicted values.
@@ -182,15 +185,16 @@ python scripts/analyze_ticks.py observer_logs/ticks_EURUSD.csv
 ## Running Tests
 
 Install the Python requirements and run `pytest` from the repository root. At a
-minimum `numpy`, `scikit-learn` and `pytest` are needed.  The `xgboost` and
-`lightgbm` packages are optional if you want to train XGBoost or LightGBM models.
+minimum `numpy`, `scikit-learn` and `pytest` are needed.  The `xgboost`,
+`lightgbm` and `catboost` packages are optional if you want to train XGBoost,
+LightGBM or CatBoost models.
 `stable-baselines3` can be
 installed to experiment with PPO, DQN, A2C or DDPG agents. Continuous-action
 methods like DDPG require an environment using a `Box` action space – the
 included discrete environment must be adapted for such algorithms:
 
 ```bash
-pip install numpy scikit-learn pytest xgboost lightgbm stable-baselines3 shap
+pip install numpy scikit-learn pytest xgboost lightgbm catboost stable-baselines3 shap
 pytest
 ```
 

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -314,6 +314,26 @@ def test_train_lightgbm(tmp_path: Path):
     assert data.get("weighted") is False
 
 
+def test_train_catboost(tmp_path: Path):
+    pytest.importorskip("catboost")
+    data_dir = tmp_path / "logs"
+    out_dir = tmp_path / "out"
+    data_dir.mkdir()
+    log_file = data_dir / "trades_test.csv"
+    _write_log(log_file)
+
+    train(data_dir, out_dir, model_type="catboost", n_estimators=10)
+
+    model_file = out_dir / "model.json"
+    assert model_file.exists()
+    with open(model_file) as f:
+        data = json.load(f)
+    assert data.get("model_type") == "catboost"
+    assert "coefficients" in data
+    assert len(data.get("probability_table", [])) == 24
+    assert data.get("weighted") is False
+
+
 def test_train_nn(tmp_path: Path):
     data_dir = tmp_path / "logs"
     out_dir = tmp_path / "out"


### PR DESCRIPTION
## Summary
- add optional CatBoost model training with probability export
- allow `--model-type catboost` on CLI
- document CatBoost usage and add corresponding unit test

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688ab20d7810832f8a8910a93d010c7b