### PR TITLE
Add data provenance metadata to logs and model

### DIFF
--- a/tests/test_sqlite_service.py
+++ b/tests/test_sqlite_service.py
@@ -74,7 +74,7 @@ def test_load_logs_from_db(tmp_path: Path):
     conn.commit()
     conn.close()
 
-    df = _load_logs(db_file)
+    df, _, _ = _load_logs(db_file)
     assert not df.empty
     assert "symbol" in df.columns
     assert "slippage" in df.columns


### PR DESCRIPTION
## Summary
- export logs with JSON header and manifest containing commit hash and checksum
- capture dataset commit/checksum from manifest in training script
- ensure model.json records data provenance

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68901c006588832fb1da56f129271863