### PR TITLE
Add regime clustering and routing support

### DIFF
--- a/experts/StrategyTemplate.mq4
+++ b/experts/StrategyTemplate.mq4
@@ -78,6 +78,10 @@ int EncoderDim = __ENCODER_DIM__;
 double EncoderWeights[] = {__ENCODER_WEIGHTS__};
 int EncoderCenterCount = __ENCODER_CENTER_COUNT__;
 double EncoderCenters[] = {__ENCODER_CENTERS__};
+int RegimeCount = __REGIME_COUNT__;
+int RegimeFeatureCount = __REGIME_FEATURE_COUNT__;
+double RegimeCenters[__REGIME_COUNT__][__REGIME_FEATURE_COUNT__] = {__REGIME_CENTERS__};
+int RegimeFeatureIdx[] = {__REGIME_FEATURE_IDX__};
 datetime LastModelLoad = 0;
 int      DecisionLogHandle = INVALID_HANDLE;
 int      DecisionSocket = INVALID_HANDLE;
@@ -343,20 +347,17 @@ double GetEncodedFeature(int idx)
 
 int GetRegime()
 {
-   if(EncoderCenterCount <= 0)
-      return(0);
-   double enc[100];
-   for(int i=0; i<EncoderDim && i<100; i++)
-      enc[i] = GetEncodedFeature(i);
+   double feats[100];
+   for(int i=0; i<RegimeFeatureCount && i<100; i++)
+      feats[i] = GetFeature(RegimeFeatureIdx[i]);
    int best = 0;
    double bestDist = 0.0;
-   for(int c=0; c<EncoderCenterCount; c++)
+   for(int c=0; c<RegimeCount; c++)
    {
       double d = 0.0;
-      int base = c * EncoderDim;
-      for(int j=0; j<EncoderDim; j++)
+      for(int j=0; j<RegimeFeatureCount; j++)
       {
-         double diff = enc[j] - EncoderCenters[base + j];
+         double diff = feats[j] - RegimeCenters[c][j];
          d += diff * diff;
       }
       if(c == 0 || d < bestDist)

--- a/scripts/cluster_regimes.py
+++ b/scripts/cluster_regimes.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Cluster historical feature vectors into market regimes.
+
+This utility loads trade logs using the same feature extraction pipeline as
+:mod:`train_target_clone` and runs a clustering algorithm (KMeans by default)
+ to label distinct market regimes.  The resulting cluster centers and
+scaling information are written to ``regime_model.json`` so that training and
+real-time systems can detect the current regime.
+"""
+import argparse
+import json
+from pathlib import Path
+from typing import List
+
+import numpy as np
+from sklearn.cluster import KMeans
+from sklearn.feature_extraction import DictVectorizer
+
+try:  # optional dependency
+    import hdbscan  # type: ignore
+except Exception:  # pragma: no cover - optional
+    hdbscan = None
+
+# Reuse data loading and feature extraction from training script
+from train_target_clone import _load_logs, _extract_features  # type: ignore
+
+
+def cluster_features(
+    data_dir: Path, out_file: Path, clusters: int = 3, algorithm: str = "kmeans"
+) -> None:
+    """Cluster feature vectors and write model to ``out_file``."""
+    rows_df, _, _ = _load_logs(data_dir)
+    feats, *_ = _extract_features(rows_df.to_dict("records"))
+    if not feats:
+        raise ValueError("No features found for clustering")
+
+    vec = DictVectorizer(sparse=False)
+    X = vec.fit_transform(feats)
+    mean = X.mean(axis=0)
+    std = X.std(axis=0)
+    std[std == 0] = 1.0
+    X_scaled = (X - mean) / std
+
+    if algorithm == "hdbscan" and hdbscan is not None:
+        clusterer = hdbscan.HDBSCAN(min_cluster_size=max(2, clusters))
+        labels = clusterer.fit_predict(X_scaled)
+        centers: List[np.ndarray] = []
+        for lbl in sorted(set(labels)):
+            if lbl == -1:
+                continue  # noise
+            centers.append(X_scaled[labels == lbl].mean(axis=0))
+        centers_arr = np.vstack(centers) if centers else np.empty((0, X.shape[1]))
+        algo_name = "hdbscan"
+    else:
+        km = KMeans(n_clusters=clusters, n_init=10, random_state=42)
+        km.fit(X_scaled)
+        centers_arr = km.cluster_centers_
+        algo_name = "kmeans"
+
+    model = {
+        "feature_names": vec.get_feature_names_out().tolist(),
+        "mean": mean.astype(float).tolist(),
+        "std": std.astype(float).tolist(),
+        "centers": centers_arr.astype(float).tolist(),
+        "algorithm": algo_name,
+    }
+    out_file.write_text(json.dumps(model))
+
+
+def main() -> None:
+    p = argparse.ArgumentParser()
+    p.add_argument("--data-dir", required=True, type=Path)
+    p.add_argument("--out-file", type=Path, default=Path("regime_model.json"))
+    p.add_argument("--clusters", type=int, default=3, help="number of regimes")
+    p.add_argument(
+        "--algorithm",
+        choices=["kmeans", "hdbscan"],
+        default="kmeans",
+        help="clustering algorithm",
+    )
+    args = p.parse_args()
+    cluster_features(args.data_dir, args.out_file, args.clusters, args.algorithm)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add cluster_regimes.py to learn market regime clusters
- include regime IDs during training and export regime centers
- update model generator and MQL4 template to compute regimes and dispatch predictions

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68957b57293c832f9998932f53360131