### PR TITLE
Validate stream events

### DIFF
--- a/tests/test_stream_listener_validation.py
+++ b/tests/test_stream_listener_validation.py
@@ -1,0 +1,67 @@
+import logging
+from types import SimpleNamespace
+from pathlib import Path
+
+import sys
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from scripts import stream_listener as sl
+
+
+def test_trade_validation(monkeypatch, caplog):
+    records = []
+
+    def fake_append(path, record):
+        records.append(record)
+
+    monkeypatch.setattr(sl, "append_csv", fake_append)
+
+    msg = SimpleNamespace(
+        eventId="bad",  # invalid type
+        eventTime="t",
+        brokerTime="b",
+        localTime="l",
+        action="OPEN",
+        ticket=1,
+        magic=0,
+        source="src",
+        symbol="X",
+        orderType=0,
+        lots=0.1,
+        price=1.0,
+        sl=0.0,
+        tp=0.0,
+        profit=0.0,
+        comment="",
+        remainingLots=0.0,
+        decisionId=0,
+    )
+    with caplog.at_level(logging.WARNING):
+        sl.process_trade(msg)
+    assert not records
+    assert "invalid trade event" in caplog.text
+
+
+def test_metric_validation(monkeypatch, caplog):
+    records = []
+
+    def fake_append(path, record):
+        records.append(record)
+
+    monkeypatch.setattr(sl, "append_csv", fake_append)
+
+    msg = SimpleNamespace(
+        time="t",
+        magic=0,
+        winRate=0.1,
+        avgProfit=0.2,
+        tradeCount="bad",  # invalid type
+        drawdown=0.0,
+        sharpe=0.0,
+        fileWriteErrors=0,
+        socketErrors=0,
+        bookRefreshSeconds=0,
+    )
+    with caplog.at_level(logging.WARNING):
+        sl.process_metric(msg)
+    assert not records
+    assert "invalid metric event" in caplog.text


### PR DESCRIPTION
## Summary
- add Pydantic models for trade and metric events
- validate ZeroMQ stream messages before logging
- test malformed trade and metric messages are rejected

## Testing
- `pytest tests/test_stream_listener.py tests/test_stream_listener_binary.py tests/test_stream_listener_validation.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68979b38f468832f9a5787612a6cb593