### PR TITLE
Use Arrow Flight for trade and metric streaming

### DIFF
--- a/tests/test_flight_server.py
+++ b/tests/test_flight_server.py
@@ -5,7 +5,7 @@ import pyarrow as pa
 import pyarrow.flight as flight
 
 from scripts.flight_server import FlightServer
-from schemas import METRIC_SCHEMA
+from schemas import METRIC_SCHEMA, TRADE_SCHEMA
 
 
 def test_flight_server_roundtrip():
@@ -17,9 +17,11 @@ def test_flight_server_roundtrip():
         time.sleep(0.01)
 
     client = flight.FlightClient(f"grpc://127.0.0.1:{server.port}")
-    desc = flight.FlightDescriptor.for_path("metrics")
-    writer, _ = client.do_put(desc, METRIC_SCHEMA)
-    batch = pa.record_batch([
+
+    # send a metrics batch
+    m_desc = flight.FlightDescriptor.for_path("metrics")
+    m_writer, _ = client.do_put(m_desc, METRIC_SCHEMA)
+    m_batch = pa.record_batch([
         pa.array([1]),
         pa.array(["2024-01-01T00:00:00"]),
         pa.array([1]),
@@ -32,13 +34,58 @@ def test_flight_server_roundtrip():
         pa.array([0]),
         pa.array([5]),
     ], schema=METRIC_SCHEMA)
-    writer.write_batch(batch)
-    writer.close()
+    m_writer.write_batch(m_batch)
+    m_writer.close()
 
-    info = client.get_flight_info(desc)
-    reader = client.do_get(info.endpoints[0].ticket)
-    table = reader.read_all()
-    assert table.num_rows == 1
+    # send a trade batch
+    t_desc = flight.FlightDescriptor.for_path("trades")
+    t_writer, _ = client.do_put(t_desc, TRADE_SCHEMA)
+    t_batch = pa.record_batch([
+        pa.array([1]),  # schema_version
+        pa.array([1]),  # event_id
+        pa.array(["trace"]),
+        pa.array(["2024-01-01T00:00:00"]),
+        pa.array(["2024-01-01T00:00:00"]),
+        pa.array(["2024-01-01T00:00:00"]),
+        pa.array(["OPEN"]),
+        pa.array([1]),
+        pa.array([1]),
+        pa.array(["src"]),
+        pa.array(["EURUSD"]),
+        pa.array([0]),
+        pa.array([1.0]),
+        pa.array([1.0]),
+        pa.array([0.0]),
+        pa.array([0.0]),
+        pa.array([0.0]),
+        pa.array([0.0]),
+        pa.array([0.0]),
+        pa.array(["c"]),
+        pa.array([0.0]),
+        pa.array([0.0]),
+        pa.array([0]),
+        pa.array([""]),
+        pa.array([0.0]),
+        pa.array([0.0]),
+        pa.array([0.0]),
+        pa.array([0.0]),
+        pa.array([0.0]),
+        pa.array([0]),
+    ], schema=TRADE_SCHEMA)
+    t_writer.write_batch(t_batch)
+    t_writer.close()
+
+    # verify metrics
+    m_info = client.get_flight_info(m_desc)
+    m_reader = client.do_get(m_info.endpoints[0].ticket)
+    m_table = m_reader.read_all()
+    assert m_table.num_rows == 1
+
+    # verify trades
+    t_info = client.get_flight_info(t_desc)
+    t_reader = client.do_get(t_info.endpoints[0].ticket)
+    t_table = t_reader.read_all()
+    assert t_table.num_rows == 1
 
     server.shutdown()
     t.join(timeout=1)


### PR DESCRIPTION
## Summary
- replace Kafka hooks in Observer_TBot with a single Arrow Flight client for trades and metrics
- validate trade and metric paths in the Flight server
- test Flight server round-trips for both trades and metrics

## Testing
- `pip install pyarrow pytest`
- `pytest tests/test_flight_server.py::test_flight_server_roundtrip -q`


------
https://chatgpt.com/codex/tasks/task_e_6897effeb784832f908228ffd6817499