### PR TITLE
Adapt book refresh interval based on CPU load

### DIFF
--- a/scripts/metrics_collector.py
+++ b/scripts/metrics_collector.py
@@ -30,6 +30,7 @@ FIELDS = [
     "expectancy",
     "file_write_errors",
     "socket_errors",
+    "book_refresh_seconds",
     "trace_id",
     "span_id",
 ]


### PR DESCRIPTION
## Summary
- add `GetCpuLoad` helper and track average tick duration
- adjust book refresh interval based on CPU load and log it in metrics
- extend metrics collector to handle new `book_refresh_seconds` field

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68927e6a57d8832f8aa00dbfa1a629b2