### PR TITLE
Add gRPC logging service and integrate client in observer EA

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ The EA records trade openings and closings using the `OnTradeTransaction` callba
   - `promote_best_models.py` – selects top models by metric and copies them to a best directory.
   - `plot_metrics.py` – plot metric history using Matplotlib.
   - `plot_feature_importance.py` – display SHAP feature importances saved in `model.json`.
+  - `grpc_log_service.py` – gRPC server receiving trade and metric logs.
 - `models/` – location for generated models.
 - `config.json` – example configuration file.
 
@@ -247,14 +248,15 @@ After completing a trial run commit both `run_info.json` files along with the ge
 ## Real-time Streaming
 
 On start-up the observer EA tries to stream each trade event and periodic
-metric summary over a TCP socket. If the socket server cannot be reached it
+metric summary over gRPC. If the channel cannot be reached it
 falls back to writing a SQLite database ``trades_raw.sqlite`` and finally to a
-CSV file ``trades_raw.csv``. A log message indicates which backend was chosen.
-Run the ``socket_log_service.py`` helper to capture socket messages into a CSV
-file. The service now uses ``asyncio`` to handle multiple connections concurrently:
+CSV file ``trades_raw.csv``. Configure the destination via the ``GrpcHost``
+and ``GrpcPort`` inputs (default ``127.0.0.1:50051``).
+
+Run the ``grpc_log_service.py`` helper to capture RPC messages into CSV files:
 
 ```bash
-python scripts/socket_log_service.py --out stream.csv
+python scripts/grpc_log_service.py --trade-out trades.csv --metrics-out metrics.csv
 ```
 
 For persistent storage you can instead log directly to a SQLite database using ``sqlite_log_service.py``:

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ prometheus_client
 opentelemetry-sdk
 opentelemetry-exporter-otlp
 protobuf
+grpcio
 
 # Optional extras
 xgboost; extra == "xgboost"

--- a/scripts/grpc_log_service.py
+++ b/scripts/grpc_log_service.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""gRPC service that logs trade and metric events to CSV files."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+from concurrent import futures
+from pathlib import Path
+
+import grpc
+from google.protobuf import empty_pb2
+
+from proto import trade_event_pb2, metrics_pb2
+
+TRADE_FIELDS = [
+    "event_id",
+    "event_time",
+    "broker_time",
+    "local_time",
+    "action",
+    "ticket",
+    "magic",
+    "source",
+    "symbol",
+    "order_type",
+    "lots",
+    "price",
+    "sl",
+    "tp",
+    "profit",
+    "profit_after_trade",
+    "spread",
+    "comment",
+    "remaining_lots",
+    "slippage",
+    "volume",
+    "open_time",
+    "book_bid_vol",
+    "book_ask_vol",
+    "book_imbalance",
+    "sl_hit_dist",
+    "tp_hit_dist",
+    "decision_id",
+]
+
+METRIC_FIELDS = [
+    "time",
+    "magic",
+    "win_rate",
+    "avg_profit",
+    "trade_count",
+    "drawdown",
+    "sharpe",
+    "file_write_errors",
+    "socket_errors",
+    "book_refresh_seconds",
+]
+
+
+class _LogService:
+    def __init__(self, trade_out: Path, metrics_out: Path) -> None:
+        self.trade_out = Path(trade_out)
+        self.metrics_out = Path(metrics_out)
+        self.trade_out.parent.mkdir(parents=True, exist_ok=True)
+        self.metrics_out.parent.mkdir(parents=True, exist_ok=True)
+
+    def _append(self, out: Path, fields: list[str], obj) -> None:
+        first = not out.exists()
+        with out.open("a", newline="") as f:
+            writer = csv.writer(f, delimiter=";")
+            if first:
+                writer.writerow(fields)
+            writer.writerow([getattr(obj, f) for f in fields])
+
+    def LogTrade(self, request, context):  # noqa: N802 gRPC naming
+        self._append(self.trade_out, TRADE_FIELDS, request)
+        return empty_pb2.Empty()
+
+    def LogMetrics(self, request, context):  # noqa: N802 gRPC naming
+        self._append(self.metrics_out, METRIC_FIELDS, request)
+        return empty_pb2.Empty()
+
+
+def create_server(host: str, port: int, trade_out: Path, metrics_out: Path) -> grpc.Server:
+    service = _LogService(trade_out, metrics_out)
+    server = grpc.server(futures.ThreadPoolExecutor(max_workers=10))
+    trade_handler = grpc.unary_unary_rpc_method_handler(
+        service.LogTrade,
+        request_deserializer=trade_event_pb2.TradeEvent.FromString,
+        response_serializer=empty_pb2.Empty.SerializeToString,
+    )
+    metrics_handler = grpc.unary_unary_rpc_method_handler(
+        service.LogMetrics,
+        request_deserializer=metrics_pb2.Metrics.FromString,
+        response_serializer=empty_pb2.Empty.SerializeToString,
+    )
+    handler = grpc.method_handlers_generic_handler(
+        "tbot.LogService",
+        {"LogTrade": trade_handler, "LogMetrics": metrics_handler},
+    )
+    server.add_generic_rpc_handlers((handler,))
+    server.add_insecure_port(f"{host}:{port}")
+    return server
+
+
+def serve(host: str, port: int, trade_out: Path, metrics_out: Path) -> None:
+    server = create_server(host, port, trade_out, metrics_out)
+    server.start()
+    server.wait_for_termination()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="gRPC log service")
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=50051)
+    parser.add_argument("--trade-out", default="trades.csv", help="trade CSV output")
+    parser.add_argument("--metrics-out", default="metrics.csv", help="metrics CSV output")
+    args = parser.parse_args()
+
+    serve(args.host, args.port, Path(args.trade_out), Path(args.metrics_out))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_grpc_log_service.py
+++ b/tests/test_grpc_log_service.py
@@ -1,0 +1,67 @@
+import socket
+from pathlib import Path
+
+import grpc
+
+from proto import trade_event_pb2, metrics_pb2
+from scripts import grpc_log_service
+
+
+def test_grpc_log_service(tmp_path: Path):
+    host = "127.0.0.1"
+    srv_sock = socket.socket()
+    srv_sock.bind((host, 0))
+    port = srv_sock.getsockname()[1]
+    srv_sock.close()
+
+    trade_out = tmp_path / "trades.csv"
+    metrics_out = tmp_path / "metrics.csv"
+    server = grpc_log_service.create_server(host, port, trade_out, metrics_out)
+    server.start()
+    try:
+        channel = grpc.insecure_channel(f"{host}:{port}")
+        log_trade = channel.unary_unary(
+            "/tbot.LogService/LogTrade",
+            request_serializer=lambda x: x.SerializeToString(),
+        )
+        log_metrics = channel.unary_unary(
+            "/tbot.LogService/LogMetrics",
+            request_serializer=lambda x: x.SerializeToString(),
+        )
+
+        trade = trade_event_pb2.TradeEvent(
+            event_id=1,
+            event_time="t",
+            broker_time="b",
+            local_time="l",
+            action="OPEN",
+            ticket=1,
+            magic=2,
+            source="mt4",
+            symbol="EURUSD",
+            order_type=0,
+            lots=0.1,
+            price=1.2345,
+        )
+        log_trade(trade)
+
+        metrics = metrics_pb2.Metrics(
+            time="t",
+            magic=2,
+            win_rate=0.5,
+            avg_profit=1.0,
+            trade_count=1,
+            drawdown=0.1,
+            sharpe=1.2,
+            file_write_errors=0,
+            socket_errors=0,
+            book_refresh_seconds=5,
+        )
+        log_metrics(metrics)
+    finally:
+        server.stop(0)
+
+    assert trade_out.exists()
+    assert metrics_out.exists()
+    assert "EURUSD" in trade_out.read_text()
+    assert "0.5" in metrics_out.read_text()


### PR DESCRIPTION
## Summary
- add grpc_log_service with LogTrade and LogMetrics RPCs for CSV logging
- switch Observer_TBot to gRPC client DLL with file logging fallback
- document gRPC settings and add tests for RPC logging

## Testing
- `pytest tests/test_grpc_log_service.py`

------
https://chatgpt.com/codex/tasks/task_e_68956c3b32ec832f83824d51b6632697