### PR TITLE
Add schema version checks for observer messages

### DIFF
--- a/schemas/VERSION_HISTORY.md
+++ b/schemas/VERSION_HISTORY.md
@@ -1,0 +1,4 @@
+# Version History
+
+## 1
+- Initial schema version. Observer messages prepend this version byte and consumers validate it.


### PR DESCRIPTION
## Summary
- prefix trade and metric messages with `SCHEMA_VERSION`
- validate schema version in stream and metric consumers
- record initial version in `schemas/VERSION_HISTORY.md`

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pip install -r requirements.txt` *(fails: ImportError: cannot import name 'build_py_2to3')*

------
https://chatgpt.com/codex/tasks/task_e_6898d4d4137c832f8a59215d803fd9a4