### PR TITLE
Support multiple higher timeframe features

### DIFF
--- a/scripts/generate_mql4_from_model.py
+++ b/scripts/generate_mql4_from_model.py
@@ -194,22 +194,23 @@ def generate(model_json: Path, out_dir: Path):
     import re
     cases = []
     used_tfs = {'0'}
+    tf_pattern = re.compile(r'^(sma|rsi|macd|macd_signal)_([A-Za-z0-9]+)$')
+    indicator_expr = {
+        'sma': 'CachedSMA',
+        'rsi': 'CachedRSI',
+        'macd': 'CachedMACD',
+        'macd_signal': 'CachedMACDSignal',
+    }
     for idx, name in enumerate(feature_names):
         expr = feature_map.get(name)
         if expr is None:
-            m = re.match(r'^(sma|rsi|macd|macd_signal)_([A-Za-z0-9]+)$', name)
+            m = tf_pattern.match(name)
             if m:
-                ind, tf = m.group(1), m.group(2).upper()
+                ind, tf = m.groups()
+                tf = tf.upper()
                 tf_val = tf_const.get(tf, '0')
                 used_tfs.add(tf_val)
-                if ind == 'sma':
-                    expr = f'CachedSMA[TFIdx({tf_val})]'
-                elif ind == 'rsi':
-                    expr = f'CachedRSI[TFIdx({tf_val})]'
-                elif ind == 'macd':
-                    expr = f'CachedMACD[TFIdx({tf_val})]'
-                elif ind == 'macd_signal':
-                    expr = f'CachedMACDSignal[TFIdx({tf_val})]'
+                expr = f"{indicator_expr[ind]}[TFIdx({tf_val})]"
             elif name.startswith('ratio_'):
                 parts = name[6:].split('_')
                 if len(parts) == 2:

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -379,7 +379,7 @@ def test_generate_higher_tf(tmp_path: Path):
         "coefficients": [0.1, 0.2, 0.3, 0.4],
         "intercept": 0.0,
         "threshold": 0.5,
-        "feature_names": ["sma_H1", "rsi_H1", "macd_H1", "macd_signal_H1"],
+        "feature_names": ["sma_H1", "rsi_H4", "macd_H1", "macd_signal_H4"],
     }
     model_file = tmp_path / "model.json"
     with open(model_file, "w") as f:
@@ -392,8 +392,10 @@ def test_generate_higher_tf(tmp_path: Path):
     assert len(generated) == 1
     with open(generated[0]) as f:
         content = f.read()
-    assert "PERIOD_H1" in content
+    assert "TFIdx(PERIOD_H1)" in content
+    assert "TFIdx(PERIOD_H4)" in content
     assert "CachedSMA" in content
+    assert "CachedRSI" in content
 
 
 def test_generate_scaling_arrays(tmp_path: Path):

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -537,8 +537,7 @@ def test_higher_timeframe_features(tmp_path: Path):
         use_sma=True,
         use_rsi=True,
         use_macd=True,
-        use_higher_timeframe=True,
-        higher_timeframe="H1",
+        higher_timeframes=["H1"],
     )
 
     with open(out_dir / "model.json") as f:


### PR DESCRIPTION
## Summary
- allow `train_target_clone` to accept a list of `--higher-timeframes`
- cache indicators per timeframe and expose `sma_H1`, `rsi_H4`, etc.
- expand MQL4 feature mapping for timeframe-suffixed indicators
- add tests for multi-timeframe generation and training

## Testing
- `pytest tests/test_generate.py::test_generate_higher_tf -q`
- `pytest tests/test_train.py::test_higher_timeframe_features -q`


------
https://chatgpt.com/codex/tasks/task_e_688ac9d2a1b0832fbc7e30b1a1cd7cd4