### PR TITLE
Add mixture-of-experts option with gating model

### DIFF
--- a/scripts/generate_mql4_from_model.py
+++ b/scripts/generate_mql4_from_model.py
@@ -81,6 +81,21 @@ def generate(model_jsons: Union[Path, Iterable[Path]], out_dir: Path, lite_mode:
     output = output.replace('__INTERCEPTS__', ', '.join(intercepts))
     output = output.replace('__MODEL_COUNT__', str(len(models)))
 
+    g_coeff = base.get('gating_coefficients', [])
+    if isinstance(g_coeff, list) and g_coeff and isinstance(g_coeff[0], list):
+        flat = [c for row in g_coeff for c in row]
+    else:
+        flat = g_coeff
+    g_rows: List[str] = []
+    if flat:
+        for i in range(len(models)):
+            row = flat[i * feature_count : (i + 1) * feature_count]
+            g_rows.append('{' + ', '.join(_fmt(c) for c in row) + '}')
+    output = output.replace('__GATING_COEFFICIENTS__', ', '.join(g_rows))
+    g_inter = base.get('gating_intercepts', [])
+    g_inter_str = ', '.join(_fmt(x) for x in g_inter) if g_inter else ''
+    output = output.replace('__GATING_INTERCEPTS__', g_inter_str)
+
     cal_coef = _fmt(base.get('calibration_coef', 1.0))
     cal_inter = _fmt(base.get('calibration_intercept', 0.0))
     output = output.replace('__CAL_COEF__', cal_coef)


### PR DESCRIPTION
## Summary
- add `--moe` flag to train separate symbol experts and a gating classifier
- store expert coefficients and gating weights in `model.json`
- update code generation and template so EA evaluates gating model and selects the appropriate expert

## Testing
- `pytest tests/test_generate.py tests/test_train_target_clone_features.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68968b039248832faf5172f2382b80cb