### PR TITLE
Handle and weight uncertain decisions

### DIFF
--- a/scripts/label_uncertain.py
+++ b/scripts/label_uncertain.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Label uncertain model decisions.
+
+Reads ``uncertain_decisions.csv`` and writes ``uncertain_decisions_labeled.csv``
+with an additional ``label`` column. Labels may be provided interactively or
+set for all rows via ``--label`` to support simple heuristic labeling.
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+from pathlib import Path
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Label uncertain decisions")
+    parser.add_argument("input", help="CSV file with uncertain decisions")
+    parser.add_argument(
+        "output",
+        nargs="?",
+        default="uncertain_decisions_labeled.csv",
+        help="output CSV file with labels",
+    )
+    parser.add_argument(
+        "--label",
+        type=int,
+        choices=[0, 1],
+        help="assign this label to all rows instead of prompting",
+    )
+    args = parser.parse_args()
+
+    in_path = Path(args.input)
+    out_path = Path(args.output)
+
+    rows: list[dict[str, str]] = []
+    with in_path.open(newline="") as f:
+        reader = csv.DictReader(f, delimiter=";")
+        fieldnames = reader.fieldnames or []
+        for row in reader:
+            if args.label is None:
+                print(f"Features: {row.get('features', '')}")
+                lbl = input("Label (0/1): ").strip() or "0"
+            else:
+                lbl = str(args.label)
+            row["label"] = lbl
+            rows.append(row)
+    if "label" not in fieldnames:
+        fieldnames.append("label")
+    with out_path.open("w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames, delimiter=";")
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    main()


### PR DESCRIPTION
## Summary
- Flag model decisions near the threshold and log them to a dedicated `uncertain_decisions.csv`
- Provide `scripts/label_uncertain.py` to label logged uncertainties
- Train pipeline loads labeled uncertainties and up-weights them during fitting

## Testing
- `pytest` *(fails: AssertionError: assert False; NameError: name 'flight_uri' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6897e88fad7c832f8edc5345aafb5286