### PR TITLE
feat: retrain on sharpe

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,14 +112,14 @@ model when ``model.json`` changes.
 ## Automatic Retraining
 
 The ``auto_retrain.py`` helper watches the most recent entries in
-``metrics.csv`` and triggers a new training run when the rolling win rate drops
-below a chosen threshold. After training completes the updated model is
-published to the terminal's ``Files`` directory.
+``metrics.csv`` and triggers a new training run when the rolling win rate or
+Sharpe ratio drops below configurable thresholds. After training completes the
+updated model is published to the terminal's ``Files`` directory.
 
 An example cron job running every 15 minutes:
 
 ```cron
-*/15 * * * * /path/to/BotCopier/scripts/auto_retrain.py --log-dir /path/to/observer_logs --out-dir /path/to/BotCopier/models --files-dir /path/to/MT4/MQL4/Files --win-rate-threshold 0.4
+*/15 * * * * /path/to/BotCopier/scripts/auto_retrain.py --log-dir /path/to/observer_logs --out-dir /path/to/BotCopier/models --files-dir /path/to/MT4/MQL4/Files --win-rate-threshold 0.4 --sharpe-threshold 0.0
 ```
 
 ## Metrics Tracking

--- a/tests/test_auto_retrain.py
+++ b/tests/test_auto_retrain.py
@@ -6,11 +6,18 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from scripts.auto_retrain import retrain_if_needed
 
 
-def _write_metrics(file: Path, win_rate: float) -> None:
+def _write_metrics(file: Path, win_rate: float, sharpe: float = 0.0) -> None:
     with open(file, "w", newline="") as f:
         writer = csv.writer(f, delimiter=";")
-        writer.writerow(["time", "magic", "win_rate", "avg_profit", "trade_count"])
-        writer.writerow(["2024.01.01 00:00", "0", str(win_rate), "1.0", "10"])
+        writer.writerow([
+            "time",
+            "magic",
+            "win_rate",
+            "avg_profit",
+            "trade_count",
+            "sharpe",
+        ])
+        writer.writerow(["2024.01.01 00:00", "0", str(win_rate), "1.0", "10", str(sharpe)])
 
 
 def test_retrain_trigger(monkeypatch, tmp_path: Path):
@@ -67,3 +74,37 @@ def test_retrain_not_triggered(monkeypatch, tmp_path: Path):
     assert result is False
     assert "train" not in called
     assert "publish" not in called
+
+
+def test_retrain_trigger_sharpe(monkeypatch, tmp_path: Path):
+    log_dir = tmp_path / "logs"
+    out_dir = tmp_path / "out"
+    files_dir = tmp_path / "files"
+    log_dir.mkdir()
+    out_dir.mkdir()
+    files_dir.mkdir()
+    metrics_file = log_dir / "metrics.csv"
+    _write_metrics(metrics_file, 0.7, -0.2)
+
+    called = {}
+
+    def fake_train(ld, od, incremental=True):
+        called["train"] = (ld, od, incremental)
+
+    def fake_publish(mf, fd):
+        called["publish"] = (mf, fd)
+
+    monkeypatch.setattr("scripts.auto_retrain.train", fake_train)
+    monkeypatch.setattr("scripts.auto_retrain.publish", fake_publish)
+
+    result = retrain_if_needed(
+        log_dir,
+        out_dir,
+        files_dir,
+        win_rate_threshold=0.4,
+        sharpe_threshold=0.0,
+    )
+
+    assert result is True
+    assert called.get("train") == (log_dir, out_dir, True)
+    assert called.get("publish") == (out_dir / "model.json", files_dir)

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -145,13 +145,14 @@ def _write_log_many(file: Path, count: int = 10):
 def _write_metrics(file: Path):
     with open(file, "w", newline="") as f:
         writer = csv.writer(f, delimiter=";")
-        writer.writerow(["time", "magic", "win_rate", "avg_profit", "trade_count"])
+        writer.writerow(["time", "magic", "win_rate", "avg_profit", "trade_count", "sharpe"])
         writer.writerow([
             "2024.01.02 00:00",
             "0",
             "0.5",
             "1.0",
             "2",
+            "0.1",
         ])
 
 


### PR DESCRIPTION
## Summary
- retrain target clone when win rate or sharpe ratio fall below thresholds
- expose sharpe ratio threshold flag on CLI
- document automatic retraining example cron job using win rate and sharpe thresholds

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688c427b6a70832f8bc8e270b64fa0ec