### PR TITLE
Archive session artifacts with manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,9 +328,11 @@ and export traces using the OTLP protocol.  Point
 events across components.  The ``trace_id`` of each trade event is also included
 in the ``LogTrade`` JSON emitted by the EA for end-to-end tracing.
 
-After each trading session ``upload_logs.py`` can commit these CSV files and
-push them back to the repository. The script uses the ``GITHUB_TOKEN``
-environment variable for authentication.
+After each trading session ``upload_logs.py`` packages ``trades_raw.csv``,
+``metrics.csv`` and ``model.json`` together with a ``manifest.json`` into a
+single ``run_<timestamp>.tar.gz`` archive. The archive is committed to the
+repository and the original files are removed locally. The script uses the
+``GITHUB_TOKEN`` environment variable for authentication.
 
 ### Environment Variables
 

--- a/scripts/upload_logs.py
+++ b/scripts/upload_logs.py
@@ -1,26 +1,77 @@
 #!/usr/bin/env python3
-"""Commit generated log files and push them to GitHub.
+"""Package generated artefacts and push them to GitHub.
 
-The script adds any ``*.csv.gz`` files under ``logs/`` to the Git repository,
-commits them if they have changed and pushes the new commit to the ``origin``
-remote. Authentication is performed using the ``GITHUB_TOKEN`` environment
-variable which must contain a personal access token with permission to push to
-the repository.
+After each trading or training session the raw outputs ``trades_raw.csv``,
+``metrics.csv`` and ``model.json`` are compressed into a single
+``run_<timestamp>.tar.gz`` archive.  A ``manifest.json`` containing the current
+commit hash, schema version and SHA256 checksums of each file is included in the
+archive.  The archive is committed to the repository and the raw files are
+removed locally. Authentication is performed using the ``GITHUB_TOKEN``
+environment variable which must contain a personal access token with permission
+to push to the repository.
 """
 from __future__ import annotations
 
 import datetime as dt
+import hashlib
+import json
 import os
 import subprocess
 import sys
+import tarfile
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 LOG_DIR = REPO_ROOT / "logs"
+TRADES_FILE = LOG_DIR / "trades_raw.csv"
+METRICS_FILE = LOG_DIR / "metrics.csv"
+MODEL_FILE = REPO_ROOT / "model.json"
 
 
 def run(cmd: list[str]) -> None:
     subprocess.run(cmd, check=True, cwd=REPO_ROOT)
+
+
+def _sha256(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(8192), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def create_archive() -> Path | None:
+    """Create a ``run_<timestamp>.tar.gz`` archive with a manifest."""
+
+    files = [TRADES_FILE, METRICS_FILE, MODEL_FILE]
+    if not all(p.exists() for p in files):
+        return None
+
+    commit = (
+        subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=REPO_ROOT)
+        .decode()
+        .strip()
+    )
+    schema_version = os.environ.get("SCHEMA_VERSION", "1.0")
+    manifest = {
+        "commit": commit,
+        "schema_version": schema_version,
+        "files": {p.name: {"sha256": _sha256(p)} for p in files},
+    }
+    manifest_path = LOG_DIR / "manifest.json"
+    with manifest_path.open("w") as f:
+        json.dump(manifest, f, indent=2)
+
+    timestamp = dt.datetime.utcnow().strftime("%Y%m%dT%H%M%SZ")
+    archive = LOG_DIR / f"run_{timestamp}.tar.gz"
+    with tarfile.open(archive, "w:gz") as tar:
+        for p in files + [manifest_path]:
+            tar.add(p, arcname=p.name)
+
+    for p in files + [manifest_path]:
+        p.unlink()
+
+    return archive
 
 
 def main() -> int:
@@ -29,16 +80,19 @@ def main() -> int:
         print("GITHUB_TOKEN environment variable is required", file=sys.stderr)
         return 1
 
-    logs = sorted(LOG_DIR.glob("*.csv.gz"))
-    existing = [str(p) for p in logs if p.exists()]
-    if not existing:
-        print("No log files found", file=sys.stderr)
+    archive = create_archive()
+    if not archive:
+        print("Required log files are missing", file=sys.stderr)
         return 0
 
-    run(["git", "add", *existing])
-    status = subprocess.check_output(
-        ["git", "status", "--porcelain", *existing], cwd=REPO_ROOT
-    ).decode().strip()
+    run(["git", "add", str(archive)])
+    status = (
+        subprocess.check_output(
+            ["git", "status", "--porcelain", str(archive)], cwd=REPO_ROOT
+        )
+        .decode()
+        .strip()
+    )
     if not status:
         print("No changes to commit")
         return 0

--- a/tests/test_upload_logs.py
+++ b/tests/test_upload_logs.py
@@ -1,0 +1,50 @@
+import json
+import tarfile
+import subprocess
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import scripts.upload_logs as ul
+
+
+def test_create_archive(tmp_path, monkeypatch):
+    repo = tmp_path
+    logs = repo / "logs"
+    logs.mkdir()
+    trades = logs / "trades_raw.csv"
+    trades.write_text("a,b\n1,2\n")
+    metrics = logs / "metrics.csv"
+    metrics.write_text("c,d\n3,4\n")
+    model = repo / "model.json"
+    model.write_text("{}")
+
+    subprocess.run(["git", "init"], cwd=repo, check=True)
+    (repo / "dummy.txt").write_text("x")
+    subprocess.run(["git", "add", "dummy.txt"], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-m", "init"], cwd=repo, check=True)
+
+    monkeypatch.setenv("SCHEMA_VERSION", "9.9")
+    monkeypatch.setenv("GITHUB_TOKEN", "token")
+    monkeypatch.setattr(ul, "REPO_ROOT", repo)
+    monkeypatch.setattr(ul, "LOG_DIR", logs)
+    monkeypatch.setattr(ul, "TRADES_FILE", trades)
+    monkeypatch.setattr(ul, "METRICS_FILE", metrics)
+    monkeypatch.setattr(ul, "MODEL_FILE", model)
+
+    archive = ul.create_archive()
+    assert archive and archive.exists()
+    assert not trades.exists()
+    assert not metrics.exists()
+    assert not model.exists()
+
+    with tarfile.open(archive, "r:gz") as tar:
+        names = set(tar.getnames())
+        assert {"trades_raw.csv", "metrics.csv", "model.json", "manifest.json"} <= names
+        manifest = json.load(tar.extractfile("manifest.json"))
+
+    assert manifest["schema_version"] == "9.9"
+    assert "commit" in manifest
+    for fname in ("trades_raw.csv", "metrics.csv", "model.json"):
+        assert fname in manifest["files"]
+


### PR DESCRIPTION
## Summary
- package `trades_raw.csv`, `metrics.csv` and `model.json` into timestamped `run_*.tar.gz`
- include commit hash, schema version and checksums in `manifest.json`
- update upload script, docs and add tests for archiving

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68978363d9fc832fbff492b7585b3d7e