### PR TITLE
Add gzipped binary socket logging

### DIFF
--- a/scripts/socket_log_service.py
+++ b/scripts/socket_log_service.py
@@ -5,6 +5,7 @@ import argparse
 import asyncio
 import csv
 import json
+import zlib
 from pathlib import Path
 from asyncio import StreamReader, StreamWriter, Queue
 
@@ -47,26 +48,50 @@ async def _writer_task(out_file: Path, queue: Queue) -> None:
             queue.task_done()
 
 
-async def _handle_conn(reader: StreamReader, writer: StreamWriter, queue: Queue) -> None:
+async def _handle_conn(
+    reader: StreamReader,
+    writer: StreamWriter,
+    queue: Queue,
+    binary: bool = False,
+) -> None:
     """Process a single connection and push rows to ``queue``."""
 
     try:
-        while data := await reader.readline():
-            line = data.decode("utf-8", errors="replace").strip()
-            if not line:
-                continue
-            try:
-                obj = json.loads(line)
-            except json.JSONDecodeError:
-                continue
-            row = [str(obj.get(field, "")) for field in FIELDS]
-            await queue.put(row)
+        if binary:
+            while True:
+                try:
+                    header = await reader.readexactly(4)
+                except asyncio.IncompleteReadError:
+                    break
+                length = int.from_bytes(header, "little")
+                try:
+                    payload = await reader.readexactly(length)
+                except asyncio.IncompleteReadError:
+                    break
+                try:
+                    data = zlib.decompress(payload).decode("utf-8")
+                    obj = json.loads(data)
+                except Exception:
+                    continue
+                row = [str(obj.get(field, "")) for field in FIELDS]
+                await queue.put(row)
+        else:
+            while data := await reader.readline():
+                line = data.decode("utf-8", errors="replace").strip()
+                if not line:
+                    continue
+                try:
+                    obj = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                row = [str(obj.get(field, "")) for field in FIELDS]
+                await queue.put(row)
     finally:
         writer.close()
         await writer.wait_closed()
 
 
-def listen_once(host: str, port: int, out_file: Path) -> None:
+def listen_once(host: str, port: int, out_file: Path, *, binary: bool = False) -> None:
     """Accept a single connection and process it until closed."""
 
     async def _run() -> None:
@@ -74,7 +99,7 @@ def listen_once(host: str, port: int, out_file: Path) -> None:
         done = asyncio.Event()
 
         async def wrapped(reader: StreamReader, writer: StreamWriter) -> None:
-            await _handle_conn(reader, writer, queue)
+            await _handle_conn(reader, writer, queue, binary=binary)
             done.set()
 
         server = await asyncio.start_server(wrapped, host, port)
@@ -89,14 +114,16 @@ def listen_once(host: str, port: int, out_file: Path) -> None:
     asyncio.run(_run())
 
 
-def serve(host: str, port: int, out_file: Path) -> None:
+def serve(host: str, port: int, out_file: Path, *, binary: bool = False) -> None:
     """Accept multiple connections concurrently and append lines."""
 
     async def _run() -> None:
         queue: Queue = Queue()
 
         server = await asyncio.start_server(
-            lambda r, w: _handle_conn(r, w, queue), host, port
+            lambda r, w: _handle_conn(r, w, queue, binary=binary),
+            host,
+            port,
         )
         writer_task = asyncio.create_task(_writer_task(out_file, queue))
         async with server:
@@ -114,9 +141,10 @@ def main() -> None:
     p.add_argument("--host", default="127.0.0.1")
     p.add_argument("--port", type=int, default=9000)
     p.add_argument("--out", required=True, help="output CSV file")
+    p.add_argument("--binary", action="store_true", help="expect length-prefixed gzipped JSON")
     args = p.parse_args()
 
-    serve(args.host, args.port, Path(args.out))
+    serve(args.host, args.port, Path(args.out), binary=args.binary)
 
 
 if __name__ == "__main__":

--- a/tests/test_socket_log_service_binary.py
+++ b/tests/test_socket_log_service_binary.py
@@ -1,0 +1,56 @@
+import json
+import socket
+import threading
+import time
+import zlib
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from scripts.socket_log_service import listen_once
+
+
+def test_socket_log_service_binary(tmp_path: Path):
+    host = "127.0.0.1"
+    srv_sock = socket.socket()
+    srv_sock.bind((host, 0))
+    port = srv_sock.getsockname()[1]
+    srv_sock.close()
+
+    out_file = tmp_path / "out.csv"
+    t = threading.Thread(target=listen_once, args=(host, port, out_file), kwargs={"binary": True})
+    t.start()
+    time.sleep(0.1)
+
+    msg = {
+        "event_id": 1,
+        "event_time": "t",
+        "broker_time": "b",
+        "local_time": "l",
+        "action": "OPEN",
+        "ticket": 1,
+        "magic": 2,
+        "source": "mt4",
+        "symbol": "EURUSD",
+        "order_type": 0,
+        "lots": 0.1,
+        "price": 1.2345,
+        "sl": 1.0,
+        "tp": 2.0,
+        "profit": 0.0,
+        "comment": "hi",
+        "remaining_lots": 0.1,
+    }
+
+    payload = zlib.compress(json.dumps(msg).encode("utf-8"))
+    packet = len(payload).to_bytes(4, "little") + payload
+
+    client = socket.socket()
+    client.connect((host, port))
+    client.sendall(packet)
+    client.close()
+
+    t.join(timeout=2)
+    assert out_file.exists()
+    lines = [l.strip() for l in out_file.read_text().splitlines() if l.strip()]
+    assert "EURUSD" in lines[-1]

--- a/tests/test_stream_listener_binary.py
+++ b/tests/test_stream_listener_binary.py
@@ -1,0 +1,21 @@
+import json
+import subprocess
+import sys
+import zlib
+from pathlib import Path
+
+
+def test_stream_listener_binary(tmp_path: Path):
+    script = Path(__file__).resolve().parents[1] / "scripts" / "stream_listener.py"
+    msg = {
+        "schema_version": "1.0",
+        "type": "event",
+        "foo": "bar",
+    }
+    payload = zlib.compress(json.dumps(msg).encode("utf-8"))
+    packet = len(payload).to_bytes(4, "little") + payload
+    subprocess.run([sys.executable, str(script), "--binary"], input=packet, cwd=tmp_path)
+    out_file = tmp_path / "logs" / "trades_raw.csv"
+    assert out_file.exists()
+    lines = [l.strip() for l in out_file.read_text().splitlines() if l.strip()]
+    assert "bar" in lines[-1]


### PR DESCRIPTION
## Summary
- add `UseBinarySocketLogging` EA input to send length-prefixed gzipped JSON
- handle binary mode in `socket_log_service.py` and `stream_listener.py`
- test binary paths for socket and stream listeners

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688ef8ad2c00832fad65bea9131b2629