### PR TITLE
Add feature scaling stats and normalization to MQL4 generation

### DIFF
--- a/experts/StrategyTemplate.mq4
+++ b/experts/StrategyTemplate.mq4
@@ -349,16 +349,16 @@ double GetFeature(int index)
       sync with the Python training script.  Unknown indices default
       to zero. */
    RefreshIndicatorCache();
-   double val = 0.0;
+   double raw = 0.0;
    switch(index)
    {
 __FEATURE_CASES__      default:
-         val = 0.0;
+         raw = 0.0;
          break;
    }
    if(index < ArraySize(FeatureMean) && index < ArraySize(FeatureStd) && FeatureStd[index] != 0)
-      val = (val - FeatureMean[index]) / FeatureStd[index];
-   return(val);
+      return((raw - FeatureMean[index]) / FeatureStd[index]);
+   return(raw);
 }
 
 double ComputeLogisticScore()

--- a/scripts/generate_mql4_from_model.py
+++ b/scripts/generate_mql4_from_model.py
@@ -172,12 +172,16 @@ def generate(model_jsons: Union[Path, Iterable[Path]], out_dir: Path):
     output = output.replace('__ENCODER_CENTERS__', center_flat)
     output = output.replace('__ENCODER_CENTER_COUNT__', str(len(centers)))
 
-    feature_mean = base.get('feature_mean', [])
-    mean_str = ', '.join(_fmt(v) for v in feature_mean)
-    output = output.replace('__FEATURE_MEAN__', mean_str)
-    feature_std = base.get('feature_std', [])
-    std_str = ', '.join(_fmt(v) for v in feature_std)
-    output = output.replace('__FEATURE_STD__', std_str)
+    mean_map = {
+        f: m for f, m in zip(base.get('feature_names', []), base.get('feature_mean', []))
+    }
+    mean_vec = [_fmt(mean_map.get(f, 0.0)) for f in feature_names]
+    output = output.replace('__FEATURE_MEAN__', ', '.join(mean_vec))
+    std_map = {
+        f: s for f, s in zip(base.get('feature_names', []), base.get('feature_std', []))
+    }
+    std_vec = [_fmt(std_map.get(f, 1.0)) for f in feature_names]
+    output = output.replace('__FEATURE_STD__', ', '.join(std_vec))
 
     cal_events = base.get('calendar_events', [])
     if cal_events:

--- a/scripts/train_target_clone.py
+++ b/scripts/train_target_clone.py
@@ -782,6 +782,11 @@ def train(
     else:
         X_val = np.empty((0, X_train.shape[1]))
 
+    # statistics for feature scaling
+    feature_mean = X_train.mean(axis=0)
+    feature_std = X_train.std(axis=0)
+    feature_std[feature_std == 0] = 1.0
+
     X_train_reg = vec.transform(feat_train_reg)
     X_val_reg = vec.transform(feat_val_reg) if feat_val_reg else np.empty((0, X_train_reg.shape[1]))
 
@@ -1088,12 +1093,6 @@ def train(
             else:
                 t = threshold
             hourly_thresholds.append(float(t))
-
-    # statistics for feature scaling
-    X_stats = vec.transform(feat_train)
-    feature_mean = X_stats.mean(axis=0)
-    feature_std = X_stats.std(axis=0)
-    feature_std[feature_std == 0] = 1.0
 
     # Compute SHAP feature importance on the training set
     try:


### PR DESCRIPTION
## Summary
- Compute per-feature mean and standard deviation after building training matrices and persist them in `model.json`.
- Emit `FeatureMean[]` and `FeatureStd[]` arrays in generated MQL4 code aligned with feature order.
- Normalize features inside `GetFeature()` using these statistics.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688d68375338832f8e1e439ce0edfbd5