### PR TITLE
Add ensemble model support

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,13 @@ python train_target_clone.py --data-dir "C:\\path\\to\\observer_logs" --out-dir 
 python generate_mql4_from_model.py models/model.json experts
 ```
 
+Multiple models can be supplied to build a simple ensemble. Feature names are
+merged and the generated EA averages the probabilities from each model:
+
+```bash
+python generate_mql4_from_model.py models/model_a.json models/model_b.json experts
+```
+
 Pass `--model-type catboost` to train a CatBoost model when the `catboost`
 package is installed.
 


### PR DESCRIPTION
## Summary
- allow `generate_mql4_from_model.py` to ingest multiple `model.json` files and merge feature sets
- update `StrategyTemplate.mq4` to store coefficients per model and average probabilities
- document ensemble generation and add regression test

## Testing
- `pytest tests/test_generate.py`

------
https://chatgpt.com/codex/tasks/task_e_688ada480d54832f872048f5008cfbf1