### PR TITLE
feat: add optuna hyperparameter tuning

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,12 +55,16 @@ Pass ``--regress-sl-tp`` to also fit linear models predicting stop loss and take
 profit distances. The coefficients are saved in ``model.json`` and generated
 strategies will automatically place orders with these predicted values.
 
-Hyperparameters can be optimised automatically when `optuna` is installed:
+Hyperparameters can be optimised automatically when `optuna` is installed. The
+best trial's parameters and validation score are saved to `model.json`:
 
 ```bash
 pip install optuna
 python train_target_clone.py --data-dir "C:\\path\\to\\observer_logs" --out-dir models --optuna-trials 50
 ```
+
+Optuna explores learning rate, tree depth or regularisation strength depending
+on the chosen model type.
 
 For ongoing training simply rerun the script with the ``--incremental`` flag and
 the latest log directory. The generated MQ4 file name will include the training

--- a/scripts/train_target_clone.py
+++ b/scripts/train_target_clone.py
@@ -628,6 +628,8 @@ def train(
     event_window: float = 60.0,
 ):
     """Train a simple classifier model from the log directory."""
+    if optuna_trials > 0 and not HAS_OPTUNA:
+        raise ImportError("optuna is required for hyperparameter search")
 
     cache_file = out_dir / "feature_cache.npz"
 
@@ -1136,7 +1138,7 @@ def train(
             model["encoder_centers"] = encoder.get("centers")
     if best_trial is not None:
         model["optuna_best_params"] = best_trial.params
-        model["optuna_best_score"] = best_trial.value
+        model["optuna_best_score"] = float(best_trial.value)
     if hourly_thresholds is not None:
         model["hourly_thresholds"] = hourly_thresholds
 


### PR DESCRIPTION
## Summary
- gate hyperparameter search behind `optuna` availability and raise a clear error if trials are requested without it
- persist best Optuna trial parameters and validation score into `model.json`
- document `--optuna-trials` usage and what gets recorded

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688c3c93a1dc832fa22cfb63baefa7ea