### PR TITLE
Add Optuna optimization and tests for target clone training

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,13 +88,15 @@ whose mean absolute SHAP value falls below this threshold are removed and the
 classifier is refit on the reduced set. A warning is emitted when pruning
 eliminates more than the fraction specified via ``--prune-warn``.
 
-Hyperparameters can be optimised automatically when `optuna` is installed. If
-`optuna` is missing the script trains with default parameters and continues.
-The best trial's parameters and validation score are saved to `model.json`:
+Hyperparameters, model type, decision threshold and feature selection can be
+optimised automatically when `optuna` is installed. If `optuna` is missing the
+script trains with default parameters and continues. The best trial's
+parameters and validation score are saved to `model.json` along with a summary
+of the study:
 
 ```bash
 pip install optuna
-python train_target_clone.py --data-dir "C:\\path\\to\\observer_logs" --out-dir models --optuna-trials 50
+python scripts/train_target_clone.py --data-dir "C:\\path\\to\\observer_logs" --out-dir models --optuna-trials 50
 ```
 
 Optuna explores learning rate, tree depth or regularisation strength depending

--- a/tests/test_train_target_clone_optuna.py
+++ b/tests/test_train_target_clone_optuna.py
@@ -1,0 +1,119 @@
+import csv
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from scripts.train_target_clone import train
+
+
+def _write_sample_log(file: Path):
+    fields = [
+        "event_id",
+        "event_time",
+        "broker_time",
+        "local_time",
+        "action",
+        "ticket",
+        "magic",
+        "source",
+        "symbol",
+        "order_type",
+        "lots",
+        "price",
+        "sl",
+        "tp",
+        "profit",
+        "spread",
+        "comment",
+        "remaining_lots",
+        "slippage",
+        "volume",
+        "open_time",
+        "book_bid_vol",
+        "book_ask_vol",
+        "book_imbalance",
+        "sl_hit_dist",
+        "tp_hit_dist",
+    ]
+    rows = [
+        [
+            "1",
+            "2024.01.01 00:00:00",
+            "",
+            "",
+            "OPEN",
+            "1",
+            "",
+            "",
+            "EURUSD",
+            "0",
+            "0.1",
+            "1.1000",
+            "1.0950",
+            "1.1100",
+            "0",
+            "2",
+            "",
+            "0.1",
+            "0.0001",
+            "100",
+            "",
+            "0",
+            "0",
+            "0",
+            "0",
+            "0",
+        ],
+        [
+            "2",
+            "2024.01.01 01:00:00",
+            "",
+            "",
+            "OPEN",
+            "2",
+            "",
+            "",
+            "EURUSD",
+            "1",
+            "0.1",
+            "1.2000",
+            "1.1950",
+            "1.2100",
+            "0",
+            "3",
+            "",
+            "0.1",
+            "0.0002",
+            "200",
+            "",
+            "0",
+            "0",
+            "0",
+            "0",
+            "0",
+        ],
+    ]
+    with open(file, "w", newline="") as f:
+        writer = csv.writer(f, delimiter=";")
+        writer.writerow(fields)
+        writer.writerows(rows)
+
+def test_optuna_study_serialization(tmp_path: Path):
+    pytest.importorskip("optuna")
+    data_dir = tmp_path / "logs"
+    out_dir = tmp_path / "out"
+    data_dir.mkdir()
+    _write_sample_log(data_dir / "trades_sample.csv")
+
+    train(data_dir, out_dir, optuna_trials=1)
+
+    model_file = out_dir / "model.json"
+    assert model_file.exists()
+    with open(model_file) as f:
+        data = json.load(f)
+    assert "optuna_best_params" in data
+    assert "optuna_trials" in data and data["optuna_trials"]
+    assert data.get("optuna_study", {}).get("n_trials") == 1


### PR DESCRIPTION
## Summary
- allow `train_target_clone.py` to tune model type, threshold and feature subsets via Optuna
- persist Optuna study details in `model.json`
- document Optuna usage and add regression test

## Testing
- `pip show optuna`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68955aa48cbc832fb09a7370f95479b6