### PR TITLE
Switch observer to Cap'n Proto over ZeroMQ

### DIFF
--- a/proto/metrics.capnp
+++ b/proto/metrics.capnp
@@ -1,0 +1,14 @@
+@0xc2c2c2c2c2c2c2c2;
+
+struct Metrics {
+  time @0 :Text;
+  magic @1 :Int32;
+  winRate @2 :Float64;
+  avgProfit @3 :Float64;
+  tradeCount @4 :Int32;
+  drawdown @5 :Float64;
+  sharpe @6 :Float64;
+  fileWriteErrors @7 :Int32;
+  socketErrors @8 :Int32;
+  bookRefreshSeconds @9 :Int32;
+}

--- a/proto/trade.capnp
+++ b/proto/trade.capnp
@@ -1,0 +1,32 @@
+@0xc1c1c1c1c1c1c1c1;
+
+struct TradeEvent {
+  eventId @0 :Int32;
+  eventTime @1 :Text;
+  brokerTime @2 :Text;
+  localTime @3 :Text;
+  action @4 :Text;
+  ticket @5 :Int32;
+  magic @6 :Int32;
+  source @7 :Text;
+  symbol @8 :Text;
+  orderType @9 :Int32;
+  lots @10 :Float64;
+  price @11 :Float64;
+  sl @12 :Float64;
+  tp @13 :Float64;
+  profit @14 :Float64;
+  profitAfterTrade @15 :Float64;
+  spread @16 :Float64;
+  comment @17 :Text;
+  remainingLots @18 :Float64;
+  slippage @19 :Float64;
+  volume @20 :Int32;
+  openTime @21 :Text;
+  bookBidVol @22 :Float64;
+  bookAskVol @23 :Float64;
+  bookImbalance @24 :Float64;
+  slHitDist @25 :Float64;
+  tpHitDist @26 :Float64;
+  decisionId @27 :Int32;
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,8 @@ opentelemetry-sdk
 opentelemetry-exporter-otlp
 protobuf
 grpcio
+pyzmq
+pycapnp
 onnxruntime
 skl2onnx
 

--- a/scripts/zmq_stream.py
+++ b/scripts/zmq_stream.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""Bridge PUSH/PULL input to PUB output using ZeroMQ.
+
+The service listens on a PULL socket for incoming binary messages from the
+observer EA and republishes them on a PUB socket so that multiple listeners can
+subscribe to the stream.
+"""
+from __future__ import annotations
+
+import argparse
+import zmq
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description="ZeroMQ stream bridge")
+    p.add_argument("--pull", default="tcp://*:5555", help="address to bind the PULL socket")
+    p.add_argument("--pub", default="tcp://*:5556", help="address to bind the PUB socket")
+    args = p.parse_args()
+
+    ctx = zmq.Context()
+    pull = ctx.socket(zmq.PULL)
+    pull.bind(args.pull)
+    pub = ctx.socket(zmq.PUB)
+    pub.bind(args.pub)
+
+    try:
+        while True:
+            msg = pull.recv()
+            pub.send(msg)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        pull.close()
+        pub.close()
+        ctx.term()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stream_listener_binary.py
+++ b/tests/test_stream_listener_binary.py
@@ -1,17 +1,58 @@
 import subprocess
 import sys
+import time
 from pathlib import Path
 
-from proto import observer_pb2, trade_event_pb2
+import capnp
+import zmq
 
 
 def test_stream_listener_binary(tmp_path: Path):
     script = Path(__file__).resolve().parents[1] / "scripts" / "stream_listener.py"
-    event = trade_event_pb2.TradeEvent(event_id=1, event_time="t", symbol="X", price=1.0)
-    envelope = observer_pb2.ObserverMessage(schema_version="1.0", event=event)
-    payload = envelope.SerializeToString()
-    packet = len(payload).to_bytes(4, "little") + payload
-    subprocess.run([sys.executable, str(script), "--binary"], input=packet, cwd=tmp_path)
+    endpoint = "tcp://127.0.0.1:6000"
+    proc = subprocess.Popen([sys.executable, str(script), "--endpoint", endpoint], cwd=tmp_path)
+
+    ctx = zmq.Context()
+    pub = ctx.socket(zmq.PUB)
+    pub.bind(endpoint)
+    time.sleep(0.5)
+
+    schema_path = Path(__file__).resolve().parents[1] / "proto" / "trade.capnp"
+    trade_capnp = capnp.load(str(schema_path))
+    msg = trade_capnp.TradeEvent.new_message(
+        eventId=1,
+        eventTime="t",
+        brokerTime="b",
+        localTime="l",
+        action="OPEN",
+        ticket=1,
+        magic=0,
+        source="mt4",
+        symbol="X",
+        orderType=0,
+        lots=0.0,
+        price=1.0,
+        sl=0.0,
+        tp=0.0,
+        profit=0.0,
+        profitAfterTrade=0.0,
+        spread=0.0,
+        comment="",
+        remainingLots=0.0,
+        slippage=0.0,
+        volume=0,
+        openTime="",
+        bookBidVol=0.0,
+        bookAskVol=0.0,
+        bookImbalance=0.0,
+        slHitDist=0.0,
+        tpHitDist=0.0,
+        decisionId=0,
+    )
+    pub.send(b"\x00" + msg.to_bytes())
+    time.sleep(0.5)
+    proc.terminate()
+    proc.wait(timeout=5)
     out_file = tmp_path / "logs" / "trades_raw.csv"
     assert out_file.exists()
     lines = [l.strip() for l in out_file.read_text().splitlines() if l.strip()]


### PR DESCRIPTION
## Summary
- add Cap'n Proto trade and metrics schemas
- publish observer messages over ZeroMQ
- listen to ZeroMQ events and log to CSV
- send messages from Observer_TBot using ZeroMQ PUSH

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6896b661fb68832f8b61e737abc051ae