### PR TITLE
Add DVC tracking and training pipeline

### DIFF
--- a/.dvc/.gitignore
+++ b/.dvc/.gitignore
@@ -1,0 +1,3 @@
+/config.local
+/tmp
+/cache

--- a/.dvc/config
+++ b/.dvc/config
@@ -1,0 +1,2 @@
+['core']
+    analytics = false

--- a/.dvcignore
+++ b/.dvcignore
@@ -1,0 +1,3 @@
+# Add patterns of files dvc should ignore, which could improve
+# the performance. Learn more at
+# https://dvc.org/doc/user-guide/dvcignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt dvc
+      - name: Verify DVC data hashes
+        run: dvc status
+      - name: Run tests
+        run: pytest

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ models/best/
 *.temp
 *~
 *.swp
+/models

--- a/README.md
+++ b/README.md
@@ -54,6 +54,19 @@ The EA records trade openings and closings using the `OnTradeTransaction` callba
    python scripts/promote_best_models.py models --dest models/best
    ```
 
+
+### DVC Pipeline
+
+The `observer_logs/` and `models/` directories are tracked with [DVC](https://dvc.org). A basic workflow:
+
+```bash
+# reproduce training and upload logs
+dvc repro train_pipeline
+# push artifacts and metadata
+dvc push
+# verify data hashes
+dvc status
+```
 ## External Training
 
 Exported logs can be processed by the Python scripts.  A typical workflow is:

--- a/dvc.lock
+++ b/dvc.lock
@@ -1,0 +1,31 @@
+schema: '2.0'
+stages:
+  train_pipeline:
+    cmd: python scripts/upload_logs.py && python scripts/train_target_clone.py 
+      --data-dir observer_logs --out-dir models --learning-rate 0.1 
+      --n-estimators 100
+    deps:
+    - path: observer_logs
+      hash: md5
+      md5: d751713988987e9331980363e24189ce.dir
+      size: 0
+      nfiles: 0
+    - path: scripts/train_target_clone.py
+      hash: md5
+      md5: 95719d9afb4b029ae113a36075543fd0
+      size: 94657
+      isexec: true
+    - path: scripts/upload_logs.py
+      hash: md5
+      md5: 814effe1ae2114638687e01ac76710ef
+      size: 1972
+    params:
+      params.yaml:
+        training.learning_rate: 0.1
+        training.n_estimators: 100
+    outs:
+    - path: models
+      hash: md5
+      md5: d751713988987e9331980363e24189ce.dir
+      size: 0
+      nfiles: 0

--- a/dvc.yaml
+++ b/dvc.yaml
@@ -1,0 +1,14 @@
+stages:
+  train_pipeline:
+    cmd: python scripts/upload_logs.py && python scripts/train_target_clone.py --data-dir observer_logs --out-dir models --learning-rate 0.1 --n-estimators 100
+    deps:
+      - observer_logs
+      - scripts/train_target_clone.py
+      - scripts/upload_logs.py
+    params:
+      - training.learning_rate
+      - training.n_estimators
+    meta:
+      commit: ce4d18fe3e26793c55a17a992472d02fe78d3c9e
+    outs:
+      - models

--- a/params.yaml
+++ b/params.yaml
@@ -1,0 +1,3 @@
+training:
+  learning_rate: 0.1
+  n_estimators: 100


### PR DESCRIPTION
## Summary
- initialize DVC and track `observer_logs/` and `models/`
- add train pipeline stage with commit metadata and params
- document DVC workflow and add CI check for dataset hashes

## Testing
- `dvc status`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68969e0125f4832f9821872b73041746