### PR TITLE
Add federated averaging server and client synchronization

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,7 @@ skl2onnx
 fastapi
 uvicorn
 websocket-client
+requests
 
 # Optional extras
 xgboost; extra == "xgboost"

--- a/scripts/federated_server.py
+++ b/scripts/federated_server.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Simple federated averaging server."""
+
+from __future__ import annotations
+
+import argparse
+from threading import Lock
+from typing import List
+
+from fastapi import FastAPI
+from pydantic import BaseModel
+import uvicorn
+
+
+app = FastAPI()
+
+
+class ModelUpdate(BaseModel):
+    weights: List[float]
+    intercept: float | None = None
+
+
+state = {
+    "updates": [],
+    "weights": None,
+    "intercept": None,
+    "expected": 1,
+    "lock": Lock(),
+}
+
+
+@app.post("/update")
+def update(update: ModelUpdate):
+    with state["lock"]:
+        state["updates"].append(update)
+        if len(state["updates"]) >= state["expected"]:
+            ws = [u.weights for u in state["updates"]]
+            state["weights"] = [sum(col) / len(col) for col in zip(*ws)]
+            inters = [u.intercept for u in state["updates"] if u.intercept is not None]
+            state["intercept"] = (
+                sum(inters) / len(inters) if inters else None
+            )
+            state["updates"] = []
+    return {"weights": state["weights"], "intercept": state["intercept"]}
+
+
+@app.get("/weights")
+def weights():
+    return {"weights": state["weights"], "intercept": state["intercept"]}
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description="Federated averaging server")
+    p.add_argument("--host", default="0.0.0.0")
+    p.add_argument("--port", type=int, default=8000)
+    p.add_argument(
+        "--clients", type=int, default=2, help="number of clients to wait for"
+    )
+    args = p.parse_args()
+    state["expected"] = args.clients
+    uvicorn.run(app, host=args.host, port=args.port)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/tests/test_federated_server.py
+++ b/tests/test_federated_server.py
@@ -1,0 +1,70 @@
+import json
+import socket
+import threading
+import time
+from pathlib import Path
+
+import requests
+import uvicorn
+
+from scripts import federated_server
+from scripts.train_target_clone import sync_with_server
+
+
+def _free_port() -> int:
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+def _start_server(port: int) -> tuple[uvicorn.Server, threading.Thread]:
+    config = uvicorn.Config(
+        federated_server.app, host="127.0.0.1", port=port, log_level="warning"
+    )
+    server = uvicorn.Server(config)
+    thread = threading.Thread(target=server.run, daemon=True)
+    thread.start()
+    while not server.started:
+        time.sleep(0.1)
+    return server, thread
+
+
+def test_two_clients_sync(tmp_path: Path) -> None:
+    port = _free_port()
+    server, thread = _start_server(port)
+    federated_server.state["expected"] = 2
+    url = f"http://127.0.0.1:{port}"
+
+    m1 = tmp_path / "m1.json"
+    m2 = tmp_path / "m2.json"
+    m1.write_text(json.dumps({"coefficients": [1.0, 2.0], "intercept": 0.5}))
+    m2.write_text(json.dumps({"coefficients": [3.0, 4.0], "intercept": 1.5}))
+
+    t1 = threading.Thread(
+        target=sync_with_server, args=(m1, url), kwargs={"poll_interval": 0.1}
+    )
+    t2 = threading.Thread(
+        target=sync_with_server, args=(m2, url), kwargs={"poll_interval": 0.1}
+    )
+    t1.start()
+    t2.start()
+    t1.join()
+    t2.join()
+
+    r = requests.get(f"{url}/weights")
+    data = r.json()
+    assert data["weights"] == [2.0, 3.0]
+    assert data["intercept"] == 1.0
+
+    with open(m1) as f:
+        m1_data = json.load(f)
+    with open(m2) as f:
+        m2_data = json.load(f)
+    assert m1_data["coefficients"] == m2_data["coefficients"] == [2.0, 3.0]
+    assert m1_data["intercept"] == m2_data["intercept"] == 1.0
+
+    server.should_exit = True
+    thread.join(timeout=5)
+


### PR DESCRIPTION
## Summary
- add simple FastAPI-based federated averaging server for model weights
- extend training script to sync weights with server via new `--federated-server` flag
- add unit test covering two clients averaging their updates

## Testing
- `pytest tests/test_federated_server.py -q`
- `pytest -q` *(fails: Missing dependencies such as Protobuf runtime version mismatch, aiohttp, capnp)*

------
https://chatgpt.com/codex/tasks/task_e_689797ef8d04832f8ffd59515ee87b7d