### PR TITLE
Add SHAP feature importances and plotting script

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ The EA records trade openings and closings using the `OnTradeTransaction` callba
   - `evaluate_predictions.py` – basic log evaluation utility.
   - `promote_best_models.py` – selects top models by metric and copies them to a best directory.
   - `plot_metrics.py` – plot metric history using Matplotlib.
+  - `plot_feature_importance.py` – display SHAP feature importances saved in `model.json`.
 - `models/` – location for generated models.
 - `config.json` – example configuration file.
 
@@ -39,6 +40,13 @@ Exported logs can be processed by the Python scripts.  A typical workflow is:
 ```bash
 python train_target_clone.py --data-dir "C:\\path\\to\\observer_logs" --out-dir models
 python generate_mql4_from_model.py models/model.json experts
+```
+
+The training step saves mean absolute SHAP values for each feature under
+`feature_importance` in `model.json`. Visualise these importances with:
+
+```bash
+python plot_feature_importance.py models/model.json
 ```
 
 Multiple models can be supplied to build a simple ensemble. Feature names are

--- a/scripts/plot_feature_importance.py
+++ b/scripts/plot_feature_importance.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""Plot feature importances stored in model.json."""
+
+import argparse
+import json
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Plot mean absolute SHAP feature importances"
+    )
+    parser.add_argument("model", type=Path, help="Path to model.json")
+    parser.add_argument(
+        "--top", type=int, default=20, help="Number of top features to display"
+    )
+    args = parser.parse_args()
+
+    data = json.loads(args.model.read_text())
+    importance = data.get("feature_importance", {})
+    if not importance:
+        print("No feature_importance data found in model.json")
+        return
+
+    items = sorted(importance.items(), key=lambda x: x[1], reverse=True)[: args.top]
+    features, values = zip(*items)
+
+    plt.figure(figsize=(8, max(4, len(features) * 0.4)))
+    plt.barh(features, values)
+    plt.xlabel("Mean |SHAP value|")
+    plt.title("Top Feature Importances")
+    plt.gca().invert_yaxis()
+    plt.tight_layout()
+    plt.show()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/train_target_clone.py
+++ b/scripts/train_target_clone.py
@@ -1119,9 +1119,13 @@ def train(
     try:
         import shap  # type: ignore
 
-        explainer = shap.Explainer(clf, X_train)
-        shap_values = explainer(X_train)
-        importances = np.abs(shap_values.values).mean(axis=0)
+        if model_type == "logreg":
+            explainer = shap.LinearExplainer(clf, X_train)
+            shap_values = explainer.shap_values(X_train)
+        else:
+            explainer = shap.Explainer(clf, X_train)
+            shap_values = explainer(X_train).values
+        importances = np.abs(shap_values).mean(axis=0)
         feature_importance = dict(
             zip(vec.get_feature_names_out().tolist(), importances.tolist())
         )


### PR DESCRIPTION
## Summary
- compute SHAP values after training and save mean absolute importances in `model.json`
- add utility to plot feature importances
- document how to visualise SHAP importances in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688d824e5310832f9c0c61a0bfe44706