### PR TITLE
Integrate meta-strategy gating for regime-based model selection

### DIFF
--- a/experts/StrategyTemplate.mq4
+++ b/experts/StrategyTemplate.mq4
@@ -798,19 +798,11 @@ void OnTick()
       return;
    }
 
+   double prob = GetProbability();
+
    double feats[100];
    for(int i=0; i<FeatureCount && i<100; i++)
       feats[i] = GetFeature(i);
-
-   double prob_sum = 0.0;
-   for(int m=0; m<ModelCount; m++)
-   {
-      double z = ModelIntercepts[m];
-      for(int i=0; i<FeatureCount; i++)
-         z += ModelCoefficients[m][i] * feats[i];
-      prob_sum += 1.0 / (1.0 + MathExp(-z));
-   }
-   double prob = prob_sum / MathMax(ModelCount,1);
 
    if(EnableDebugLogging)
    {

--- a/scripts/meta_strategy.py
+++ b/scripts/meta_strategy.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Train a meta-classifier that maps regime features to best base model."""
+import argparse
+import json
+from pathlib import Path
+from typing import Dict, Iterable, List
+
+import numpy as np
+import pandas as pd
+from sklearn.linear_model import LogisticRegression
+
+
+def train_meta_model(
+    df: pd.DataFrame,
+    feature_cols: List[str],
+    label_col: str = "best_model",
+) -> Dict[str, object]:
+    """Train multinomial logistic regression to select best model.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        DataFrame containing regime features and labels of best model.
+    feature_cols : List[str]
+        Columns to use as features.
+    label_col : str, default "best_model"
+        Column containing the index of the best-performing base model.
+
+    Returns
+    -------
+    Dict[str, object]
+        Dictionary with feature names, gating coefficients and intercepts.
+    """
+    X = df[feature_cols].values
+    y = df[label_col].values
+    clf = LogisticRegression(multi_class="multinomial", solver="lbfgs", max_iter=200)
+    clf.fit(X, y)
+    coeffs = clf.coef_
+    intercepts = clf.intercept_
+    # For binary problems, sklearn returns a single row; create symmetric rows
+    if coeffs.shape[0] == 1 and len(clf.classes_) == 2:
+        coeffs = np.vstack([np.zeros_like(coeffs[0]), coeffs[0]])
+        intercepts = np.array([0.0, intercepts[0]])
+    return {
+        "feature_names": feature_cols,
+        "gating_coefficients": coeffs.tolist(),
+        "gating_intercepts": intercepts.tolist(),
+    }
+
+
+def select_model(params: Dict[str, object], features: Dict[str, float]) -> int:
+    """Select the best model given regime features.
+
+    Parameters
+    ----------
+    params : dict
+        Output from :func:`train_meta_model` containing coefficients.
+    features : Dict[str, float]
+        Mapping from feature name to value.
+
+    Returns
+    -------
+    int
+        Index of chosen base model.
+    """
+    names = params.get("feature_names", [])
+    coeffs = np.array(params.get("gating_coefficients", []))
+    intercepts = np.array(params.get("gating_intercepts", []))
+    if coeffs.size == 0:
+        return 0
+    x = np.array([features.get(n, 0.0) for n in names])
+    scores = intercepts + coeffs.dot(x)
+    return int(np.argmax(scores))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Train meta gating model")
+    parser.add_argument("data", help="CSV file with regime features and best_model column")
+    parser.add_argument("out", help="Output JSON file for gating parameters")
+    parser.add_argument("--features", nargs="+", required=True, help="Feature column names")
+    parser.add_argument("--label", default="best_model", help="Label column name")
+    args = parser.parse_args()
+
+    df = pd.read_csv(args.data)
+    params = train_meta_model(df, args.features, label_col=args.label)
+    out_path = Path(args.out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(out_path, "w") as f:
+        json.dump(params, f)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_meta_strategy.py
+++ b/tests/test_meta_strategy.py
@@ -1,0 +1,65 @@
+import pandas as pd
+
+import json
+from pathlib import Path
+
+from scripts.meta_strategy import train_meta_model, select_model
+from scripts.generate_mql4_from_model import generate
+
+
+def test_regime_switch_triggers_model_change():
+    df = pd.DataFrame(
+        {
+            "volatility": [-1.0, -0.8, -0.6, 0.6, 0.8, 1.2],
+            "time": [0, 1, 2, 10, 11, 12],
+            "liquidity": [0.9, 0.85, 0.8, 0.2, 0.15, 0.1],
+            "best_model": [0, 0, 0, 1, 1, 1],
+        }
+    )
+    params = train_meta_model(df, ["volatility", "time", "liquidity"], label_col="best_model")
+
+    low_regime = {"volatility": -1.0, "time": 0, "liquidity": 0.9}
+    high_regime = {"volatility": 1.0, "time": 12, "liquidity": 0.1}
+
+    assert select_model(params, low_regime) != select_model(params, high_regime)
+
+
+def test_generate_with_gating(tmp_path: Path):
+    df = pd.DataFrame(
+        {
+            "volatility": [-1.0, -0.5, 0.6, 1.2],
+            "time": [0, 1, 10, 11],
+            "liquidity": [0.9, 0.85, 0.2, 0.1],
+            "best_model": [0, 0, 1, 1],
+        }
+    )
+    gating = train_meta_model(df, ["volatility", "time", "liquidity"], label_col="best_model")
+    gating_file = tmp_path / "gating.json"
+    gating_file.write_text(json.dumps(gating))
+
+    m1 = {
+        "model_id": "m1",
+        "coefficients": [0.1, 0.0, 0.0],
+        "intercept": 0.0,
+        "threshold": 0.5,
+        "feature_names": ["volatility", "time", "liquidity"],
+    }
+    m2 = {
+        "model_id": "m2",
+        "coefficients": [-0.1, 0.0, 0.0],
+        "intercept": 0.0,
+        "threshold": 0.5,
+        "feature_names": ["volatility", "time", "liquidity"],
+    }
+    f1 = tmp_path / "m1.json"
+    f2 = tmp_path / "m2.json"
+    f1.write_text(json.dumps(m1))
+    f2.write_text(json.dumps(m2))
+
+    out_dir = tmp_path / "out"
+    generate([f1, f2], out_dir, gating_json=gating_file)
+    generated = list(out_dir.glob("Generated_m1_*.mq4"))
+    assert generated
+    content = generated[0].read_text()
+    assert "GatingCoefficients" in content
+    assert "GatingIntercepts" in content


### PR DESCRIPTION
## Summary
- add `meta_strategy.py` to train a logistic meta-classifier that maps regime features to the best base model
- allow `generate_mql4_from_model.py` to embed multiple base models and an optional gating model
- evaluate the gating function on every tick in `StrategyTemplate.mq4`
- test that regime changes switch the active model and that gating parameters are embedded

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896b3038554832f8aa8e6f7dbe0c36f