### PR TITLE
Use cyclical time features

### DIFF
--- a/experts/StrategyTemplate.mq4
+++ b/experts/StrategyTemplate.mq4
@@ -177,6 +177,26 @@ int OnInit()
 // Feature extraction utilities
 //----------------------------------------------------------------------
 
+double HourSin()
+{
+   return(MathSin(2.0 * 3.141592653589793 * TimeHour(TimeCurrent()) / 24.0));
+}
+
+double HourCos()
+{
+   return(MathCos(2.0 * 3.141592653589793 * TimeHour(TimeCurrent()) / 24.0));
+}
+
+double DowSin()
+{
+   return(MathSin(2.0 * 3.141592653589793 * TimeDayOfWeek(TimeCurrent()) / 7.0));
+}
+
+double DowCos()
+{
+   return(MathCos(2.0 * 3.141592653589793 * TimeDayOfWeek(TimeCurrent()) / 7.0));
+}
+
 double GetSLDistance()
 {
    for(int i = OrdersTotal() - 1; i >= 0; i--)

--- a/scripts/generate_mql4_from_model.py
+++ b/scripts/generate_mql4_from_model.py
@@ -195,18 +195,16 @@ def generate(model_jsons: Union[Path, Iterable[Path]], out_dir: Path):
     output = output.replace('__EVENT_WINDOW__', event_window)
 
     feature_map = {
-        'hour': 'TimeHour(TimeCurrent())',
-        'hour_sin': 'MathSin(2*M_PI*TimeHour(TimeCurrent())/24)',
-        'hour_cos': 'MathCos(2*M_PI*TimeHour(TimeCurrent())/24)',
-        'dow_sin': 'MathSin(2*M_PI*TimeDayOfWeek(TimeCurrent())/7)',
-        'dow_cos': 'MathCos(2*M_PI*TimeDayOfWeek(TimeCurrent())/7)',
+        'hour_sin': 'HourSin()',
+        'hour_cos': 'HourCos()',
+        'dow_sin': 'DowSin()',
+        'dow_cos': 'DowCos()',
         'spread': 'MarketInfo(SymbolToTrade, MODE_SPREAD)',
         'lots': 'Lots',
         'sl_dist': 'GetSLDistance()',
         'tp_dist': 'GetTPDistance()',
         'equity': 'AccountEquity()',
         'margin_level': 'AccountMarginLevel()',
-        'day_of_week': 'TimeDayOfWeek(TimeCurrent())',
         'sma': 'CachedSMA[TFIdx(0)]',
         'rsi': 'CachedRSI[TFIdx(0)]',
         'macd': 'CachedMACD[TFIdx(0)]',

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -121,29 +121,6 @@ def test_generate_sl_tp_coeffs(tmp_path: Path):
     assert "GetNewSL(" in content
 
 
-def test_day_of_week_feature(tmp_path: Path):
-    model = {
-        "model_id": "dow",
-        "magic": 888,
-        "coefficients": [0.1],
-        "intercept": 0.0,
-        "threshold": 0.5,
-        "feature_names": ["day_of_week"],
-    }
-    model_file = tmp_path / "model.json"
-    with open(model_file, "w") as f:
-        json.dump(model, f)
-
-    out_dir = tmp_path / "out"
-    generate(model_file, out_dir)
-
-    generated = list(out_dir.glob("Generated_dow_*.mq4"))
-    assert len(generated) == 1
-    with open(generated[0]) as f:
-        content = f.read()
-    assert "TimeDayOfWeek(TimeCurrent())" in content
-
-
 def test_sin_cos_features(tmp_path: Path):
     model = {
         "model_id": "sc",
@@ -164,8 +141,8 @@ def test_sin_cos_features(tmp_path: Path):
     assert len(generated) == 1
     with open(generated[0]) as f:
         content = f.read()
-    assert "MathSin(2*M_PI*TimeHour(TimeCurrent())/24)" in content
-    assert "MathCos(2*M_PI*TimeDayOfWeek(TimeCurrent())/7)" in content
+    assert "HourSin()" in content
+    assert "DowCos()" in content
 
 
 def test_volatility_feature(tmp_path: Path):

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -170,7 +170,8 @@ def test_train(tmp_path: Path):
         data = json.load(f)
     assert "coefficients" in data
     assert "threshold" in data
-    assert "day_of_week" in data.get("feature_names", [])
+    assert "day_of_week" not in data.get("feature_names", [])
+    assert "hour" not in data.get("feature_names", [])
     assert "hour_sin" in data.get("feature_names", [])
     assert "hour_cos" in data.get("feature_names", [])
     assert "dow_sin" in data.get("feature_names", [])


### PR DESCRIPTION
## Summary
- encode trade hour and weekday as sine/cosine features rather than raw integers
- expose new HourSin/HourCos and DowSin/DowCos helpers in StrategyTemplate.mq4
- simplify MQL4 generation to rely on the new cyclical helpers

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688c228d39ec832f82bf55629cfc973f