### PR TITLE
Add stream listener and log uploader scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,9 @@ experts/*.ex4
 
 # Log directories
 observer_logs/
-logs/
+logs/*
+!logs/metrics.csv
+!logs/trades_raw.csv
 *.log
 
 # Generated models

--- a/README.md
+++ b/README.md
@@ -192,6 +192,28 @@ The collector exposes an HTTP endpoint returning the most recent metrics as JSON
 curl http://127.0.0.1:8080/metrics?limit=10
 ```
 
+To capture newline-delimited JSON from the EA directly, run the
+``stream_listener.py`` helper which writes trade events to
+``logs/trades_raw.csv`` and metrics to ``logs/metrics.csv``. Each message must
+include a matching ``schema_version`` field (default ``1.0`` or overridden via
+the ``SCHEMA_VERSION`` environment variable).
+
+After each trading session ``upload_logs.py`` can commit these CSV files and
+push them back to the repository. The script uses the ``GITHUB_TOKEN``
+environment variable for authentication.
+
+### Environment Variables
+
+* ``SCHEMA_VERSION`` – expected message schema version for ``stream_listener.py``.
+* ``GITHUB_TOKEN`` – personal access token with ``repo`` scope used by
+  ``upload_logs.py`` to push commits.
+
+### Cron Job Example
+
+```cron
+0 0 * * * cd /path/to/BotCopier && GITHUB_TOKEN=XXXX python scripts/upload_logs.py
+```
+
 ## Tick History Export
 
 Historical tick data can be exported for all symbols that appear in the account

--- a/scripts/upload_logs.py
+++ b/scripts/upload_logs.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Commit generated log files and push them to GitHub.
+
+The script adds ``logs/trades_raw.csv`` and ``logs/metrics.csv`` to the Git
+repository, commits them if they have changed and pushes the new commit to the
+``origin`` remote. Authentication is performed using the ``GITHUB_TOKEN``
+environment variable which must contain a personal access token with permission
+to push to the repository.
+"""
+from __future__ import annotations
+
+import datetime as dt
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+LOG_FILES = [REPO_ROOT / "logs" / "trades_raw.csv", REPO_ROOT / "logs" / "metrics.csv"]
+
+
+def run(cmd: list[str]) -> None:
+    subprocess.run(cmd, check=True, cwd=REPO_ROOT)
+
+
+def main() -> int:
+    token = os.environ.get("GITHUB_TOKEN")
+    if not token:
+        print("GITHUB_TOKEN environment variable is required", file=sys.stderr)
+        return 1
+
+    existing = [str(p) for p in LOG_FILES if p.exists()]
+    if not existing:
+        print("No log files found", file=sys.stderr)
+        return 0
+
+    run(["git", "add", *existing])
+    status = subprocess.check_output(
+        ["git", "status", "--porcelain", *existing], cwd=REPO_ROOT
+    ).decode().strip()
+    if not status:
+        print("No changes to commit")
+        return 0
+
+    commit_message = f"Update trading logs {dt.datetime.utcnow().isoformat()}"
+    run(["git", "commit", "-m", commit_message])
+
+    origin_url = subprocess.check_output(
+        ["git", "remote", "get-url", "origin"], cwd=REPO_ROOT
+    ).decode().strip()
+    if origin_url.startswith("https://"):
+        push_url = origin_url.replace("https://", f"https://{token}@")
+    elif origin_url.startswith("git@github.com:"):
+        repo_path = origin_url.split(":", 1)[1]
+        push_url = f"https://{token}@github.com/{repo_path}"
+    else:
+        push_url = origin_url
+
+    run(["git", "push", push_url, "HEAD"])
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add JSON `stream_listener.py` to validate schema_version and save trade and metric messages to CSV
- introduce `upload_logs.py` to commit log CSVs and push to GitHub using `GITHUB_TOKEN`
- document required environment variables and cron job in README, and adjust `.gitignore` for log files

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e47f2db5c832fbd3f88e2ea4cab97