### PR TITLE
Log open time and trade duration features

### DIFF
--- a/experts/Observer_TBot.mq4
+++ b/experts/Observer_TBot.mq4
@@ -103,7 +103,7 @@ int OnInit()
          FileSeek(trade_log_handle, 0, SEEK_END);
          if(need_header)
          {
-            string header = "event_id;event_time;broker_time;local_time;action;ticket;magic;source;symbol;order_type;lots;price;sl;tp;profit;profit_after_trade;spread;comment;remaining_lots;slippage;volume";
+            string header = "event_id;event_time;broker_time;local_time;action;ticket;magic;source;symbol;order_type;lots;price;sl;tp;profit;profit_after_trade;spread;comment;remaining_lots;slippage;volume;open_time";
             int _wr = FileWrite(trade_log_handle, header);
             if(_wr <= 0)
                FileWriteErrors++;
@@ -256,7 +256,7 @@ void OnTradeTransaction(const MqlTradeTransaction &trans,
    {
       LogTrade("OPEN", ticket, magic, "mt4", symbol, order_type,
                lots, price, sl, tp, 0.0, profit_after, MarketInfo(symbol, MODE_SPREAD),
-               remaining, now, comment, slippage, iVolume(symbol, 0, 0));
+               remaining, now, comment, slippage, iVolume(symbol, 0, 0), 0);
       if(!IsTracked(ticket))
          AddTicket(ticket);
       else if(entry==DEAL_ENTRY_INOUT && remaining>0.0 && OrderSelect(ticket, SELECT_BY_TICKET, MODE_TRADES))
@@ -267,14 +267,19 @@ void OnTradeTransaction(const MqlTradeTransaction &trans,
          LogTrade("MODIFY", ticket, magic, "mt4", symbol, order_type,
                   0.0, cur_price, cur_sl, cur_tp, 0.0, profit_after,
                   MarketInfo(symbol, MODE_SPREAD), remaining, now, comment, 0.0,
-                  iVolume(symbol, 0, 0));
+                  iVolume(symbol, 0, 0), 0);
       }
    }
    else if(entry==DEAL_ENTRY_OUT || entry==DEAL_ENTRY_OUT_BY)
    {
+      datetime open_time = 0;
+      if(OrderSelect(ticket, SELECT_BY_TICKET, MODE_HISTORY))
+         open_time = OrderOpenTime();
+      else if(OrderSelect(ticket, SELECT_BY_TICKET, MODE_TRADES))
+         open_time = OrderOpenTime();
       LogTrade("CLOSE", ticket, magic, "mt4", symbol, order_type,
                lots, price, sl, tp, profit, profit_after, MarketInfo(symbol, MODE_SPREAD),
-               remaining, now, comment, slippage, iVolume(symbol, 0, 0));
+               remaining, now, comment, slippage, iVolume(symbol, 0, 0), open_time);
       if(IsTracked(ticket) && remaining==0.0)
          RemoveTicket(ticket);
       else if(remaining>0.0 && OrderSelect(ticket, SELECT_BY_TICKET, MODE_TRADES))
@@ -285,7 +290,7 @@ void OnTradeTransaction(const MqlTradeTransaction &trans,
          LogTrade("MODIFY", ticket, magic, "mt4", symbol, order_type,
                   0.0, cur_price, cur_sl, cur_tp, 0.0, profit_after,
                   MarketInfo(symbol, MODE_SPREAD), remaining, now, comment, 0.0,
-                  iVolume(symbol, 0, 0));
+                  iVolume(symbol, 0, 0), 0);
       }
    }
 }
@@ -316,7 +321,7 @@ void OnTick()
                   OrderLots(), OrderOpenPrice(), OrderStopLoss(), OrderTakeProfit(),
                   0.0, profit_after, MarketInfo(OrderSymbol(), MODE_SPREAD),
                   OrderLots(), now, OrderComment(), 0.0,
-                  iVolume(OrderSymbol(), 0, 0));
+                  iVolume(OrderSymbol(), 0, 0), 0);
          AddTicket(ticket);
       }
    }
@@ -337,7 +342,7 @@ void OnTick()
                        OrderTakeProfit(), OrderProfit()+OrderSwap()+OrderCommission(),
                        profit_after2, MarketInfo(OrderSymbol(), MODE_SPREAD),
                        0.0, now, OrderComment(), 0.0,
-                       iVolume(OrderSymbol(), 0, 0));
+                       iVolume(OrderSymbol(), 0, 0), OrderOpenTime());
          }
          RemoveTicket(ticket);
          t--; // adjust index after removal
@@ -423,15 +428,18 @@ void LogTrade(string action, int ticket, int magic, string source,
               string symbol, int order_type, double lots, double price,
               double sl, double tp, double profit, double profit_after,
               double spread, double remaining, datetime time_event, string comment,
-              double slippage, double volume)
+              double slippage, double volume, datetime open_time)
 {
    int id = NextEventId++;
-   string line = StringFormat("%d;%s;%s;%s;%s;%d;%d;%s;%s;%d;%.2f;%.5f;%.5f;%.5f;%.2f;%.2f;%d;%s;%.2f;%.5f;%d",
+   string open_time_str = "";
+   if(action=="CLOSE" && open_time>0)
+      open_time_str = TimeToString(open_time, TIME_DATE|TIME_SECONDS);
+   string line = StringFormat("%d;%s;%s;%s;%s;%d;%d;%s;%s;%d;%.2f;%.5f;%.5f;%.5f;%.2f;%.2f;%d;%s;%.2f;%.5f;%d;%s",
       id,
       TimeToString(time_event, TIME_DATE|TIME_SECONDS),
       TimeToString(TimeCurrent(), TIME_DATE|TIME_SECONDS),
       TimeToString(TimeLocal(), TIME_DATE|TIME_SECONDS),
-      action, ticket, magic, source, symbol, order_type, lots, price, sl, tp, profit, profit_after, spread, comment, remaining, slippage, (int)volume);
+      action, ticket, magic, source, symbol, order_type, lots, price, sl, tp, profit, profit_after, spread, comment, remaining, slippage, (int)volume, open_time_str);
 
    if(!EnableSocketLogging)
    {
@@ -453,13 +461,13 @@ void LogTrade(string action, int ticket, int magic, string source,
       }
    }
 
-   string json = StringFormat("{\"schema_version\":%d,\"event_id\":%d,\"event_time\":\"%s\",\"broker_time\":\"%s\",\"local_time\":\"%s\",\"action\":\"%s\",\"ticket\":%d,\"magic\":%d,\"source\":\"%s\",\"symbol\":\"%s\",\"order_type\":%d,\"lots\":%.2f,\"price\":%.5f,\"sl\":%.5f,\"tp\":%.5f,\"profit\":%.2f,\"profit_after_trade\":%.2f,\"spread\":%d,\"comment\":\"%s\",\"remaining_lots\":%.2f,\"slippage\":%.5f,\"volume\":%d}",
+   string json = StringFormat("{\"schema_version\":%d,\"event_id\":%d,\"event_time\":\"%s\",\"broker_time\":\"%s\",\"local_time\":\"%s\",\"action\":\"%s\",\"ticket\":%d,\"magic\":%d,\"source\":\"%s\",\"symbol\":\"%s\",\"order_type\":%d,\"lots\":%.2f,\"price\":%.5f,\"sl\":%.5f,\"tp\":%.5f,\"profit\":%.2f,\"profit_after_trade\":%.2f,\"spread\":%d,\"comment\":\"%s\",\"remaining_lots\":%.2f,\"slippage\":%.5f,\"volume\":%d,\"open_time\":\"%s\"}",
       LogSchemaVersion, id,
       EscapeJson(TimeToString(time_event, TIME_DATE|TIME_SECONDS)),
       EscapeJson(TimeToString(TimeCurrent(), TIME_DATE|TIME_SECONDS)),
       EscapeJson(TimeToString(TimeLocal(), TIME_DATE|TIME_SECONDS)),
       EscapeJson(action), ticket, magic, EscapeJson(source), EscapeJson(symbol), order_type,
-      lots, price, sl, tp, profit, profit_after, spread, EscapeJson(comment), remaining, slippage, (int)volume);
+      lots, price, sl, tp, profit, profit_after, spread, EscapeJson(comment), remaining, slippage, (int)volume, EscapeJson(open_time_str));
 
    SendJson(json);
 }


### PR DESCRIPTION
## Summary
- extend Observer_TBot logging to include trade `open_time` in headers, CSV and JSON outputs
- compute trade duration from `open_time` in training data loader with backward compatibility

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688ea80e65f8832faba076a352252a1d