### PR TITLE
feat: add correlated price features

### DIFF
--- a/experts/StrategyTemplate.mq4
+++ b/experts/StrategyTemplate.mq4
@@ -322,6 +322,26 @@ void RefreshIndicatorCache()
    }
 }
 
+double PairCorrelation(string sym1, string sym2, int window=5)
+{
+   double mean1 = iMA(sym1, 0, window, 0, MODE_SMA, PRICE_CLOSE, 1);
+   double mean2 = iMA(sym2, 0, window, 0, MODE_SMA, PRICE_CLOSE, 1);
+   double num = 0.0;
+   double den1 = 0.0;
+   double den2 = 0.0;
+   for(int i=1; i<=window; i++)
+   {
+      double d1 = iClose(sym1, 0, i) - mean1;
+      double d2 = iClose(sym2, 0, i) - mean2;
+      num += d1 * d2;
+      den1 += d1 * d1;
+      den2 += d2 * d2;
+   }
+   if(den1 <= 0 || den2 <= 0)
+      return(0.0);
+   return(num / MathSqrt(den1 * den2));
+}
+
 double GetFeature(int index)
 {
    /* Return a simple set of features for the logistic model.

--- a/scripts/generate_mql4_from_model.py
+++ b/scripts/generate_mql4_from_model.py
@@ -262,10 +262,7 @@ def generate(model_jsons: Union[Path, Iterable[Path]], out_dir: Path):
             elif name.startswith('corr_'):
                 parts = name[5:].split('_')
                 if len(parts) == 2:
-                    expr = (
-                        f'iMA("{parts[0]}", 0, 5, 0, MODE_SMA, PRICE_CLOSE, 0) - '
-                        f'iMA("{parts[1]}", 0, 5, 0, MODE_SMA, PRICE_CLOSE, 0)'
-                    )
+                    expr = f'PairCorrelation("{parts[0]}", "{parts[1]}")'
             elif name.startswith('ae') and name[2:].isdigit():
                 idx_ae = int(name[2:])
                 expr = f'GetEncodedFeature({idx_ae})'


### PR DESCRIPTION
## Summary
- allow `_extract_features` to ingest synchronized price series and compute pair correlation and ratio metrics
- export `corr_` and `ratio_` features to MQL4 via a new `PairCorrelation` helper using `iClose`/`iMA`
- cover correlation features with tests including extra price series data

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688c267310cc832fb4002b1032e1f5fb