### PR TITLE
Add order book volume features to Observer and strategy

### DIFF
--- a/scripts/generate_mql4_from_model.py
+++ b/scripts/generate_mql4_from_model.py
@@ -229,6 +229,9 @@ def generate(model_jsons: Union[Path, Iterable[Path]], out_dir: Path):
         'volume': 'iVolume(SymbolToTrade, 0, 0)',
         'event_flag': 'GetCalendarFlag()',
         'event_impact': 'GetCalendarImpact()',
+        'book_bid_vol': 'BookBidVol()',
+        'book_ask_vol': 'BookAskVol()',
+        'book_imbalance': 'BookImbalance()',
     }
 
     tf_const = {

--- a/tests/test_train_target_clone_features.py
+++ b/tests/test_train_target_clone_features.py
@@ -32,6 +32,10 @@ def _write_sample_log(file: Path):
         "remaining_lots",
         "slippage",
         "volume",
+        "open_time",
+        "book_bid_vol",
+        "book_ask_vol",
+        "book_imbalance",
     ]
     rows = [
         [
@@ -55,6 +59,10 @@ def _write_sample_log(file: Path):
             "0.1",
             "0.0001",
             "100",
+            "",
+            "0",
+            "0",
+            "0",
         ],
         [
             "2",
@@ -77,6 +85,10 @@ def _write_sample_log(file: Path):
             "0.1",
             "0.0002",
             "200",
+            "",
+            "0",
+            "0",
+            "0",
         ],
     ]
     with open(file, "w", newline="") as f:


### PR DESCRIPTION
## Summary
- Log bid/ask volumes and imbalance from MarketBookGet in Observer_TBot logs
- Train pipeline reads new order book columns and exposes features
- StrategyTemplate and generator map order book features using MarketBookGet

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68900fddb6d8832f89ef2fdc08ec2c66