### PR TITLE
Add workflow docs, requirements, and logging tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,14 +5,18 @@ __pycache__/
 *.pyd
 
 # MetaTrader build artifacts
-experts/*.ex4
+*.ex4
 
 # Log directories
+logs/
 observer_logs/
-logs/*
-!logs/metrics.csv
-!logs/trades_raw.csv
 *.log
 
 # Generated models
 models/best/
+
+# Temporary files
+*.tmp
+*.temp
+*~
+*.swp

--- a/README.md
+++ b/README.md
@@ -33,6 +33,26 @@ The EA records trade openings and closings using the `OnTradeTransaction` callba
 5. Attach `Observer_TBot` to a single chart and adjust the extern inputs as needed
    (magic numbers to observe, log directory, lot bounds, etc.).
 
+## Workflow
+
+1. Run `Observer_TBot` inside MetaTrader to capture trade activity in `logs/`.
+2. Train a model from the collected logs:
+   ```bash
+   python scripts/train_target_clone.py --data-dir logs --out-dir models
+   ```
+3. Generate an EA from the trained model:
+   ```bash
+   python scripts/generate_mql4_from_model.py models/model.json experts
+   ```
+4. Evaluate the model against new trades:
+   ```bash
+   python scripts/evaluate_predictions.py predictions.csv logs/trades.csv
+   ```
+5. Promote the top performing models:
+   ```bash
+   python scripts/promote_best_models.py models --dest models/best
+   ```
+
 ## External Training
 
 Exported logs can be processed by the Python scripts.  A typical workflow is:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+numpy
+pandas
+scikit-learn
+pytest
+
+# Optional extras
+xgboost; extra == "xgboost"
+optuna; extra == "optuna"
+stable-baselines3; extra == "rl"

--- a/tests/test_logging_basic.py
+++ b/tests/test_logging_basic.py
@@ -1,0 +1,43 @@
+import json
+import socket
+import threading
+import time
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from scripts.socket_log_service import listen_once
+
+
+def test_logging_roundtrip(tmp_path: Path):
+    host = "127.0.0.1"
+    srv = socket.socket()
+    srv.bind((host, 0))
+    port = srv.getsockname()[1]
+    srv.close()
+
+    out_file = tmp_path / "trade.csv"
+    t = threading.Thread(target=listen_once, args=(host, port, out_file))
+    t.start()
+    time.sleep(0.1)
+
+    msg = {
+        "event_id": 1,
+        "event_time": "2024.01.01 00:00:00",
+        "action": "OPEN",
+        "ticket": 1,
+        "symbol": "EURUSD",
+        "order_type": 0,
+        "lots": 0.1,
+    }
+
+    client = socket.socket()
+    client.connect((host, port))
+    client.sendall(json.dumps(msg).encode() + b"\n")
+    client.close()
+
+    t.join(timeout=2)
+    assert out_file.exists()
+    text = out_file.read_text().splitlines()
+    assert text[0].startswith("event_id")
+    assert "EURUSD" in text[1]


### PR DESCRIPTION
## Summary
- Document the end-to-end workflow from observing trades through promoting models.
- Ignore generated logs, compiled EAs, and temporary files.
- Provide `requirements.txt` with optional extras for XGBoost, Optuna, and stable-baselines.
- Add pytest coverage for logging.

## Testing
- `pip install numpy pandas scikit-learn`
- `pip install aiohttp`
- `pytest tests/test_logging_basic.py tests/test_train.py tests/test_generate.py tests/test_evaluate.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688e9cbe2748832fa69946acd9612991