### PR TITLE
Include decision ids in trade logs

### DIFF
--- a/experts/StrategyTemplate.mq4
+++ b/experts/StrategyTemplate.mq4
@@ -797,18 +797,20 @@ void OnTick()
    int ticket;
    double thr = GetTradeThreshold();
    string action = (prob > thr) ? "buy" : "sell";
+   int decision_id = NextDecisionId;
    LogDecision(feats, prob, action);
+   string order_comment = StringFormat("model|decision_id=%d", decision_id);
    if(prob > thr)
    {
       ticket = OrderSend(SymbolToTrade, OP_BUY, tradeLots, Ask, 3,
                          GetNewSL(true), GetNewTP(true),
-                         "model", MagicNumber, 0, clrBlue);
+                         order_comment, MagicNumber, 0, clrBlue);
    }
    else
    {
       ticket = OrderSend(SymbolToTrade, OP_SELL, tradeLots, Bid, 3,
                          GetNewSL(false), GetNewTP(false),
-                         "model", MagicNumber, 0, clrRed);
+                         order_comment, MagicNumber, 0, clrRed);
    }
 
    if(ticket < 0)

--- a/scripts/socket_log_service.py
+++ b/scripts/socket_log_service.py
@@ -35,6 +35,7 @@ FIELDS = [
     "profit",
     "comment",
     "remaining_lots",
+    "decision_id",
     "trace_id",
     "span_id",
 ]

--- a/scripts/sqlite_log_service.py
+++ b/scripts/sqlite_log_service.py
@@ -34,6 +34,7 @@ FIELDS = [
     "book_bid_vol",
     "book_ask_vol",
     "book_imbalance",
+    "decision_id",
 ]
 
 


### PR DESCRIPTION
## Summary
- Tag each executed order with its originating decision ID in StrategyTemplate
- Parse decision IDs from order comments and record them in Observer trade logs
- Extend socket and SQLite log services plus tests to support the new decision_id field

## Testing
- `pytest tests/test_stream_listener.py tests/test_socket_log_service_binary.py tests/test_logging_basic.py tests/test_sqlite_service.py`

------
https://chatgpt.com/codex/tasks/task_e_6893bd8dec70832f9903eb35c576199f