### PR TITLE
Add incremental online trainer with model reload documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,17 @@ The EA records trade openings and closings using the `OnTradeTransaction` callba
    python scripts/promote_best_models.py models --dest models/best
    ```
 
+## Online Training
+
+`scripts/online_trainer.py` keeps a model updated as new trades arrive.  It can
+tail ``logs/trades_raw.csv`` or consume newline-delimited JSON records from a
+socket and applies :func:`sklearn.linear_model.SGDClassifier.partial_fit`
+after each batch.  When the coefficients change the updated ``model.json`` is
+written and ``generate_mql4_from_model.py`` is invoked to rebuild the strategy
+source.  Set ``ReloadModelInterval`` on the EA so it periodically reloads the
+file from the terminal's ``Files`` directory and continues trading with the new
+parameters.
+
 ## Dashboard
 
 A small web dashboard can display trades, metrics and training progress in real time.

--- a/experts/StrategyTemplate.mq4
+++ b/experts/StrategyTemplate.mq4
@@ -895,6 +895,9 @@ bool HasOpenOrders()
 
 void OnTick()
 {
+   // When ReloadModelInterval is set, periodically check for updated
+   // coefficients written by ``online_trainer.py`` and reload them without
+   // recompiling the EA.
    if(ReloadModelInterval > 0 && TimeCurrent() - LastModelLoad >= ReloadModelInterval)
    {
       if(LoadModel())

--- a/scripts/online_trainer.py
+++ b/scripts/online_trainer.py
@@ -1,170 +1,190 @@
 #!/usr/bin/env python3
-"""Online trainer that updates a River model from streaming events."""
+"""Incrementally update a model from streaming trade events.
+
+The trainer is designed to run continuously.  It tails
+``logs/trades_raw.csv`` or consumes newline-delimited JSON records from a
+socket.  After each batch it updates an :class:`~sklearn.linear_model.SGDClassifier`
+using :meth:`partial_fit` and persists the coefficients to ``model.json``.
+Whenever the coefficients change the script invokes
+``generate_mql4_from_model.py`` so the corresponding Expert Advisor can be
+reloaded by MetaTrader.
+
+This module intentionally keeps dependencies light so it can run alongside the
+MetaTrader terminal on modest hardware.
+"""
 from __future__ import annotations
 
 import argparse
 import asyncio
+import csv
 import json
+import subprocess
+import sys
 import time
-from collections import defaultdict
 from pathlib import Path
-from typing import Dict, Any, Optional
+from typing import Iterable, List, Dict, Any
 
-from river.linear_model import LogisticRegression
-from river.tree import HoeffdingTreeClassifier
-from river import stats
-
-# optional imports for gRPC message definitions
-try:
-    from proto import observer_pb2, observer_pb2_grpc  # type: ignore
-except Exception:  # pragma: no cover - proto generation not always available
-    observer_pb2 = observer_pb2_grpc = None
+import numpy as np
+from sklearn.linear_model import SGDClassifier
 
 
 class OnlineTrainer:
-    """Incrementally train a model from streamed events."""
+    """Manage incremental updates and model persistence."""
 
     def __init__(
         self,
-        model_type: str = "logistic",
-        save_path: Path | str = Path("model_online.json"),
-        save_interval: int = 5,
+        model_path: Path | str = Path("model.json"),
+        batch_size: int = 32,
+        run_generator: bool = True,
     ) -> None:
-        self.model_name = model_type
-        if model_type == "logistic":
-            self.model = LogisticRegression()
-        else:
-            self.model = HoeffdingTreeClassifier()
-        self.save_path = Path(save_path)
-        self.save_interval = save_interval * 60  # minutes -> seconds
-        self.last_save = time.time()
-        self.last_event_id = 0
-        self.feature_stats: Dict[str, stats.Mean] = defaultdict(stats.Mean)
-        if self.save_path.exists():
+        self.model_path = Path(model_path)
+        self.batch_size = batch_size
+        self.run_generator = run_generator
+        self.clf = SGDClassifier(loss="log_loss")
+        self.feature_names: List[str] = []
+        self._prev_coef: List[float] | None = None
+        if self.model_path.exists():
             self._load()
 
     # ------------------------------------------------------------------
     # Model persistence
     # ------------------------------------------------------------------
     def _load(self) -> None:
+        """Restore coefficients from ``model.json`` if present."""
         try:
-            with open(self.save_path, "r") as f:
-                data = json.load(f)
+            data = json.loads(self.model_path.read_text())
         except Exception:
             return
-        self.last_event_id = data.get("last_event_id", 0)
-        for f, info in data.get("feature_stats", {}).items():
-            m = stats.Mean()
-            m.n = info.get("count", 0)
-            m.mean = info.get("mean", 0.0)
-            self.feature_stats[f] = m
-        if data.get("model_type") == "logistic":
-            self.model = LogisticRegression()
-            weights = data.get("coefficients", [])
-            names = data.get("feature_names", [])
-            for n, w in zip(names, weights):
-                self.model._weights[n] = w
-            self.model.intercept = data.get("intercept", 0.0)
-            self.model_name = "logistic"
-        elif data.get("model_type") == "hoeffding_tree":
-            self.model = HoeffdingTreeClassifier()
-            # Minimal restoration: Hoeffding trees in River expose ``__setstate__``
-            # for pickled dictionaries.  Persist ``model_state`` if present.
-            state = data.get("model_state")
-            if state is not None:
-                self.model.__setstate__(state)
-            self.model_name = "hoeffding_tree"
+        self.feature_names = data.get("feature_names", [])
+        coef = data.get("coefficients")
+        intercept = data.get("intercept")
+        if self.feature_names and coef is not None and intercept is not None:
+            n = len(self.feature_names)
+            self.clf.partial_fit(np.zeros((1, n)), [0], classes=np.array([0, 1]))
+            self.clf.coef_ = np.array([coef])
+            self.clf.intercept_ = np.array([intercept])
+            self._prev_coef = list(coef) + [intercept]
 
-    def save_model(self) -> None:
-        feature_names = sorted(self.feature_stats.keys())
-        payload: Dict[str, Any] = {
-            "model_type": self.model_name,
-            "feature_names": feature_names,
-            "last_event_id": self.last_event_id,
-            "feature_stats": {
-                f: {"count": st.n, "mean": st.get()} for f, st in self.feature_stats.items()
-            },
+    def _save(self) -> None:
+        payload = {
+            "feature_names": self.feature_names,
+            "coefficients": self.clf.coef_[0].tolist(),
+            "intercept": float(self.clf.intercept_[0]),
         }
-        if isinstance(self.model, LogisticRegression):
-            payload["coefficients"] = [self.model._weights.get(f, 0.0) for f in feature_names]
-            payload["intercept"] = self.model.intercept
-        elif isinstance(self.model, HoeffdingTreeClassifier):
-            payload["model_state"] = self.model.__getstate__()
-        with open(self.save_path, "w") as f:
-            json.dump(payload, f)
+        self.model_path.write_text(json.dumps(payload))
+
+    def _maybe_generate(self) -> None:
+        if not self.run_generator:
+            return
+        script = Path(__file__).resolve().with_name("generate_mql4_from_model.py")
+        experts_dir = Path(__file__).resolve().parents[1] / "experts"
+        subprocess.run(
+            [sys.executable, str(script), str(self.model_path), str(experts_dir)],
+            check=False,
+        )
 
     # ------------------------------------------------------------------
-    # Event processing
+    # Incremental training
     # ------------------------------------------------------------------
-    def process_event(self, event: Dict[str, Any]) -> None:
-        features = event.get("features", {})
-        target = event.get("y")
-        event_id = event.get("event_id")
-        if event_id is not None:
-            self.last_event_id = int(event_id)
-        if features and target is not None:
-            self.model.learn_one(features, target)
-            for k, v in features.items():
-                self.feature_stats[k].update(v)
-        now = time.time()
-        if now - self.last_save >= self.save_interval:
-            self.save_model()
-            self.last_save = now
+    def _ensure_features(self, keys: Iterable[str]) -> None:
+        new_feats = [k for k in keys if k not in self.feature_names and k != "y"]
+        if not new_feats:
+            return
+        self.feature_names.extend(sorted(new_feats))
+        if hasattr(self.clf, "coef_"):
+            n = len(self.feature_names)
+            coef = np.zeros((1, n))
+            coef[:, : self.clf.coef_.shape[1]] = self.clf.coef_
+            self.clf.coef_ = coef
+
+    def _vectorise(self, batch: List[Dict[str, Any]]):
+        for rec in batch:
+            self._ensure_features(rec.keys())
+        X = [[float(rec.get(f, 0.0)) for f in self.feature_names] for rec in batch]
+        y = [int(rec["y"]) for rec in batch]
+        return np.asarray(X), np.asarray(y)
+
+    def update(self, batch: List[Dict[str, Any]]) -> None:
+        X, y = self._vectorise(batch)
+        if not hasattr(self.clf, "classes_"):
+            self.clf.partial_fit(X, y, classes=np.array([0, 1]))
+        else:
+            self.clf.partial_fit(X, y)
+        coef = self.clf.coef_[0].tolist()
+        intercept = float(self.clf.intercept_[0])
+        if self._prev_coef != coef + [intercept]:
+            self._prev_coef = coef + [intercept]
+            self._save()
+            self._maybe_generate()
 
     # ------------------------------------------------------------------
-    # Streaming interfaces
+    # Data sources
     # ------------------------------------------------------------------
-    async def consume_websocket(self, url: str) -> None:
-        import aiohttp  # imported lazily to avoid mandatory dependency
-
-        async with aiohttp.ClientSession() as session:
-            async with session.ws_connect(url) as ws:
-                async for msg in ws:
-                    if msg.type == aiohttp.WSMsgType.TEXT:
-                        try:
-                            event = json.loads(msg.data)
-                            self.process_event(event)
-                        except Exception:
+    def tail_csv(self, path: Path) -> None:
+        """Continuously follow ``path`` for new rows."""
+        path = Path(path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        pos = 0
+        batch: List[Dict[str, Any]] = []
+        while True:
+            if path.exists():
+                with path.open() as f:
+                    f.seek(pos)
+                    reader = csv.DictReader(f)
+                    for row in reader:
+                        pos = f.tell()
+                        if "y" not in row and "label" not in row:
                             continue
+                        row["y"] = row.get("y") or row.get("label")
+                        batch.append(row)
+                        if len(batch) >= self.batch_size:
+                            self.update(batch)
+                            batch.clear()
+            if batch:
+                self.update(batch)
+                batch.clear()
+            time.sleep(1.0)
 
-    async def consume_grpc(self, target: str) -> None:
-        import grpc  # imported lazily
+    async def consume_socket(self, host: str, port: int) -> None:
+        reader, _ = await asyncio.open_connection(host, port)
+        batch: List[Dict[str, Any]] = []
+        while True:
+            line = await reader.readline()
+            if not line:
+                await asyncio.sleep(0.5)
+                continue
+            try:
+                rec = json.loads(line.decode())
+            except Exception:
+                continue
+            batch.append(rec)
+            if len(batch) >= self.batch_size:
+                self.update(batch)
+                batch.clear()
 
-        if observer_pb2 is None:
-            raise RuntimeError("gRPC proto definitions are not available")
-        async with grpc.aio.insecure_channel(target) as channel:
-            stub = observer_pb2_grpc.ObserverStub(channel)  # type: ignore
-            request = observer_pb2.SubscribeRequest()  # type: ignore
-            async for msg in stub.Subscribe(request):  # type: ignore
-                event = {
-                    "event_id": msg.event.event_id,
-                    "features": dict(msg.event.features),
-                    "y": msg.event.label,
-                }
-                self.process_event(event)
 
-
-def main(argv: Optional[list[str]] = None) -> None:
-    p = argparse.ArgumentParser(description="Online training from decision streams")
-    p.add_argument("--ws-url")
-    p.add_argument("--grpc-url")
-    p.add_argument("--model", choices=["logistic", "hoeffding_tree"], default="logistic")
-    p.add_argument("--save-path", default="model_online.json")
-    p.add_argument("--save-interval", type=int, default=5, help="Minutes between checkpoint saves")
+def main(argv: List[str] | None = None) -> None:
+    p = argparse.ArgumentParser(description="Online incremental trainer")
+    g = p.add_mutually_exclusive_group(required=True)
+    g.add_argument("--csv", type=Path, help="Path to trades_raw.csv to follow")
+    g.add_argument("--socket", help="host:port for JSON line stream")
+    p.add_argument("--model", type=Path, default=Path("model.json"))
+    p.add_argument("--batch-size", type=int, default=32)
+    p.add_argument(
+        "--no-generate",
+        action="store_true",
+        help="Do not run generate_mql4_from_model.py on updates",
+    )
     args = p.parse_args(argv)
-    trainer = OnlineTrainer(args.model, Path(args.save_path), args.save_interval)
-    if args.ws_url:
-        asyncio.run(trainer.consume_websocket(args.ws_url))
-    elif args.grpc_url:
-        asyncio.run(trainer.consume_grpc(args.grpc_url))
+
+    trainer = OnlineTrainer(args.model, args.batch_size, not args.no_generate)
+    if args.csv:
+        trainer.tail_csv(args.csv)
     else:
-        # No streaming source specified; run a dummy loop waiting for events
-        try:
-            while True:
-                time.sleep(1)
-        except KeyboardInterrupt:
-            pass
+        host, port = args.socket.split(":", 1)
+        asyncio.run(trainer.consume_socket(host, int(port)))
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
     main()
+


### PR DESCRIPTION
## Summary
- Implement a long-running `online_trainer.py` that tails `trades_raw.csv` or a socket, incrementally updates an `SGDClassifier`, persists `model.json`, and regenerates the EA when coefficients change
- Explain usage of `ReloadModelInterval` for automatic model reloads in the README and add explanatory comments in `StrategyTemplate.mq4`

## Testing
- `pytest tests/test_online_trainer.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6898f9618614832f9145f6a86f7843c3