### PR TITLE
Support compressed float32 models

### DIFF
--- a/scripts/generate_mql4_from_model.py
+++ b/scripts/generate_mql4_from_model.py
@@ -2,6 +2,7 @@
 """Render MQL4 strategy file from model description."""
 import argparse
 import json
+import gzip
 from pathlib import Path
 from datetime import datetime
 from typing import Iterable, List, Union
@@ -21,7 +22,8 @@ def generate(model_jsons: Union[Path, Iterable[Path]], out_dir: Path):
         model_jsons = [model_jsons]
     models: List[dict] = []
     for mj in model_jsons:
-        with open(mj) as f:
+        open_func = gzip.open if str(mj).endswith('.gz') else open
+        with open_func(mj, 'rt') as f:
             data = json.load(f)
         sessions = data.get('session_models')
         if sessions:

--- a/scripts/publish_model.py
+++ b/scripts/publish_model.py
@@ -3,12 +3,14 @@
 
 import argparse
 import json
+import gzip
 from pathlib import Path
 
 
 def publish(model_json: Path, files_dir: Path) -> None:
-    """Copy minimal model fields to ``files_dir/model.json``."""
-    with open(model_json) as f:
+    """Copy minimal model fields to ``files_dir/model.json`` or ``model.json.gz``."""
+    open_func = gzip.open if str(model_json).endswith('.gz') else open
+    with open_func(model_json, 'rt') as f:
         data = json.load(f)
 
     out = {
@@ -20,8 +22,9 @@ def publish(model_json: Path, files_dir: Path) -> None:
     }
 
     files_dir.mkdir(parents=True, exist_ok=True)
-    dest = files_dir / "model.json"
-    with open(dest, "w") as f:
+    dest = files_dir / model_json.name
+    open_func_out = gzip.open if dest.suffix == '.gz' else open
+    with open_func_out(dest, 'wt') as f:
         json.dump(out, f, indent=2)
     print(f"Model parameters written to {dest}")
 

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -3,6 +3,7 @@ import json
 import sys
 from pathlib import Path
 import hashlib
+import gzip
 
 import pandas as pd
 import pytest
@@ -705,3 +706,19 @@ def test_train_regress_sl_tp(tmp_path: Path):
         data = json.load(f)
     assert "sl_coefficients" in data
     assert "tp_coefficients" in data
+
+
+def test_train_compress_model(tmp_path: Path):
+    data_dir = tmp_path / "logs"
+    out_dir = tmp_path / "out"
+    data_dir.mkdir()
+    log_file = data_dir / "trades_test.csv"
+    _write_log(log_file)
+
+    train(data_dir, out_dir, compress_model=True)
+
+    model_file = out_dir / "model.json.gz"
+    assert model_file.exists()
+    with gzip.open(model_file, "rt") as f:
+        data = json.load(f)
+    assert "coefficients" in data

--- a/tests/test_train_rl_agent_offline.py
+++ b/tests/test_train_rl_agent_offline.py
@@ -2,6 +2,7 @@ import csv
 import json
 from pathlib import Path
 import sys
+import gzip
 
 import pytest
 
@@ -90,3 +91,19 @@ def test_train_cql(tmp_path: Path) -> None:
         data = json.load(f)
     assert data.get("training_type") == "offline_rl"
     assert data.get("algo") == "cql"
+
+
+def test_train_cql_compress_model(tmp_path: Path) -> None:
+    data_dir = tmp_path / "logs"
+    out_dir = tmp_path / "out"
+    data_dir.mkdir()
+    out_dir.mkdir()
+    _write_log(data_dir / "trades_1.csv")
+
+    train(data_dir, out_dir, algo="cql", training_steps=5, compress_model=True)
+
+    model_file = out_dir / "model.json.gz"
+    assert model_file.exists()
+    with gzip.open(model_file, "rt") as f:
+        data = json.load(f)
+    assert data.get("training_type") == "offline_rl"


### PR DESCRIPTION
## Summary
- Downcast model coefficients, feature means, and standard deviations to `float32` before serialization.
- Add `--compress-model` option for training scripts to write gzip-compressed `model.json.gz`, and update tooling to read or publish gzipped models.
- Extend `StrategyTemplate.mq4` to load and parse `.gz` model files.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6891553f87bc832f924edd4d1383328a