### PR TITLE
Add evaluation metrics and model promotion

### DIFF
--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -43,6 +43,11 @@ def test_evaluate(tmp_path: Path):
 
     assert stats["matched_events"] == 1
     assert stats["predicted_events"] == 1
+    assert stats["accuracy"] == 1.0
+    assert stats["precision"] == 1.0
+    assert stats["recall"] == 1.0
+    assert stats["profit_factor"] == float("inf")
+    assert stats["sharpe_ratio"] == 0.0
 
 
 def test_direction_mapping(tmp_path: Path):

--- a/tests/test_promote_best_models.py
+++ b/tests/test_promote_best_models.py
@@ -1,0 +1,26 @@
+import json
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from scripts.promote_best_models import promote
+
+
+def _create_model(dir_path: Path, name: str, metric_value: float):
+    model_dir = dir_path / name
+    model_dir.mkdir()
+    model_file = model_dir / f"{name}.json"
+    model_file.write_text("{}")
+    with open(model_dir / "evaluation.json", "w") as f:
+        json.dump({"accuracy": metric_value}, f)
+    return model_file
+
+
+def test_promote_uses_evaluation(tmp_path: Path):
+    m1 = _create_model(tmp_path, "model_a", 0.9)
+    _create_model(tmp_path, "model_b", 0.8)
+
+    best_dir = tmp_path / "best"
+    promote(tmp_path, best_dir, max_models=1, metric="accuracy")
+
+    assert (best_dir / m1.name).exists()


### PR DESCRIPTION
## Summary
- compute accuracy, precision, recall, profit factor and Sharpe ratio in evaluation utility
- write evaluation summaries to evaluation.json by default
- promote models based on evaluation.json metrics and copy top performers before publish

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e8dbc5730832f8810267d83b3727f