### PR TITLE
feat: allow sqlite logging

### DIFF
--- a/experts/Observer_TBot.mq4
+++ b/experts/Observer_TBot.mq4
@@ -16,6 +16,7 @@ extern bool   EnableDebugLogging            = false;
 extern bool   UseBrokerTime                 = true;
 extern string SymbolsToTrack                = ""; // empty=all
 extern bool   EnableSocketLogging           = false;
+extern bool   EnableSqliteLogging           = false;
 extern bool   UseBinarySocketLogging        = false;
 extern string LogSocketHost                 = "127.0.0.1";
 extern int    LogSocketPort                 = 9000;
@@ -183,7 +184,7 @@ int OnInit()
       }
    }
 
-   if(EnableSocketLogging || StreamMetricsOnly)
+   if(EnableSocketLogging || EnableSqliteLogging || StreamMetricsOnly)
    {
       datetime now = UseBrokerTime ? TimeCurrent() : TimeLocal();
       next_socket_attempt = now;
@@ -442,7 +443,7 @@ void OnTimer()
    FlushTradeBuffer();
    datetime now = UseBrokerTime ? TimeCurrent() : TimeLocal();
 
-   if((EnableSocketLogging || StreamMetricsOnly) && log_socket==INVALID_HANDLE && now >= next_socket_attempt)
+   if((EnableSocketLogging || EnableSqliteLogging || StreamMetricsOnly) && log_socket==INVALID_HANDLE && now >= next_socket_attempt)
    {
       log_socket = SocketCreate();
       if(log_socket!=INVALID_HANDLE)

--- a/scripts/sqlite_log_service.py
+++ b/scripts/sqlite_log_service.py
@@ -24,9 +24,16 @@ FIELDS = [
     "sl",
     "tp",
     "profit",
+    "profit_after_trade",
+    "spread",
     "comment",
     "remaining_lots",
     "slippage",
+    "volume",
+    "open_time",
+    "book_bid_vol",
+    "book_ask_vol",
+    "book_imbalance",
 ]
 
 


### PR DESCRIPTION
## Summary
- stream trade events to sqlite logging service
- store full trade fields in sqlite DB
- read incremental events in training script

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68915a036608832f9ff582ea902bd2aa