### PR TITLE
Improve training and model export

### DIFF
--- a/experts/StrategyTemplate.mq4
+++ b/experts/StrategyTemplate.mq4
@@ -119,8 +119,12 @@ bool ParseModelJson(string json)
    ExtractJsonArray(json, "\"probability_table\"", ProbabilityLookup);
    ExtractJsonArray(json, "\"sl_coefficients\"", SLModelCoefficients);
    ExtractJsonArray(json, "\"tp_coefficients\"", TPModelCoefficients);
-   ExtractJsonArray(json, "\"feature_mean\"", FeatureMean);
-   ExtractJsonArray(json, "\"feature_std\"", FeatureStd);
+   ExtractJsonArray(json, "\"mean\"", FeatureMean);
+   if(ArraySize(FeatureMean)==0)
+      ExtractJsonArray(json, "\"feature_mean\"", FeatureMean);
+   ExtractJsonArray(json, "\"std\"", FeatureStd);
+   if(ArraySize(FeatureStd)==0)
+      ExtractJsonArray(json, "\"feature_std\"", FeatureStd);
    if(ArraySize(ModelIntercepts)>0)
       ModelIntercepts[0] = ExtractJsonNumber(json, "\"intercept\"");
    SLModelIntercept = ExtractJsonNumber(json, "\"sl_intercept\"");

--- a/scripts/generate_mql4_from_model.py
+++ b/scripts/generate_mql4_from_model.py
@@ -172,14 +172,13 @@ def generate(model_jsons: Union[Path, Iterable[Path]], out_dir: Path):
     output = output.replace('__ENCODER_CENTERS__', center_flat)
     output = output.replace('__ENCODER_CENTER_COUNT__', str(len(centers)))
 
-    mean_map = {
-        f: m for f, m in zip(base.get('feature_names', []), base.get('feature_mean', []))
-    }
+    mean_vals = base.get('mean', base.get('feature_mean', []))
+    std_vals = base.get('std', base.get('feature_std', []))
+
+    mean_map = {f: m for f, m in zip(base.get('feature_names', []), mean_vals)}
     mean_vec = [_fmt(mean_map.get(f, 0.0)) for f in feature_names]
     output = output.replace('__FEATURE_MEAN__', ', '.join(mean_vec))
-    std_map = {
-        f: s for f, s in zip(base.get('feature_names', []), base.get('feature_std', []))
-    }
+    std_map = {f: s for f, s in zip(base.get('feature_names', []), std_vals)}
     std_vec = [_fmt(std_map.get(f, 1.0)) for f in feature_names]
     output = output.replace('__FEATURE_STD__', ', '.join(std_vec))
 

--- a/scripts/train_target_clone.py
+++ b/scripts/train_target_clone.py
@@ -811,9 +811,8 @@ def train(
         hours_val = np.array([])
     else:
         tscv = TimeSeriesSplit(n_splits=min(5, len(labels) - 1))
-        # iterate through sequential splits and select the final one for validation
-        for train_idx, val_idx in tscv.split(features):
-            pass
+        # select the final chronological split for validation
+        train_idx, val_idx = list(tscv.split(features))[-1]
         feat_train = [features[i] for i in train_idx]
         feat_val = [features[i] for i in val_idx]
         y_train = labels[train_idx]
@@ -1230,8 +1229,8 @@ def train(
         "accuracy": val_acc,
         "num_samples": int(labels.shape[0]) + (int(existing_model.get("num_samples", 0)) if existing_model else 0),
         "feature_importance": feature_importance,
-        "feature_mean": feature_mean.tolist(),
-        "feature_std": feature_std.tolist(),
+        "mean": feature_mean.tolist(),
+        "std": feature_std.tolist(),
     }
     if calendar_events:
         model["calendar_events"] = [

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -417,8 +417,8 @@ def test_generate_scaling_arrays(tmp_path: Path):
         "intercept": 0.0,
         "threshold": 0.5,
         "feature_names": ["hour"],
-        "feature_mean": [12.0],
-        "feature_std": [3.0],
+        "mean": [12.0],
+        "std": [3.0],
     }
     model_file = tmp_path / "model.json"
     with open(model_file, "w") as f:

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -182,8 +182,8 @@ def test_train(tmp_path: Path):
     assert "equity" in data.get("feature_names", [])
     assert "margin_level" in data.get("feature_names", [])
     assert data.get("weighted") is True
-    assert "feature_mean" in data
-    assert "feature_std" in data
+    assert "mean" in data
+    assert "std" in data
 
     init_file = out_dir / "policy_init.json"
     assert init_file.exists()

--- a/tests/test_train_target_clone_features.py
+++ b/tests/test_train_target_clone_features.py
@@ -1,0 +1,130 @@
+import csv
+import json
+import sys
+from pathlib import Path
+from datetime import datetime
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from scripts.train_target_clone import _extract_features, train
+
+
+def _write_sample_log(file: Path):
+    fields = [
+        "event_id",
+        "event_time",
+        "broker_time",
+        "local_time",
+        "action",
+        "ticket",
+        "magic",
+        "source",
+        "symbol",
+        "order_type",
+        "lots",
+        "price",
+        "sl",
+        "tp",
+        "profit",
+        "spread",
+        "comment",
+        "remaining_lots",
+        "slippage",
+        "volume",
+    ]
+    rows = [
+        [
+            "1",
+            "2024.01.01 00:00:00",
+            "",
+            "",
+            "OPEN",
+            "1",
+            "",
+            "",
+            "EURUSD",
+            "0",
+            "0.1",
+            "1.1000",
+            "1.0950",
+            "1.1100",
+            "0",
+            "2",
+            "",
+            "0.1",
+            "0.0001",
+            "100",
+        ],
+        [
+            "2",
+            "2024.01.01 01:00:00",
+            "",
+            "",
+            "OPEN",
+            "2",
+            "",
+            "",
+            "EURUSD",
+            "1",
+            "0.1",
+            "1.2000",
+            "1.1950",
+            "1.2100",
+            "0",
+            "3",
+            "",
+            "0.1",
+            "0.0002",
+            "200",
+        ],
+    ]
+    with open(file, "w", newline="") as f:
+        writer = csv.writer(f, delimiter=";")
+        writer.writerow(fields)
+        writer.writerows(rows)
+
+
+def test_feature_extraction_basic():
+    rows = [
+        {
+            "event_time": datetime(2024, 1, 1, 0, 0),
+            "action": "OPEN",
+            "symbol": "EURUSD",
+            "order_type": "0",
+            "lots": 0.1,
+            "price": 1.1000,
+            "sl": 1.0950,
+            "tp": 1.1100,
+            "profit": 0,
+            "spread": 2,
+            "slippage": 0.0001,
+            "equity": 1000,
+            "margin_level": 150,
+        }
+    ]
+    feats, *_ = _extract_features(rows, use_slippage=True)
+    assert "hour_sin" in feats[0] and "hour_cos" in feats[0]
+    assert "dow_sin" in feats[0] and "dow_cos" in feats[0]
+    assert "spread" in feats[0]
+    assert "slippage" in feats[0]
+    assert "equity" in feats[0] and "margin_level" in feats[0]
+
+
+def test_model_serialization(tmp_path: Path):
+    data_dir = tmp_path / "logs"
+    out_dir = tmp_path / "out"
+    data_dir.mkdir()
+    _write_sample_log(data_dir / "trades_sample.csv")
+
+    train(data_dir, out_dir, use_slippage=True)
+
+    model_file = out_dir / "model.json"
+    assert model_file.exists()
+    with open(model_file) as f:
+        data = json.load(f)
+    assert "feature_names" in data
+    assert "mean" in data
+    assert "std" in data
+    assert "threshold" in data
+    assert "val_accuracy" in data


### PR DESCRIPTION
## Summary
- Use `TimeSeriesSplit` for chronological validation and record feature scaling stats under `mean` and `std`
- Allow MQL code generation to consume new scaling keys
- Add tests covering feature extraction and model serialization

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e5b2dab84832f9d91733af388ddba