### PR TITLE
feat: add data drift monitoring for auto retrain

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,13 +161,18 @@ model when ``model.json`` changes.
 
 The ``auto_retrain.py`` helper watches the most recent entries in
 ``metrics.csv`` and triggers a new training run when the rolling win rate or
-Sharpe ratio drops below configurable thresholds. After training completes the
-updated model is published to the terminal's ``Files`` directory.
+Sharpe ratio drops below configurable thresholds. It can also monitor data
+drift by comparing the win rate distribution of a reference metrics file
+against the latest metrics using the population stability index (PSI) or
+Kolmogorov–Smirnov (KS) statistic. When either statistic exceeds configured
+limits the model is retrained even if win rate remains acceptable. After
+training completes the updated model is published to the terminal's ``Files``
+directory.
 
 An example cron job running every 15 minutes:
 
 ```cron
-*/15 * * * * /path/to/BotCopier/scripts/auto_retrain.py --log-dir /path/to/observer_logs --out-dir /path/to/BotCopier/models --files-dir /path/to/MT4/MQL4/Files --win-rate-threshold 0.4 --sharpe-threshold 0.0
+*/15 * * * * /path/to/BotCopier/scripts/auto_retrain.py --log-dir /path/to/observer_logs --out-dir /path/to/BotCopier/models --files-dir /path/to/MT4/MQL4/Files --win-rate-threshold 0.4 --sharpe-threshold 0.0 --training-metrics /path/to/training_metrics.csv --psi-threshold 0.2
 ```
 
 ## Metrics Tracking

--- a/scripts/auto_retrain.py
+++ b/scripts/auto_retrain.py
@@ -7,7 +7,9 @@ import argparse
 import csv
 import sys
 from pathlib import Path
-from typing import Optional, Dict
+from typing import Optional, Dict, List
+
+import numpy as np
 
 from scripts.train_target_clone import train
 from scripts.publish_model import publish
@@ -24,14 +26,65 @@ def _load_latest_row(metrics_file: Path) -> Optional[Dict[str, str]]:
     return last
 
 
+def _load_column(metrics_file: Path, column: str) -> List[float]:
+    values: List[float] = []
+    if not metrics_file.exists():
+        return values
+    with open(metrics_file, newline="") as f:
+        reader = csv.DictReader(f, delimiter=";")
+        for row in reader:
+            try:
+                values.append(float(row.get(column, 0) or 0))
+            except Exception:
+                continue
+    return values
+
+
+def _compute_psi(base: List[float], new: List[float], bins: int = 10) -> float:
+    """Return population stability index between ``base`` and ``new``."""
+    if not base or not new:
+        return 0.0
+    arr_base = np.array(base)
+    arr_new = np.array(new)
+    quantiles = np.linspace(0, 1, bins + 1)
+    edges = np.unique(np.quantile(arr_base, quantiles))
+    if len(edges) <= 1:
+        return 0.0
+    edges[0] = -np.inf
+    edges[-1] = np.inf
+    base_hist, _ = np.histogram(arr_base, bins=edges)
+    new_hist, _ = np.histogram(arr_new, bins=edges)
+    base_perc = base_hist / arr_base.size
+    new_perc = new_hist / arr_new.size
+    base_perc = np.where(base_perc == 0, 1e-6, base_perc)
+    new_perc = np.where(new_perc == 0, 1e-6, new_perc)
+    psi = np.sum((base_perc - new_perc) * np.log(base_perc / new_perc))
+    return float(psi)
+
+
+def _compute_ks(base: List[float], new: List[float]) -> float:
+    """Return Kolmogorov–Smirnov statistic between ``base`` and ``new``."""
+    if not base or not new:
+        return 0.0
+    arr_base = np.sort(np.array(base))
+    arr_new = np.sort(np.array(new))
+    all_values = np.sort(np.concatenate([arr_base, arr_new]))
+    cdf_base = np.searchsorted(arr_base, all_values, side="right") / arr_base.size
+    cdf_new = np.searchsorted(arr_new, all_values, side="right") / arr_new.size
+    return float(np.max(np.abs(cdf_base - cdf_new)))
+
+
 def retrain_if_needed(
     log_dir: Path,
     out_dir: Path,
     files_dir: Path,
     *,
     metrics_file: Optional[Path] = None,
+    ref_metrics_file: Optional[Path] = None,
     win_rate_threshold: float = 0.4,
     sharpe_threshold: float = 0.0,
+    psi_threshold: Optional[float] = None,
+    ks_threshold: Optional[float] = None,
     incremental: bool = True,
 ) -> bool:
     metrics_path = metrics_file or (log_dir / "metrics.csv")
@@ -46,7 +99,24 @@ def retrain_if_needed(
         sharpe = float(row.get("sharpe") or row.get("sharpe_ratio") or 0)
     except Exception:
         sharpe = 0.0
-    if win_rate >= win_rate_threshold and sharpe >= sharpe_threshold:
+
+    trigger = False
+    if win_rate < win_rate_threshold or sharpe < sharpe_threshold:
+        trigger = True
+    else:
+        base_vals: List[float] = []
+        new_vals: List[float] = []
+        if ref_metrics_file is not None:
+            base_vals = _load_column(ref_metrics_file, "win_rate")
+            new_vals = _load_column(metrics_path, "win_rate")
+        psi = _compute_psi(base_vals, new_vals) if psi_threshold is not None else 0.0
+        ks = _compute_ks(base_vals, new_vals) if ks_threshold is not None else 0.0
+        if psi_threshold is not None and psi > psi_threshold:
+            trigger = True
+        if ks_threshold is not None and ks > ks_threshold:
+            trigger = True
+
+    if not trigger:
         return False
 
     train(log_dir, out_dir, incremental=incremental)
@@ -62,6 +132,10 @@ def main() -> None:
     p.add_argument("--files-dir", required=True, help="MT4 Files directory")
     p.add_argument("--metrics-file", help="path to metrics.csv")
     p.add_argument(
+        "--training-metrics",
+        help="reference metrics CSV for drift detection",
+    )
+    p.add_argument(
         "--win-rate-threshold",
         type=float,
         default=0.4,
@@ -72,6 +146,16 @@ def main() -> None:
         type=float,
         default=0.0,
         help="trigger retraining when Sharpe ratio is below this value",
+    )
+    p.add_argument(
+        "--psi-threshold",
+        type=float,
+        help="trigger retraining when population stability index exceeds this value",
+    )
+    p.add_argument(
+        "--ks-threshold",
+        type=float,
+        help="trigger retraining when KS statistic exceeds this value",
     )
     p.add_argument(
         "--no-incremental",
@@ -85,8 +169,11 @@ def main() -> None:
         Path(args.out_dir),
         Path(args.files_dir),
         metrics_file=Path(args.metrics_file) if args.metrics_file else None,
+        ref_metrics_file=Path(args.training_metrics) if args.training_metrics else None,
         win_rate_threshold=args.win_rate_threshold,
         sharpe_threshold=args.sharpe_threshold,
+        psi_threshold=args.psi_threshold,
+        ks_threshold=args.ks_threshold,
         incremental=not args.no_incremental,
     )
 

--- a/tests/test_auto_retrain.py
+++ b/tests/test_auto_retrain.py
@@ -6,7 +6,8 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from scripts.auto_retrain import retrain_if_needed
 
 
-def _write_metrics(file: Path, win_rate: float, sharpe: float = 0.0) -> None:
+def _write_metrics(file: Path, win_rate, sharpe: float = 0.0) -> None:
+    win_rates = win_rate if isinstance(win_rate, list) else [win_rate]
     with open(file, "w", newline="") as f:
         writer = csv.writer(f, delimiter=";")
         writer.writerow([
@@ -17,7 +18,8 @@ def _write_metrics(file: Path, win_rate: float, sharpe: float = 0.0) -> None:
             "trade_count",
             "sharpe",
         ])
-        writer.writerow(["2024.01.01 00:00", "0", str(win_rate), "1.0", "10", str(sharpe)])
+        for wr in win_rates:
+            writer.writerow(["2024.01.01 00:00", "0", str(wr), "1.0", "10", str(sharpe)])
 
 
 def test_retrain_trigger(monkeypatch, tmp_path: Path):
@@ -103,6 +105,43 @@ def test_retrain_trigger_sharpe(monkeypatch, tmp_path: Path):
         files_dir,
         win_rate_threshold=0.4,
         sharpe_threshold=0.0,
+    )
+
+    assert result is True
+    assert called.get("train") == (log_dir, out_dir, True)
+    assert called.get("publish") == (out_dir / "model.json", files_dir)
+
+
+def test_retrain_trigger_drift(monkeypatch, tmp_path: Path):
+    log_dir = tmp_path / "logs"
+    out_dir = tmp_path / "out"
+    files_dir = tmp_path / "files"
+    log_dir.mkdir()
+    out_dir.mkdir()
+    files_dir.mkdir()
+    metrics_file = log_dir / "metrics.csv"
+    baseline_file = tmp_path / "baseline.csv"
+    _write_metrics(baseline_file, [0.4, 0.42, 0.43, 0.45])
+    _write_metrics(metrics_file, [0.8, 0.85, 0.9, 0.87])
+
+    called = {}
+
+    def fake_train(ld, od, incremental=True):
+        called["train"] = (ld, od, incremental)
+
+    def fake_publish(mf, fd):
+        called["publish"] = (mf, fd)
+
+    monkeypatch.setattr("scripts.auto_retrain.train", fake_train)
+    monkeypatch.setattr("scripts.auto_retrain.publish", fake_publish)
+
+    result = retrain_if_needed(
+        log_dir,
+        out_dir,
+        files_dir,
+        win_rate_threshold=0.2,
+        ref_metrics_file=baseline_file,
+        psi_threshold=0.1,
     )
 
     assert result is True


### PR DESCRIPTION
## Summary
- compute population stability index and KS statistic to detect data drift
- retrain when drift exceeds `--psi-threshold` or `--ks-threshold`
- document drift detection options in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f942c3314832fa6df2906e86010fa