### PR TITLE
Add regime detection and gating support

### DIFF
--- a/experts/StrategyTemplate.mq4
+++ b/experts/StrategyTemplate.mq4
@@ -801,7 +801,17 @@ void OnTick()
       return;
    }
 
-   double prob = GetProbability();
+   UpdateFeatureHistory();
+   int modelIdx = SelectExpert();
+   double prob;
+   if(LSTMSequenceLength > 0 && ArraySize(TransformerDenseWeights) > 0)
+      prob = ComputeDecisionTransformerScore();
+   else if(LSTMSequenceLength > 0 && ArraySize(LSTMDenseWeights) > 0)
+      prob = ComputeLSTMScore();
+   else if(ArraySize(NNLayer1Weights) > 0)
+      prob = ComputeNNScore();
+   else
+      prob = ComputeLogisticScoreSession(modelIdx);
 
    double feats[100];
    for(int i=0; i<FeatureCount && i<100; i++)

--- a/scripts/detect_regime.py
+++ b/scripts/detect_regime.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Cluster historical feature vectors into market regimes and label each sample.
+
+This utility reuses the feature extraction from :mod:`train_target_clone` to
+load trade logs, cluster the resulting feature vectors using either KMeans or
+HDBSCAN and write the regime assignments along with the cluster centers to a
+JSON file.
+"""
+import argparse
+import json
+from pathlib import Path
+from typing import List
+
+import numpy as np
+from sklearn.cluster import KMeans
+from sklearn.feature_extraction import DictVectorizer
+
+try:  # optional dependency
+    import hdbscan  # type: ignore
+except Exception:  # pragma: no cover - optional
+    hdbscan = None
+
+from train_target_clone import _load_logs, _extract_features  # type: ignore
+
+
+def detect_regimes(
+    data_dir: Path,
+    out_file: Path,
+    clusters: int = 3,
+    algorithm: str = "kmeans",
+) -> None:
+    """Cluster feature vectors and write regime IDs and centers to ``out_file``."""
+    rows_df, _, _ = _load_logs(data_dir)
+    feats, *_ = _extract_features(rows_df.to_dict("records"))
+    if not feats:
+        raise ValueError("No features found for clustering")
+
+    vec = DictVectorizer(sparse=False)
+    X = vec.fit_transform(feats)
+    mean = X.mean(axis=0)
+    std = X.std(axis=0)
+    std[std == 0] = 1.0
+    X_scaled = (X - mean) / std
+
+    labels: np.ndarray
+    centers_arr: np.ndarray
+    if algorithm == "hdbscan" and hdbscan is not None:
+        clusterer = hdbscan.HDBSCAN(min_cluster_size=max(2, clusters))
+        labels = clusterer.fit_predict(X_scaled)
+        centers: List[np.ndarray] = []
+        for lbl in sorted(set(labels)):
+            if lbl == -1:
+                continue  # noise
+            centers.append(X_scaled[labels == lbl].mean(axis=0))
+        centers_arr = np.vstack(centers) if centers else np.empty((0, X.shape[1]))
+    else:
+        km = KMeans(n_clusters=clusters, n_init=10, random_state=42)
+        labels = km.fit_predict(X_scaled)
+        centers_arr = km.cluster_centers_
+
+    model = {
+        "feature_names": vec.get_feature_names_out().tolist(),
+        "mean": mean.astype(float).tolist(),
+        "std": std.astype(float).tolist(),
+        "centers": centers_arr.astype(float).tolist(),
+        "labels": labels.astype(int).tolist(),
+        "algorithm": algorithm,
+    }
+    out_file.write_text(json.dumps(model))
+
+
+def main() -> None:
+    p = argparse.ArgumentParser()
+    p.add_argument("--data-dir", required=True, type=Path)
+    p.add_argument("--out-file", type=Path, default=Path("regime_detection.json"))
+    p.add_argument("--clusters", type=int, default=3)
+    p.add_argument(
+        "--algorithm",
+        choices=["kmeans", "hdbscan"],
+        default="kmeans",
+        help="clustering algorithm",
+    )
+    args = p.parse_args()
+    detect_regimes(args.data_dir, args.out_file, args.clusters, args.algorithm)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_regime_gating.py
+++ b/tests/test_regime_gating.py
@@ -1,0 +1,42 @@
+import json
+from pathlib import Path
+
+from scripts.generate_mql4_from_model import generate
+
+
+def _select(gating, x):
+    coeff = gating["coefficients"]
+    intercepts = gating["intercepts"]
+    best = 0
+    best_z = -1e9
+    for idx, (row, b) in enumerate(zip(coeff, intercepts)):
+        z = b
+        for c in row:
+            z += c * x
+        if z > best_z:
+            best_z = z
+            best = idx
+    return best
+
+
+def test_regime_gating_selects_models(tmp_path: Path):
+    model = {
+        "model_id": "regime",
+        "feature_names": ["x"],
+        "meta_model": {
+            "feature_names": ["x"],
+            "coefficients": [[1.0], [-1.0]],
+            "intercepts": [0.0, 0.0],
+        },
+        "regime_models": [
+            {"regime": 0, "coefficients": [1.0], "intercept": 0.0, "feature_names": ["x"]},
+            {"regime": 1, "coefficients": [-1.0], "intercept": 0.0, "feature_names": ["x"]},
+        ],
+        "threshold": 0.5,
+    }
+    model_file = tmp_path / "model.json"
+    model_file.write_text(json.dumps(model))
+    out_dir = tmp_path / "out"
+    generate(model_file, out_dir)
+    gating = model["meta_model"]
+    assert _select(gating, 1.0) != _select(gating, -1.0)


### PR DESCRIPTION
## Summary
- add detect_regime utility to cluster historical features and assign regime IDs
- train per-regime models with a meta-model gating classifier in train_target_clone
- generate MQL4 strategy with gating-aware coefficients and runtime regime selection

## Testing
- `pytest tests/test_regime_gating.py tests/test_meta_strategy.py::test_regime_switch_triggers_model_change tests/test_meta_strategy.py::test_generate_with_gating -q`


------
https://chatgpt.com/codex/tasks/task_e_6897a6654df0832f8facd68c66e9a714