### PR TITLE
Log SL/TP hit distances

### DIFF
--- a/experts/Observer_TBot.mq4
+++ b/experts/Observer_TBot.mq4
@@ -712,15 +712,24 @@ void LogTrade(string action, int ticket, int magic, string source,
    string open_time_str = "";
    if(action=="CLOSE" && open_time>0)
       open_time_str = TimeToString(open_time, TIME_DATE|TIME_SECONDS);
+   double sl_hit_dist = 0.0;
+   double tp_hit_dist = 0.0;
+   if(action=="CLOSE")
+   {
+      if(sl!=0.0)
+         sl_hit_dist = MathAbs(price - sl);
+      if(tp!=0.0)
+         tp_hit_dist = MathAbs(price - tp);
+   }
    string line = StringFormat(
-      "%d;%s;%s;%s;%s;%d;%d;%s;%s;%d;%.2f;%.5f;%.5f;%.5f;%.2f;%.2f;%d;%s;%.2f;%.5f;%d;%s;%.2f;%.2f;%.5f;%d",
+      "%d;%s;%s;%s;%s;%d;%d;%s;%s;%d;%.2f;%.5f;%.5f;%.5f;%.2f;%.2f;%d;%s;%.2f;%.5f;%d;%s;%.2f;%.2f;%.5f;%.5f;%.5f;%d",
       id,
       TimeToString(time_event, TIME_DATE|TIME_SECONDS),
       TimeToString(TimeCurrent(), TIME_DATE|TIME_SECONDS),
       TimeToString(TimeLocal(), TIME_DATE|TIME_SECONDS),
       action, ticket, magic, source, symbol, order_type, lots, price, sl, tp,
       profit, profit_after, spread, comment, remaining, slippage, (int)volume,
-      open_time_str, book_bid_vol, book_ask_vol, book_imbalance, decision_id);
+      open_time_str, book_bid_vol, book_ask_vol, book_imbalance, sl_hit_dist, tp_hit_dist, decision_id);
 
    if(CurrentBackend==LOG_BACKEND_CSV)
    {
@@ -746,27 +755,27 @@ void LogTrade(string action, int ticket, int magic, string source,
       if(log_db_handle!=INVALID_HANDLE)
       {
          string sql = StringFormat(
-            "INSERT INTO logs (event_id,event_time,broker_time,local_time,action,ticket,magic,source,symbol,order_type,lots,price,sl,tp,profit,profit_after_trade,spread,comment,remaining_lots,slippage,volume,open_time,book_bid_vol,book_ask_vol,book_imbalance) VALUES (%d,'%s','%s','%s','%s',%d,%d,'%s','%s',%d,%.2f,%.5f,%.5f,%.5f,%.2f,%.2f,%d,'%s',%.2f,%.5f,%d,'%s',%.2f,%.2f,%.5f)",
+            "INSERT INTO logs (event_id,event_time,broker_time,local_time,action,ticket,magic,source,symbol,order_type,lots,price,sl,tp,profit,profit_after_trade,spread,comment,remaining_lots,slippage,volume,open_time,book_bid_vol,book_ask_vol,book_imbalance,sl_hit_dist,tp_hit_dist) VALUES (%d,'%s','%s','%s','%s',%d,%d,'%s','%s',%d,%.2f,%.5f,%.5f,%.5f,%.2f,%.2f,%d,'%s',%.2f,%.5f,%d,'%s',%.2f,%.2f,%.5f,%.5f,%.5f)",
             id,
             SqlEscape(TimeToString(time_event, TIME_DATE|TIME_SECONDS)),
             SqlEscape(TimeToString(TimeCurrent(), TIME_DATE|TIME_SECONDS)),
             SqlEscape(TimeToString(TimeLocal(), TIME_DATE|TIME_SECONDS)),
             SqlEscape(action), ticket, magic, SqlEscape(source), SqlEscape(symbol), order_type,
             lots, price, sl, tp, profit, profit_after, spread, SqlEscape(comment), remaining,
-            slippage, (int)volume, SqlEscape(open_time_str), book_bid_vol, book_ask_vol, book_imbalance);
+            slippage, (int)volume, SqlEscape(open_time_str), book_bid_vol, book_ask_vol, book_imbalance, sl_hit_dist, tp_hit_dist);
          DatabaseExecute(log_db_handle, sql);
       }
    }
 
    string json = StringFormat(
-      "{\"schema_version\":%d,\"event_id\":%d,\"trace_id\":\"%s\",\"event_time\":\"%s\",\"broker_time\":\"%s\",\"local_time\":\"%s\",\"action\":\"%s\",\"ticket\":%d,\"magic\":%d,\"source\":\"%s\",\"symbol\":\"%s\",\"order_type\":%d,\"lots\":%.2f,\"price\":%.5f,\"sl\":%.5f,\"tp\":%.5f,\"profit\":%.2f,\"profit_after_trade\":%.2f,\"spread\":%d,\"comment\":\"%s\",\"remaining_lots\":%.2f,\"slippage\":%.5f,\"volume\":%d,\"open_time\":\"%s\",\"book_bid_vol\":%.2f,\"book_ask_vol\":%.2f,\"book_imbalance\":%.5f,\"decision_id\":%d}",
+      "{\"schema_version\":%d,\"event_id\":%d,\"trace_id\":\"%s\",\"event_time\":\"%s\",\"broker_time\":\"%s\",\"local_time\":\"%s\",\"action\":\"%s\",\"ticket\":%d,\"magic\":%d,\"source\":\"%s\",\"symbol\":\"%s\",\"order_type\":%d,\"lots\":%.2f,\"price\":%.5f,\"sl\":%.5f,\"tp\":%.5f,\"profit\":%.2f,\"profit_after_trade\":%.2f,\"spread\":%d,\"comment\":\"%s\",\"remaining_lots\":%.2f,\"slippage\":%.5f,\"volume\":%d,\"open_time\":\"%s\",\"book_bid_vol\":%.2f,\"book_ask_vol\":%.2f,\"book_imbalance\":%.5f,\"sl_hit_dist\":%.5f,\"tp_hit_dist\":%.5f,\"decision_id\":%d}",
       LogSchemaVersion, id, EscapeJson(TraceId),
       EscapeJson(TimeToString(time_event, TIME_DATE|TIME_SECONDS)),
       EscapeJson(TimeToString(TimeCurrent(), TIME_DATE|TIME_SECONDS)),
       EscapeJson(TimeToString(TimeLocal(), TIME_DATE|TIME_SECONDS)),
       EscapeJson(action), ticket, magic, EscapeJson(source), EscapeJson(symbol), order_type,
       lots, price, sl, tp, profit, profit_after, spread, EscapeJson(comment), remaining,
-      slippage, (int)volume, EscapeJson(open_time_str), book_bid_vol, book_ask_vol, book_imbalance, decision_id);
+      slippage, (int)volume, EscapeJson(open_time_str), book_bid_vol, book_ask_vol, book_imbalance, sl_hit_dist, tp_hit_dist, decision_id);
 
    SendJson(json);
 }

--- a/experts/StrategyTemplate.mq4
+++ b/experts/StrategyTemplate.mq4
@@ -704,6 +704,8 @@ void LogDecision(double &feats[], double prob, string action)
 {
    if(!EnableDecisionLogging)
       return;
+   double sl_dist = PredictSLDistance();
+   double tp_dist = PredictTPDistance();
    string feat_vals = "";
    for(int i=0; i<FeatureCount; i++)
    {
@@ -713,13 +715,13 @@ void LogDecision(double &feats[], double prob, string action)
    datetime now = TimeCurrent();
    if(DecisionLogHandle != INVALID_HANDLE)
    {
-      FileWrite(DecisionLogHandle, NextDecisionId, TimeToString(now, TIME_DATE|TIME_SECONDS), ModelVersion, action, prob, feat_vals);
+      FileWrite(DecisionLogHandle, NextDecisionId, TimeToString(now, TIME_DATE|TIME_SECONDS), ModelVersion, action, prob, sl_dist, tp_dist, feat_vals);
       FileFlush(DecisionLogHandle);
    }
    if(DecisionSocket != INVALID_HANDLE)
    {
-      string json = StringFormat("{\"event_id\":%d,\"timestamp\":\"%s\",\"model_version\":\"%s\",\"action\":\"%s\",\"probability\":%.6f,\"features\":[%s]}",
-                                 NextDecisionId, TimeToString(now, TIME_DATE|TIME_SECONDS), ModelVersion, action, prob, feat_vals);
+      string json = StringFormat("{\"event_id\":%d,\"timestamp\":\"%s\",\"model_version\":\"%s\",\"action\":\"%s\",\"probability\":%.6f,\"sl_dist\":%.5f,\"tp_dist\":%.5f,\"features\":[%s]}",
+                                 NextDecisionId, TimeToString(now, TIME_DATE|TIME_SECONDS), ModelVersion, action, prob, sl_dist, tp_dist, feat_vals);
       uchar bytes[];
       StringToCharArray(json+"\n", bytes, 0, WHOLE_ARRAY, CP_UTF8);
       SocketSend(DecisionSocket, bytes, ArraySize(bytes)-1);

--- a/scripts/sqlite_log_service.py
+++ b/scripts/sqlite_log_service.py
@@ -34,6 +34,8 @@ FIELDS = [
     "book_bid_vol",
     "book_ask_vol",
     "book_imbalance",
+    "sl_hit_dist",
+    "tp_hit_dist",
     "decision_id",
 ]
 

--- a/scripts/train_target_clone.py
+++ b/scripts/train_target_clone.py
@@ -378,6 +378,10 @@ def _load_logs(
         "price",
         "sl",
         "tp",
+        "sl_dist",
+        "tp_dist",
+        "sl_hit_dist",
+        "tp_hit_dist",
         "profit",
         "spread",
         "comment",
@@ -693,8 +697,10 @@ def _extract_features(
         dow_sin = math.sin(2 * math.pi * t.weekday() / 7)
         dow_cos = math.cos(2 * math.pi * t.weekday() / 7)
 
-        sl_dist = sl - price
-        tp_dist = tp - price
+        sl_dist = _safe_float(r.get("sl_dist", sl - price))
+        tp_dist = _safe_float(r.get("tp_dist", tp - price))
+        sl_hit = _safe_float(r.get("sl_hit_dist", 0.0))
+        tp_hit = _safe_float(r.get("tp_hit_dist", 0.0))
 
         feat = {
             "symbol": symbol,
@@ -706,6 +712,8 @@ def _extract_features(
             "profit": profit,
             "sl_dist": sl_dist,
             "tp_dist": tp_dist,
+            "sl_hit_dist": sl_hit,
+            "tp_hit_dist": tp_hit,
             "spread": spread,
             "equity": account_equity,
             "margin_level": margin_level,

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -39,6 +39,8 @@ def _write_log(file: Path):
         "remaining_lots",
         "slippage",
         "volume",
+        "sl_hit_dist",
+        "tp_hit_dist",
     ]
     rows = [
         [
@@ -62,6 +64,8 @@ def _write_log(file: Path):
             "0.1",
             "0.0001",
             "100",
+            "0",
+            "0",
         ],
         [
             "2",
@@ -84,6 +88,8 @@ def _write_log(file: Path):
             "0.1",
             "0.0002",
             "200",
+            "0",
+            "0",
         ],
     ]
     with open(file, "w", newline="") as f:
@@ -114,6 +120,8 @@ def _write_log_many(file: Path, count: int = 10):
         "remaining_lots",
         "slippage",
         "volume",
+        "sl_hit_dist",
+        "tp_hit_dist",
     ]
     rows = []
     for i in range(count):
@@ -140,6 +148,8 @@ def _write_log_many(file: Path, count: int = 10):
             "0.1",
             "0.0001",
             str(100 + i),
+            "0",
+            "0",
         ])
     with open(file, "w", newline="") as f:
         writer = csv.writer(f, delimiter=";")

--- a/tests/test_train_target_clone_features.py
+++ b/tests/test_train_target_clone_features.py
@@ -37,6 +37,8 @@ def _write_sample_log(file: Path):
         "book_bid_vol",
         "book_ask_vol",
         "book_imbalance",
+        "sl_hit_dist",
+        "tp_hit_dist",
     ]
     rows = [
         [
@@ -64,6 +66,8 @@ def _write_sample_log(file: Path):
             "0",
             "0",
             "0",
+            "0",
+            "0",
         ],
         [
             "2",
@@ -87,6 +91,8 @@ def _write_sample_log(file: Path):
             "0.0002",
             "200",
             "",
+            "0",
+            "0",
             "0",
             "0",
             "0",
@@ -122,6 +128,8 @@ def test_feature_extraction_basic():
     assert "spread" in feats[0]
     assert "slippage" in feats[0]
     assert "equity" in feats[0] and "margin_level" in feats[0]
+    assert "sl_dist" in feats[0] and "tp_dist" in feats[0]
+    assert "sl_hit_dist" in feats[0] and "tp_hit_dist" in feats[0]
 
 
 def test_model_serialization(tmp_path: Path):


### PR DESCRIPTION
## Summary
- Log predicted sl_dist and tp_dist in decision events
- Capture realized sl_hit_dist and tp_hit_dist on trade close
- Consume new stop-loss/take-profit fields during feature extraction and tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68941f50a14c832fb4ba539e36a03774