### PR TITLE
Enable incremental logistic regression training

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,11 @@ Pass ``--cache-features`` to reuse the previously extracted feature matrix when
 running incrementally. This avoids reprocessing large log files as long as the
 configured features match the cached ``feature_names``.
 
+When ``--incremental`` is used with the default ``logreg`` model, training
+updates the existing classifier in place by calling ``partial_fit`` on batches
+of new samples. The class vector ``[0, 1]`` is stored in ``model.json`` so
+subsequent runs can keep learning from where the last run left off.
+
 Compile the generated MQ4 file and the observer will begin evaluating predictions from that model.
 
 ## Model Reloading


### PR DESCRIPTION
## Summary
- Update training script to use `partial_fit` for incremental `logreg` models and store class vector
- Document incremental logistic workflow in README
- Add test ensuring incremental `logreg` uses `partial_fit`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688d7e92bd88832f8a18a8b4f101215f