### PR TITLE
Integrate news sentiment features

### DIFF
--- a/experts/StrategyTemplate.mq4
+++ b/experts/StrategyTemplate.mq4
@@ -84,6 +84,8 @@ double CachedBookBidVol = 0.0;
 double CachedBookAskVol = 0.0;
 double CachedBookImbalance = 0.0;
 datetime CachedBookTime = 0;
+double CachedNewsSentiment = 0.0;
+datetime CachedNewsTime = 0;
 int EncoderWindow = __ENCODER_WINDOW__;
 int EncoderDim = __ENCODER_DIM__;
 double EncoderWeights[] = {__ENCODER_WEIGHTS__};
@@ -515,6 +517,27 @@ double PairCorrelation(string sym1, string sym2, int window=5)
    if(den1 <= 0 || den2 <= 0)
       return(0.0);
    return(num / MathSqrt(den1 * den2));
+}
+
+double GetNewsSentiment()
+{
+   if(TimeCurrent() == CachedNewsTime)
+      return(CachedNewsSentiment);
+   CachedNewsTime = TimeCurrent();
+   CachedNewsSentiment = 0.0;
+   int h = FileOpen("news_sentiment.csv", FILE_READ|FILE_CSV|FILE_COMMON, ';');
+   if(h == INVALID_HANDLE)
+      return(0.0);
+   while(!FileIsEnding(h))
+   {
+      string ts = FileReadString(h);
+      string sym = FileReadString(h);
+      double sc = FileReadNumber(h);
+      if(sym == SymbolToTrade)
+         CachedNewsSentiment = sc;
+   }
+   FileClose(h);
+   return(CachedNewsSentiment);
 }
 
 double GetFeature(int index)

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,7 @@ websocket-client
 requests
 confluent-kafka[avro]
 fastavro
+transformers
 
 # Optional extras
 xgboost; extra == "xgboost"

--- a/scripts/fetch_news.py
+++ b/scripts/fetch_news.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Fetch financial news and compute sentiment scores.
+
+This utility downloads recent headlines for given symbols and scores them using
+FinBERT from the :mod:`transformers` library.  Scores are stored in a SQLite
+and CSV file keeping only a rolling window of recent entries per symbol.
+
+Example
+-------
+    python scripts/fetch_news.py EURUSD GBPUSD
+
+Environment variables
+---------------------
+``NEWSAPI_API_KEY`` may be set to provide an API key for the NewsAPI.org
+service.  When no key is provided, the script simply exits without updating
+any data.
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import os
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable, List, Tuple
+
+import requests
+import pandas as pd
+
+
+_MODEL_NAME = "yiyanghkust/finbert-tone"
+_PIPELINE = None
+
+
+def _get_pipeline():
+    """Lazily construct the FinBERT sentiment pipeline."""
+    global _PIPELINE
+    if _PIPELINE is None:
+        from transformers import (
+            AutoModelForSequenceClassification,
+            AutoTokenizer,
+            pipeline,
+        )
+
+        tokenizer = AutoTokenizer.from_pretrained(_MODEL_NAME)
+        model = AutoModelForSequenceClassification.from_pretrained(_MODEL_NAME)
+        _PIPELINE = pipeline("sentiment-analysis", model=model, tokenizer=tokenizer)
+    return _PIPELINE
+
+
+def compute_sentiment(headlines: Iterable[str]) -> float:
+    """Return average FinBERT sentiment score for ``headlines``.
+
+    Positive scores indicate optimistic sentiment, negative scores indicate
+    pessimism.  Neutral headlines contribute ``0``.
+    """
+    nlp = _get_pipeline()
+    scores: List[float] = []
+    for hl in headlines:
+        if not hl:
+            continue
+        result = nlp(hl)[0]
+        label = result.get("label", "").lower()
+        score = float(result.get("score", 0.0))
+        if label.startswith("positive"):
+            scores.append(score)
+        elif label.startswith("negative"):
+            scores.append(-score)
+        else:
+            scores.append(0.0)
+    return float(sum(scores) / len(scores)) if scores else 0.0
+
+
+def fetch_headlines(symbol: str) -> List[str]:
+    """Fetch recent headlines for ``symbol`` using NewsAPI."""
+    api_key = os.getenv("NEWSAPI_API_KEY")
+    if not api_key:
+        return []
+    url = "https://newsapi.org/v2/everything"
+    params = {"q": symbol, "apiKey": api_key, "sortBy": "publishedAt"}
+    try:
+        resp = requests.get(url, params=params, timeout=10)
+        resp.raise_for_status()
+        data = resp.json()
+        return [a.get("title", "") for a in data.get("articles", [])]
+    except Exception:
+        return []
+
+
+def _ensure_schema(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS sentiment (symbol TEXT, timestamp TEXT, score REAL)"
+    )
+
+
+def _prune_old_entries(conn: sqlite3.Connection, window: int) -> None:
+    cur = conn.cursor()
+    syms = [row[0] for row in cur.execute("SELECT DISTINCT symbol FROM sentiment").fetchall()]
+    for sym in syms:
+        cur.execute(
+            "DELETE FROM sentiment WHERE rowid NOT IN ("  # keep most recent ``window`` rows
+            "SELECT rowid FROM sentiment WHERE symbol=? ORDER BY timestamp DESC LIMIT ?)",
+            (sym, window),
+        )
+    conn.commit()
+
+
+def update_store(
+    symbols: Iterable[str],
+    db_path: Path,
+    csv_path: Path,
+    window: int = 50,
+) -> None:
+    """Fetch headlines for ``symbols`` and update sentiment store."""
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(db_path)
+    _ensure_schema(conn)
+    now = datetime.now(timezone.utc).isoformat()
+    rows: List[Tuple[str, str, float]] = []
+    for sym in symbols:
+        headlines = fetch_headlines(sym)
+        score = compute_sentiment(headlines)
+        conn.execute(
+            "INSERT INTO sentiment(symbol, timestamp, score) VALUES(?,?,?)",
+            (sym, now, score),
+        )
+        rows.append((sym, now, score))
+    _prune_old_entries(conn, window)
+    conn.commit()
+    # export to CSV for non-python consumers
+    df = pd.read_sql_query(
+        "SELECT symbol, timestamp, score FROM sentiment ORDER BY timestamp",
+        conn,
+    )
+    conn.close()
+    df.to_csv(csv_path, index=False)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Fetch news sentiment for symbols")
+    parser.add_argument("symbols", nargs="+", help="Symbols to fetch, e.g. EURUSD")
+    parser.add_argument("--db", type=Path, default=Path("news_sentiment.db"))
+    parser.add_argument("--csv", type=Path, default=Path("news_sentiment.csv"))
+    parser.add_argument("--window", type=int, default=50)
+    args = parser.parse_args()
+    if not os.getenv("NEWSAPI_API_KEY"):
+        print("NEWSAPI_API_KEY not set; skipping fetch")
+    else:
+        update_store(args.symbols, args.db, args.csv, args.window)

--- a/scripts/generate_mql4_from_model.py
+++ b/scripts/generate_mql4_from_model.py
@@ -415,6 +415,8 @@ def generate(
             elif name.startswith('ae') and name[2:].isdigit():
                 idx_ae = int(name[2:])
                 expr = f'GetEncodedFeature({idx_ae})'
+            elif name == 'news_sentiment':
+                expr = 'GetNewsSentiment()'
         if expr is None:
             expr = '0.0'
         cases.append(f"      case {idx}:\n         val = ({expr});\n         break;")

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -199,6 +199,26 @@ def test_atr_bollinger_features(tmp_path: Path):
     assert "iBands(SymbolToTrade" in content
 
 
+def test_news_sentiment_feature(tmp_path: Path):
+    model = {
+        "model_id": "ns",
+        "magic": 111,
+        "coefficients": [0.1],
+        "intercept": 0.0,
+        "threshold": 0.5,
+        "feature_names": ["news_sentiment"],
+    }
+    model_file = tmp_path / "model.json"
+    with open(model_file, "w") as f:
+        json.dump(model, f)
+    out_dir = tmp_path / "out"
+    generate(model_file, out_dir)
+    generated = list(out_dir.glob("Generated_ns_*.mq4"))
+    assert len(generated) == 1
+    content = generated[0].read_text()
+    assert "GetNewsSentiment()" in content
+
+
 def test_stochastic_adx_features(tmp_path: Path):
     model = {
         "model_id": "stoch",

--- a/tests/test_news_sentiment.py
+++ b/tests/test_news_sentiment.py
@@ -1,0 +1,128 @@
+import csv
+import json
+from datetime import datetime
+from pathlib import Path
+
+import scripts.fetch_news as fetch_news
+from scripts.train_target_clone import train
+
+
+def _write_sample_log(file: Path):
+    fields = [
+        "event_id",
+        "event_time",
+        "broker_time",
+        "local_time",
+        "action",
+        "ticket",
+        "magic",
+        "source",
+        "symbol",
+        "order_type",
+        "lots",
+        "price",
+        "sl",
+        "tp",
+        "profit",
+        "spread",
+        "comment",
+        "remaining_lots",
+        "slippage",
+        "volume",
+        "open_time",
+        "book_bid_vol",
+        "book_ask_vol",
+        "book_imbalance",
+        "sl_hit_dist",
+        "tp_hit_dist",
+    ]
+    rows = [
+        [
+            "1",
+            "2024.01.01 00:00:00",
+            "",
+            "",
+            "OPEN",
+            "1",
+            "",
+            "",
+            "EURUSD",
+            "0",
+            "0.1",
+            "1.1000",
+            "1.0950",
+            "1.1100",
+            "0",
+            "2",
+            "",
+            "0.1",
+            "0.0001",
+            "100",
+            "",
+            "0",
+            "0",
+            "0",
+            "0",
+            "0",
+        ],
+        [
+            "2",
+            "2024.01.01 01:00:00",
+            "",
+            "",
+            "OPEN",
+            "2",
+            "",
+            "",
+            "EURUSD",
+            "1",
+            "0.1",
+            "1.2000",
+            "1.1950",
+            "1.2100",
+            "0",
+            "3",
+            "",
+            "0.1",
+            "0.0002",
+            "200",
+            "",
+            "0",
+            "0",
+            "0",
+            "0",
+            "0",
+        ],
+    ]
+    with open(file, "w", newline="") as f:
+        writer = csv.writer(f, delimiter=";")
+        writer.writerow(fields)
+        writer.writerows(rows)
+
+
+def test_news_sentiment_in_model(tmp_path, monkeypatch):
+    class DummyPipe:
+        def __call__(self, text):
+            return [{"label": "positive", "score": 0.8}]
+
+    monkeypatch.setattr(fetch_news, "_get_pipeline", lambda: DummyPipe())
+    score = fetch_news.compute_sentiment(["Great earnings for EURUSD"])
+    assert score > 0
+
+    sent_file = tmp_path / "news.csv"
+    with open(sent_file, "w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(["timestamp", "symbol", "score"])
+        writer.writerow([datetime(2024, 1, 1).isoformat(), "EURUSD", score])
+
+    data_dir = tmp_path / "logs"
+    data_dir.mkdir()
+    _write_sample_log(data_dir / "trades_sample.csv")
+
+    out_dir = tmp_path / "out"
+    train(data_dir, out_dir, news_sentiment_file=sent_file)
+
+    model_file = out_dir / "model.json"
+    with open(model_file) as f:
+        model = json.load(f)
+    assert "news_sentiment" in model.get("feature_names", [])


### PR DESCRIPTION
## Summary
- fetch FinBERT-based news sentiment and store rolling scores
- merge news_sentiment into feature extraction and MQL4 generation
- add tests for sentiment feature and include transformers dependency

## Testing
- `pytest tests/test_news_sentiment.py tests/test_generate.py`

------
https://chatgpt.com/codex/tasks/task_e_689817778498832f97fda66539e36fd4