### PR TITLE
Add change point detection to anomaly monitor

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,7 @@ fastapi
 uvicorn
 websocket-client
 requests
+ruptures
 nats-py
 confluent-kafka[avro]
 fastavro

--- a/scripts/anomaly_monitor.py
+++ b/scripts/anomaly_monitor.py
@@ -12,9 +12,15 @@ from email.message import EmailMessage
 from pathlib import Path
 
 import pandas as pd
+import ruptures as rpt
 from sklearn.ensemble import IsolationForest
 
-from otel_logging import setup_logging
+try:  # pragma: no cover - fallback for package import
+    from otel_logging import setup_logging
+except ImportError:  # pragma: no cover
+    from scripts.otel_logging import setup_logging
+from opentelemetry import trace
+from opentelemetry.trace import format_trace_id
 
 
 def _send_email(server: str, port: int, to_addr: str, body: str) -> None:
@@ -38,6 +44,37 @@ def _iforest_anomaly(series: pd.Series, threshold: float) -> bool:
     model = IsolationForest(contamination=threshold)
     preds = model.fit_predict(series.to_frame())
     return preds[-1] == -1
+
+
+def _ruptures_change_point(
+    series: pd.Series, penalty: float, window: int = 5
+) -> bool:
+    if len(series) < window * 2:
+        return False
+    algo = rpt.Pelt(model="rbf").fit(series.values)
+    result = algo.predict(pen=penalty)
+    if len(result) >= 2 and len(series) - result[-2] <= window:
+        return True
+    return False
+
+
+def detect_change_points(
+    df: pd.DataFrame, metrics: list[str], penalty: float, log: logging.Logger | None = None
+) -> list[str]:
+    hits: list[str] = []
+    for metric in metrics:
+        if metric not in df:
+            continue
+        series = df[metric].astype(float)
+        if _ruptures_change_point(series, penalty):
+            hits.append(metric)
+            if log is not None:
+                span = trace.get_current_span()
+                trace_id = format_trace_id(span.get_span_context().trace_id)
+                log.warning(
+                    f"Change point detected for {metric} trace_id={trace_id}: {series.iloc[-1]}"
+                )
+    return hits
 
 
 def check_anomaly(df: pd.DataFrame, metric: str, method: str, threshold: float) -> bool:
@@ -83,6 +120,18 @@ def main() -> None:
             conn.close()
             if not df.empty:
                 last_row = int(df["rowid"].max())
+                hits = detect_change_points(
+                    df, ["win_rate", "drawdown"], args.threshold, log
+                )
+                for metric in hits:
+                    span = trace.get_current_span()
+                    trace_id = format_trace_id(span.get_span_context().trace_id)
+                    if args.email:
+                        body = (
+                            f"Change point detected for {metric} trace_id={trace_id}: "
+                            f"{df[metric].iloc[-1]}"
+                        )
+                        _send_email(args.smtp_server, args.smtp_port, args.email, body)
                 if check_anomaly(df, args.metric, args.method, args.threshold):
                     body = f"Anomaly detected for {args.metric}: {df[args.metric].iloc[-1]}"
                     log.warning(body)

--- a/tests/test_anomaly_monitor_cp.py
+++ b/tests/test_anomaly_monitor_cp.py
@@ -1,0 +1,30 @@
+import logging
+import sys
+from pathlib import Path
+
+import pandas as pd
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from scripts.anomaly_monitor import detect_change_points
+
+
+def test_change_point_alert(caplog):
+    df = pd.DataFrame(
+        {
+            "rowid": range(1, 16),
+            "win_rate": [0.5] * 10 + [0.9] * 5,
+            "drawdown": [0.1] * 10 + [0.5] * 5,
+        }
+    )
+    trace.set_tracer_provider(TracerProvider())
+    tracer = trace.get_tracer("test_cp")
+    log = logging.getLogger("anomaly_monitor")
+    caplog.set_level(logging.WARNING, logger="anomaly_monitor")
+    with tracer.start_as_current_span("cp_test"):
+        hits = detect_change_points(df, ["win_rate", "drawdown"], penalty=0.5, log=log)
+    assert set(hits) == {"win_rate", "drawdown"}
+    messages = [r.getMessage() for r in caplog.records if "Change point detected" in r.getMessage()]
+    assert any("win_rate" in m for m in messages)
+    assert any("trace_id=" in m for m in messages)


### PR DESCRIPTION
## Summary
- analyze win_rate and drawdown series for change points using ruptures
- log alerts with trace IDs and allow optional emails
- add unit test simulating metric shift

## Testing
- `pytest tests/test_anomaly_monitor_cp.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'psutil')*


------
https://chatgpt.com/codex/tasks/task_e_6898e8ab4200832f860254f1f35ab098