### PR TITLE
Add book refresh interval and lite-mode toggle

### DIFF
--- a/scripts/generate_mql4_from_model.py
+++ b/scripts/generate_mql4_from_model.py
@@ -17,7 +17,7 @@ template_path = (
 )
 
 
-def generate(model_jsons: Union[Path, Iterable[Path]], out_dir: Path):
+def generate(model_jsons: Union[Path, Iterable[Path]], out_dir: Path, lite_mode: bool = False):
     if isinstance(model_jsons, (str, Path)):
         model_jsons = [model_jsons]
     models: List[dict] = []
@@ -255,6 +255,11 @@ def generate(model_jsons: Union[Path, Iterable[Path]], out_dir: Path):
         'book_imbalance': 'BookImbalance()',
     }
 
+    if lite_mode:
+        feature_map['book_bid_vol'] = '0.0'
+        feature_map['book_ask_vol'] = '0.0'
+        feature_map['book_imbalance'] = '0.0'
+
     tf_const = {
         'M1': 'PERIOD_M1',
         'M5': 'PERIOD_M5',
@@ -343,8 +348,9 @@ def main():
     p = argparse.ArgumentParser()
     p.add_argument('model_json', nargs='+')
     p.add_argument('out_dir')
+    p.add_argument('--lite-mode', action='store_true')
     args = p.parse_args()
-    generate([Path(m) for m in args.model_json], Path(args.out_dir))
+    generate([Path(m) for m in args.model_json], Path(args.out_dir), lite_mode=args.lite_mode)
 
 
 if __name__ == '__main__':

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -461,6 +461,29 @@ def test_generate_account_features(tmp_path: Path):
     assert "AccountMarginLevel()" in content
 
 
+def test_generate_lite_mode(tmp_path: Path):
+    model = {
+        "model_id": "lite",
+        "magic": 1,
+        "coefficients": [0.1, 0.2, 0.3],
+        "intercept": 0.0,
+        "threshold": 0.5,
+        "feature_names": ["hour", "book_bid_vol", "book_ask_vol"],
+    }
+    model_file = tmp_path / "model.json"
+    with open(model_file, "w") as f:
+        json.dump(model, f)
+
+    out_dir = tmp_path / "out"
+    generate(model_file, out_dir, lite_mode=True)
+
+    generated = list(out_dir.glob("Generated_lite_*.mq4"))
+    assert len(generated) == 1
+    content = generated[0].read_text()
+    assert content.count("BookBidVol()") == 1
+    assert content.count("BookAskVol()") == 1
+
+
 def test_generate_regime_feature(tmp_path: Path):
     model = {
         "model_id": "regime",


### PR DESCRIPTION
## Summary
- cache order book volumes and respect configurable refresh interval in Observer_TBot
- add --lite-mode to generate_mql4_from_model.py to drop order-book features
- test generation with lite-mode disabled order-book usage

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68915876f150832f8ca86f789d0ec6c9