### PR TITLE
Instrument logging with OpenTelemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,32 @@ A small web dashboard can display trades, metrics and training progress in real 
    ```
 5. Open <http://localhost:8000> in a browser and supply the token when prompted to view live updates.
 
+## Tracing and Logging
+
+The observer, stream listener and training scripts emit OpenTelemetry traces and JSON logs. Configure exports via environment variables:
+
+- `OTEL_SERVICE_NAME` – service name reported to the collector.
+- `OTEL_EXPORTER_OTLP_ENDPOINT` – OTLP HTTP endpoint (e.g. `http://localhost:4318/v1`).
+- `OTEL_EXPORTER_JAEGER_AGENT_HOST` and `OTEL_EXPORTER_JAEGER_AGENT_PORT` – send traces to a Jaeger agent.
+
+Collect logs locally with:
+
+```bash
+python scripts/log_collector.py
+```
+
+Sample Jaeger deployment:
+
+```bash
+docker run --rm -it \
+  -e COLLECTOR_ZIPKIN_HOST_PORT=:9411 \
+  -p 6831:6831/udp -p 6832:6832/udp \
+  -p 5778:5778 -p 16686:16686 \
+  -p 14268:14268 -p 14250:14250 \
+  -p 9411:9411 jaegertracing/all-in-one:1.47
+```
+
+
 
 
 ### DVC Pipeline

--- a/experts/Observer_TBot.mq4
+++ b/experts/Observer_TBot.mq4
@@ -864,7 +864,7 @@ void WriteMetrics(datetime ts)
       h = FileOpen(fname, FILE_CSV|FILE_WRITE|FILE_TXT|FILE_SHARE_WRITE, ';');
       if(h==INVALID_HANDLE)
          return;
-      int _wr = FileWrite(h, "time;magic;win_rate;avg_profit;trade_count;drawdown;sharpe;sortino;expectancy;file_write_errors;socket_errors;book_refresh_seconds");
+      int _wr = FileWrite(h, "time;magic;win_rate;avg_profit;trade_count;drawdown;sharpe;sortino;expectancy;file_write_errors;socket_errors;book_refresh_seconds;trace_id;span_id");
       if(_wr <= 0)
          FileWriteErrors++;
    }
@@ -935,7 +935,8 @@ void WriteMetrics(datetime ts)
       double sortino = stddev_neg>0 ? (sum_profit/trades)/stddev_neg : 0.0;
       double expectancy = (avg_profit * win_rate) - (avg_loss * (1.0 - win_rate));
 
-      string line = StringFormat("%s;%d;%.3f;%.2f;%d;%.2f;%.3f;%.3f;%.2f;%d;%d;%d", TimeToString(ts, TIME_DATE|TIME_MINUTES), magic, win_rate, avg_profit, trades, max_dd, sharpe, sortino, expectancy, FileWriteErrors, FlightErrors, CachedBookRefreshSeconds);
+      string span_id = GenId(8);
+      string line = StringFormat("%s;%d;%.3f;%.2f;%d;%.2f;%.3f;%.3f;%.2f;%d;%d;%d;%s;%s", TimeToString(ts, TIME_DATE|TIME_MINUTES), magic, win_rate, avg_profit, trades, max_dd, sharpe, sortino, expectancy, FileWriteErrors, FlightErrors, CachedBookRefreshSeconds, TraceId, span_id);
       if(h!=INVALID_HANDLE)
       {
          int _wr_line = FileWrite(h, line);
@@ -950,6 +951,7 @@ void WriteMetrics(datetime ts)
          trades, max_dd, sharpe, FileWriteErrors, FlightErrors, CachedBookRefreshSeconds, payload);
        if(len>0)
          SendMetrics(payload);
+      SendOtelSpan(TraceId, span_id, "metrics");
    }
 
    if(h!=INVALID_HANDLE)

--- a/scripts/auto_retrain.py
+++ b/scripts/auto_retrain.py
@@ -10,11 +10,70 @@ import time
 from pathlib import Path
 from typing import Dict, Optional
 
+import logging
+import os
+from opentelemetry import trace
+from opentelemetry._logs import set_logger_provider
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.exporter.otlp.proto.http._log_exporter import OTLPLogExporter
+try:  # Optional Jaeger exporter
+    from opentelemetry.exporter.jaeger.thrift import JaegerExporter  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    JaegerExporter = None
+from opentelemetry.sdk._logs import LoggerProvider, LoggingHandler
+from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.trace import format_trace_id, format_span_id
+
 from scripts.train_target_clone import train as train_model
 from scripts.backtest_strategy import run_backtest
 from scripts.publish_model import publish
 
 STATE_FILE = "last_event_id"
+
+resource = Resource.create({"service.name": os.getenv("OTEL_SERVICE_NAME", "auto_retrain")})
+provider = TracerProvider(resource=resource)
+if endpoint := os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT"):
+    provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter(endpoint=endpoint)))
+elif os.getenv("OTEL_EXPORTER_JAEGER_AGENT_HOST") and JaegerExporter:
+    provider.add_span_processor(
+        BatchSpanProcessor(
+            JaegerExporter(
+                agent_host_name=os.getenv("OTEL_EXPORTER_JAEGER_AGENT_HOST"),
+                agent_port=int(os.getenv("OTEL_EXPORTER_JAEGER_AGENT_PORT", "6831")),
+            )
+        )
+    )
+trace.set_tracer_provider(provider)
+tracer = trace.get_tracer(__name__)
+
+logger_provider = LoggerProvider(resource=resource)
+if endpoint:
+    logger_provider.add_log_record_processor(BatchLogRecordProcessor(OTLPLogExporter(endpoint=endpoint)))
+set_logger_provider(logger_provider)
+handler = LoggingHandler(level=logging.INFO, logger_provider=logger_provider)
+
+
+class JsonFormatter(logging.Formatter):
+    def format(self, record):
+        log = {"level": record.levelname}
+        if isinstance(record.msg, dict):
+            log.update(record.msg)
+        else:
+            log["message"] = record.getMessage()
+        if hasattr(record, "trace_id"):
+            log["trace_id"] = format_trace_id(record.trace_id)
+        if hasattr(record, "span_id"):
+            log["span_id"] = format_span_id(record.span_id)
+        return json.dumps(log)
+
+
+logger = logging.getLogger(__name__)
+handler.setFormatter(JsonFormatter())
+logger.addHandler(handler)
+logger.setLevel(logging.INFO)
 
 
 def _read_last_event_id(out_dir: Path) -> int:
@@ -59,45 +118,54 @@ def retrain_if_needed(
     tick_file: Optional[Path] = None,
 ) -> bool:
     """Retrain and publish a model when win rate or drawdown worsens."""
-    metrics_path = metrics_file or (log_dir / "metrics.csv")
-    metrics = _load_latest_metrics(metrics_path)
-    if not metrics:
-        return False
+    with tracer.start_as_current_span("retrain_if_needed"):
+        metrics_path = metrics_file or (log_dir / "metrics.csv")
+        metrics = _load_latest_metrics(metrics_path)
+        if not metrics:
+            logger.info("no metrics available")
+            return False
 
-    if metrics["win_rate"] >= win_rate_threshold and metrics["drawdown"] <= drawdown_threshold:
-        return False
+        if metrics["win_rate"] >= win_rate_threshold and metrics["drawdown"] <= drawdown_threshold:
+            logger.info("metrics within thresholds")
+            return False
 
-    # Load last processed event id for incremental training
-    import scripts.train_target_clone as tc
+        logger.info("retraining model")
+        # Load last processed event id for incremental training
+        import scripts.train_target_clone as tc
 
-    last_id = _read_last_event_id(out_dir)
-    tc.START_EVENT_ID = last_id
-    train_model(log_dir, out_dir, incremental=True)
+        last_id = _read_last_event_id(out_dir)
+        tc.START_EVENT_ID = last_id
+        train_model(log_dir, out_dir, incremental=True)
 
-    model_json = out_dir / "model.json"
-    model_onnx = out_dir / "model.onnx"
-    try:
-        data = json.loads(model_json.read_text())
-        _write_last_event_id(out_dir, int(data.get("last_event_id", last_id)))
-    except Exception:
-        pass
+        model_json = out_dir / "model.json"
+        model_onnx = out_dir / "model.onnx"
+        try:
+            data = json.loads(model_json.read_text())
+            _write_last_event_id(out_dir, int(data.get("last_event_id", last_id)))
+        except Exception:
+            pass
 
-    # Backtest to ensure new model improves over previous metrics
-    backtest_file = tick_file or (log_dir / "trades_raw.csv")
-    try:
-        result = run_backtest(model_json, backtest_file)
-    except Exception:
-        return False
+        # Backtest to ensure new model improves over previous metrics
+        backtest_file = tick_file or (log_dir / "trades_raw.csv")
+        try:
+            result = run_backtest(model_json, backtest_file)
+        except Exception:
+            return False
 
-    if result.get("win_rate", 0) <= metrics["win_rate"] or result.get("drawdown", 1) >= metrics["drawdown"]:
-        return False
+        if result.get("win_rate", 0) <= metrics["win_rate"] or result.get("drawdown", 1) >= metrics["drawdown"]:
+            logger.info("backtest did not improve metrics")
+            return False
 
-    publish(model_onnx if model_onnx.exists() else model_json, files_dir)
-    tc.START_EVENT_ID = 0
-    return True
+        publish(model_onnx if model_onnx.exists() else model_json, files_dir)
+        tc.START_EVENT_ID = 0
+        logger.info("retrain complete")
+        return True
 
 
 def main() -> None:
+    span = tracer.start_span("auto_retrain")
+    ctx = span.get_span_context()
+    logger.info("auto retrain start", extra={"trace_id": ctx.trace_id, "span_id": ctx.span_id})
     p = argparse.ArgumentParser(description="Retrain model when metrics degrade")
     p.add_argument("--log-dir", required=True, help="directory with observer logs")
     p.add_argument("--out-dir", required=True, help="output model directory")
@@ -137,6 +205,8 @@ def main() -> None:
             drawdown_threshold=args.drawdown_threshold,
             tick_file=tick_path,
         )
+    logger.info("auto retrain finished", extra={"trace_id": ctx.trace_id, "span_id": ctx.span_id})
+    span.end()
 
 
 if __name__ == "__main__":

--- a/scripts/log_collector.py
+++ b/scripts/log_collector.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+"""Simple OTLP HTTP log collector."""
+import argparse
+import json
+from aiohttp import web
+
+async def handle(request):
+    payload = await request.read()
+    try:
+        data = json.loads(payload.decode())
+        print(json.dumps(data))
+    except Exception:
+        print(payload)
+    return web.Response(text="")
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="OTLP log collector")
+    parser.add_argument("--host", default="0.0.0.0")
+    parser.add_argument("--port", type=int, default=4318)
+    args = parser.parse_args()
+    app = web.Application()
+    app.add_routes([web.post("/v1/logs", handle)])
+    web.run_app(app, host=args.host, port=args.port)
+
+if __name__ == "__main__":
+    main()

--- a/scripts/pretrain_autoencoder.py
+++ b/scripts/pretrain_autoencoder.py
@@ -6,7 +6,24 @@ import csv
 from pathlib import Path
 from typing import List
 
+import logging
+import os
 import numpy as np
+
+from opentelemetry import trace
+from opentelemetry._logs import set_logger_provider
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.exporter.otlp.proto.http._log_exporter import OTLPLogExporter
+try:  # Optional Jaeger exporter
+    from opentelemetry.exporter.jaeger.thrift import JaegerExporter  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    JaegerExporter = None
+from opentelemetry.sdk._logs import LoggerProvider, LoggingHandler
+from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.trace import format_trace_id, format_span_id
 
 try:
     import tensorflow as tf  # type: ignore
@@ -16,6 +33,49 @@ except Exception:
     HAS_TF = False
 
 from sklearn.cluster import KMeans
+
+
+resource = Resource.create({"service.name": os.getenv("OTEL_SERVICE_NAME", "pretrain_autoencoder")})
+provider = TracerProvider(resource=resource)
+if endpoint := os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT"):
+    provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter(endpoint=endpoint)))
+elif os.getenv("OTEL_EXPORTER_JAEGER_AGENT_HOST") and JaegerExporter:
+    provider.add_span_processor(
+        BatchSpanProcessor(
+            JaegerExporter(
+                agent_host_name=os.getenv("OTEL_EXPORTER_JAEGER_AGENT_HOST"),
+                agent_port=int(os.getenv("OTEL_EXPORTER_JAEGER_AGENT_PORT", "6831")),
+            )
+        )
+    )
+trace.set_tracer_provider(provider)
+tracer = trace.get_tracer(__name__)
+
+logger_provider = LoggerProvider(resource=resource)
+if endpoint:
+    logger_provider.add_log_record_processor(BatchLogRecordProcessor(OTLPLogExporter(endpoint=endpoint)))
+set_logger_provider(logger_provider)
+handler = LoggingHandler(level=logging.INFO, logger_provider=logger_provider)
+
+
+class JsonFormatter(logging.Formatter):
+    def format(self, record):
+        log = {"level": record.levelname}
+        if isinstance(record.msg, dict):
+            log.update(record.msg)
+        else:
+            log["message"] = record.getMessage()
+        if hasattr(record, "trace_id"):
+            log["trace_id"] = format_trace_id(record.trace_id)
+        if hasattr(record, "span_id"):
+            log["span_id"] = format_span_id(record.span_id)
+        return json.dumps(log)
+
+
+logger = logging.getLogger(__name__)
+handler.setFormatter(JsonFormatter())
+logger.addHandler(handler)
+logger.setLevel(logging.INFO)
 
 
 def _load_ticks(file: Path) -> List[float]:
@@ -42,61 +102,65 @@ def train(
 ) -> None:
     if not HAS_TF:
         raise ImportError("TensorFlow is required for autoencoder training")
+    with tracer.start_as_current_span("pretrain_autoencoder_train"):
+        logger.info("training autoencoder")
+        seqs: List[np.ndarray] = []
+        for tick_file in tick_dir.glob("ticks_*.csv"):
+            prices = _load_ticks(tick_file)
+            if len(prices) <= window:
+                continue
+            diffs = np.diff(prices)
+            for i in range(len(diffs) - window):
+                seqs.append(diffs[i : i + window])
+        if not seqs:
+            raise ValueError(f"No tick sequences found in {tick_dir}")
 
-    seqs: List[np.ndarray] = []
-    for tick_file in tick_dir.glob("ticks_*.csv"):
-        prices = _load_ticks(tick_file)
-        if len(prices) <= window:
-            continue
-        diffs = np.diff(prices)
-        for i in range(len(diffs) - window):
-            seqs.append(diffs[i : i + window])
-    if not seqs:
-        raise ValueError(f"No tick sequences found in {tick_dir}")
+        X = np.stack(seqs).astype(np.float32)
 
-    X = np.stack(seqs).astype(np.float32)
+        inp = keras.Input(shape=(window,))
+        x = keras.layers.Dense(latent_dim, use_bias=False)(inp)
+        out = keras.layers.Dense(window, use_bias=False)(x)
+        model = keras.Model(inp, out)
+        model.compile(optimizer="adam", loss="mse")
+        model.fit(X, X, epochs=epochs, batch_size=32, verbose=0)
 
-    inp = keras.Input(shape=(window,))
-    x = keras.layers.Dense(latent_dim, use_bias=False)(inp)
-    out = keras.layers.Dense(window, use_bias=False)(x)
-    model = keras.Model(inp, out)
-    model.compile(optimizer="adam", loss="mse")
-    model.fit(X, X, epochs=epochs, batch_size=32, verbose=0)
+        encoder_weights = model.layers[1].get_weights()[0]  # type: ignore[index]
 
-    encoder_weights = model.layers[1].get_weights()[0]  # type: ignore[index]
+        encoded = X.dot(encoder_weights.astype(np.float32))
+        km = KMeans(n_clusters=n_clusters, n_init=10, random_state=42)
+        km.fit(encoded)
 
-    encoded = X.dot(encoder_weights.astype(np.float32))
-    km = KMeans(n_clusters=n_clusters, n_init=10, random_state=42)
-    km.fit(encoded)
-
-    data = {
-        "window": window,
-        "weights": encoder_weights.tolist(),
-        "centers": km.cluster_centers_.tolist(),
-    }
-    out_path.parent.mkdir(parents=True, exist_ok=True)
-    with open(out_path, "w") as f:
-        json.dump(data, f, indent=2)
-    print(f"Encoder weights written to {out_path}")
+        data = {
+            "window": window,
+            "weights": encoder_weights.tolist(),
+            "centers": km.cluster_centers_.tolist(),
+        }
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(out_path, "w") as f:
+            json.dump(data, f, indent=2)
+        logger.info("encoder weights written", extra={"out_file": str(out_path)})
 
 
 def main() -> None:
-    p = argparse.ArgumentParser(description="Pretrain autoencoder from ticks")
-    p.add_argument("tick_dir", help="directory with ticks_*.csv files")
-    p.add_argument("out_file", help="output JSON file for encoder weights")
-    p.add_argument("--window", type=int, default=10)
-    p.add_argument("--latent-dim", type=int, default=4)
-    p.add_argument("--epochs", type=int, default=10)
-    p.add_argument("--clusters", type=int, default=4)
-    args = p.parse_args()
-    train(
-        Path(args.tick_dir),
-        Path(args.out_file),
-        window=args.window,
-        latent_dim=args.latent_dim,
-        epochs=args.epochs,
-        n_clusters=args.clusters,
-    )
+    with tracer.start_as_current_span("pretrain_autoencoder"):
+        logger.info("pretrain autoencoder start")
+        p = argparse.ArgumentParser(description="Pretrain autoencoder from ticks")
+        p.add_argument("tick_dir", help="directory with ticks_*.csv files")
+        p.add_argument("out_file", help="output JSON file for encoder weights")
+        p.add_argument("--window", type=int, default=10)
+        p.add_argument("--latent-dim", type=int, default=4)
+        p.add_argument("--epochs", type=int, default=10)
+        p.add_argument("--clusters", type=int, default=4)
+        args = p.parse_args()
+        train(
+            Path(args.tick_dir),
+            Path(args.out_file),
+            window=args.window,
+            latent_dim=args.latent_dim,
+            epochs=args.epochs,
+            n_clusters=args.clusters,
+        )
+        logger.info("pretrain autoencoder finished")
 
 
 if __name__ == "__main__":

--- a/scripts/stream_listener.py
+++ b/scripts/stream_listener.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import csv
 import json
+import logging
 import os
 import platform
 import pkgutil
@@ -22,11 +23,15 @@ except Exception:  # pragma: no cover - optional dependency
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from opentelemetry import trace
+from opentelemetry._logs import set_logger_provider
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.exporter.otlp.proto.http._log_exporter import OTLPLogExporter
 try:  # Optional Jaeger exporter
     from opentelemetry.exporter.jaeger.thrift import JaegerExporter  # type: ignore
 except Exception:  # pragma: no cover - optional dependency
     JaegerExporter = None
+from opentelemetry.sdk._logs import LoggerProvider, LoggingHandler
+from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
@@ -61,6 +66,32 @@ elif os.getenv("OTEL_EXPORTER_JAEGER_AGENT_HOST") and JaegerExporter:
     )
 trace.set_tracer_provider(provider)
 tracer = trace.get_tracer(__name__)
+
+logger_provider = LoggerProvider(resource=resource)
+if endpoint:
+    logger_provider.add_log_record_processor(BatchLogRecordProcessor(OTLPLogExporter(endpoint=endpoint)))
+set_logger_provider(logger_provider)
+handler = LoggingHandler(level=logging.INFO, logger_provider=logger_provider)
+
+
+class JsonFormatter(logging.Formatter):
+    def format(self, record):
+        log = {"level": record.levelname}
+        if isinstance(record.msg, dict):
+            log.update(record.msg)
+        else:
+            log["message"] = record.getMessage()
+        if hasattr(record, "trace_id"):
+            log["trace_id"] = format_trace_id(record.trace_id)
+        if hasattr(record, "span_id"):
+            log["span_id"] = format_span_id(record.span_id)
+        return json.dumps(log)
+
+
+logger = logging.getLogger(__name__)
+handler.setFormatter(JsonFormatter())
+logger.addHandler(handler)
+logger.setLevel(logging.INFO)
 
 # optional dashboard websocket connections
 ws_trades: WebSocket | None = None
@@ -129,6 +160,7 @@ def process_trade(msg) -> None:
         ctx = span.get_span_context()
         record.setdefault("trace_id", trace_id or format_trace_id(ctx.trace_id))
         record.setdefault("span_id", span_id or format_span_id(ctx.span_id))
+        logger.info(record)
         append_csv(LOG_FILES[TRADE_MSG], record)
         if ws_trades:
             try:
@@ -154,6 +186,7 @@ def process_metric(msg) -> None:
         ctx = span.get_span_context()
         record.setdefault("trace_id", format_trace_id(ctx.trace_id))
         record["span_id"] = format_span_id(ctx.span_id)
+        logger.info(record)
         append_csv(LOG_FILES[METRIC_MSG], record)
         if ws_metrics:
             try:


### PR DESCRIPTION
## Summary
- add trace and span IDs to MT4 observer metrics and emit spans
- send stream listener and training logs as structured JSON with OTLP export
- document trace environment variables and sample Jaeger deployment

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'opentelemetry'; ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_689791be3244832faa7329bfc45f2567