### PR TITLE
Add real-time dashboard with WebSocket updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,29 @@ The EA records trade openings and closings using the `OnTradeTransaction` callba
    python scripts/promote_best_models.py models --dest models/best
    ```
 
+## Dashboard
+
+A small web dashboard can display trades, metrics and training progress in real time.
+
+1. Install dependencies if not already done:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Set an API token used for authentication:
+   ```bash
+   export DASHBOARD_API_TOKEN="your-token"
+   ```
+3. Start the dashboard server:
+   ```bash
+   python dashboard/server.py
+   ```
+4. Launch the stream listener and forward events to the dashboard:
+   ```bash
+   python scripts/stream_listener.py --ws-url ws://localhost:8000 --api-token "$DASHBOARD_API_TOKEN"
+   ```
+5. Open <http://localhost:8000> in a browser and supply the token when prompted to view live updates.
+
+
 
 ### DVC Pipeline
 

--- a/dashboard/server.py
+++ b/dashboard/server.py
@@ -1,0 +1,102 @@
+import os
+import json
+from typing import List, Set
+
+from fastapi import FastAPI, WebSocket, WebSocketDisconnect, HTTPException, Request, Depends
+from fastapi.responses import RedirectResponse
+from fastapi.staticfiles import StaticFiles
+
+API_TOKEN = os.environ.get("DASHBOARD_API_TOKEN", "")
+
+app = FastAPI(title="BotCopier Dashboard")
+
+app.mount("/static", StaticFiles(directory=os.path.join(os.path.dirname(__file__), "static")), name="static")
+
+# In-memory stores
+trades: List[dict] = []
+metrics: List[dict] = []
+training_progress: List[dict] = []
+
+# Active WebSocket connections
+trade_connections: Set[WebSocket] = set()
+metric_connections: Set[WebSocket] = set()
+training_connections: Set[WebSocket] = set()
+
+
+async def verify_token(request: Request):
+    token = request.headers.get("X-API-Token") or request.query_params.get("token")
+    if API_TOKEN and token != API_TOKEN:
+        raise HTTPException(status_code=401, detail="Invalid token")
+
+
+@app.get("/")
+async def root():
+    return RedirectResponse(url="/static/index.html")
+
+
+@app.get("/trades")
+async def get_trades(_: Request = Depends(verify_token)):
+    return trades
+
+
+@app.get("/metrics")
+async def get_metrics(_: Request = Depends(verify_token)):
+    return metrics
+
+
+@app.get("/training_progress")
+async def get_training(_: Request = Depends(verify_token)):
+    return training_progress
+
+
+def _auth_ws(ws: WebSocket) -> bool:
+    token = ws.query_params.get("token")
+    return not API_TOKEN or token == API_TOKEN
+
+
+async def _ws_handler(ws: WebSocket, store: List[dict], connections: Set[WebSocket]):
+    if not _auth_ws(ws):
+        await ws.close(code=1008)
+        return
+    await ws.accept()
+    connections.add(ws)
+    try:
+        while True:
+            data = await ws.receive_text()
+            try:
+                payload = json.loads(data)
+                store.append(payload)
+            except Exception:
+                payload = data
+            # broadcast
+            for conn in list(connections):
+                if conn is not ws:
+                    try:
+                        await conn.send_text(data)
+                    except Exception:
+                        connections.discard(conn)
+    except WebSocketDisconnect:
+        pass
+    finally:
+        connections.discard(ws)
+
+
+@app.websocket("/ws/trades")
+async def ws_trades(ws: WebSocket):
+    await _ws_handler(ws, trades, trade_connections)
+
+
+@app.websocket("/ws/metrics")
+async def ws_metrics(ws: WebSocket):
+    await _ws_handler(ws, metrics, metric_connections)
+
+
+@app.websocket("/ws/training_progress")
+async def ws_training(ws: WebSocket):
+    await _ws_handler(ws, training_progress, training_connections)
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run("dashboard.server:app", host="0.0.0.0", port=int(os.environ.get("PORT", 8000)), reload=False)

--- a/dashboard/static/index.html
+++ b/dashboard/static/index.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>BotCopier Dashboard</title>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+</head>
+<body>
+    <h1>BotCopier Dashboard</h1>
+    <canvas id="metricsChart" width="400" height="200"></canvas>
+    <h2>Trades</h2>
+    <ul id="trades"></ul>
+    <h2>Training Progress</h2>
+    <ul id="training"></ul>
+
+    <script>
+        const token = prompt('API Token');
+
+        const ctx = document.getElementById('metricsChart').getContext('2d');
+        const metricsChart = new Chart(ctx, {
+            type: 'line',
+            data: { labels: [], datasets: [{ label: 'Win Rate', data: [] }] },
+        });
+
+        function updateChart(metric) {
+            metricsChart.data.labels.push(metric.time);
+            metricsChart.data.datasets[0].data.push(metric.win_rate);
+            metricsChart.update();
+        }
+
+        const metricsWs = new WebSocket(`ws://${location.host}/ws/metrics?token=${token}`);
+        metricsWs.onmessage = (event) => {
+            const metric = JSON.parse(event.data);
+            updateChart(metric);
+        };
+
+        const tradesWs = new WebSocket(`ws://${location.host}/ws/trades?token=${token}`);
+        tradesWs.onmessage = (event) => {
+            const trade = JSON.parse(event.data);
+            const li = document.createElement('li');
+            li.textContent = `${trade.symbol} ${trade.action} ${trade.lots}`;
+            document.getElementById('trades').appendChild(li);
+        };
+
+        const trainingWs = new WebSocket(`ws://${location.host}/ws/training_progress?token=${token}`);
+        trainingWs.onmessage = (event) => {
+            const prog = JSON.parse(event.data);
+            const li = document.createElement('li');
+            li.textContent = `${prog.step}: ${prog.status}`;
+            document.getElementById('training').appendChild(li);
+        };
+    </script>
+</body>
+</html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,9 @@ pyzmq
 pycapnp
 onnxruntime
 skl2onnx
+fastapi
+uvicorn
+websocket-client
 
 # Optional extras
 xgboost; extra == "xgboost"


### PR DESCRIPTION
## Summary
- Serve a FastAPI dashboard with token auth, REST endpoints, and WebSocket broadcasts for trades, metrics, and training progress
- Add Chart.js frontend subscribing to WebSocket streams for live metrics and trade updates
- Stream listener forwards parsed trades and metrics to dashboard WebSockets
- Document dashboard usage and new dependencies

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'capnp')*


------
https://chatgpt.com/codex/tasks/task_e_689789579ee0832f87496e9879f6fa43