### PR TITLE
Add rolling correlation features

### DIFF
--- a/experts/StrategyTemplate.mq4
+++ b/experts/StrategyTemplate.mq4
@@ -499,8 +499,13 @@ double BookImbalance()
    return(CachedBookImbalance);
 }
 
-double PairCorrelation(string sym1, string sym2, int window=5)
+double PairCorrelation(string sym1, string sym2="", int window=5)
 {
+   if(sym2 == "")
+   {
+      sym2 = sym1;
+      sym1 = SymbolToTrade;
+   }
    double mean1 = iMA(sym1, 0, window, 0, MODE_SMA, PRICE_CLOSE, 1);
    double mean2 = iMA(sym2, 0, window, 0, MODE_SMA, PRICE_CLOSE, 1);
    double num = 0.0;

--- a/scripts/generate_mql4_from_model.py
+++ b/scripts/generate_mql4_from_model.py
@@ -408,10 +408,14 @@ def generate(
                 parts = name[6:].split('_')
                 if len(parts) == 2:
                     expr = f'iClose("{parts[0]}", 0, 0) / iClose("{parts[1]}", 0, 0)'
+                elif len(parts) == 1:
+                    expr = f'iClose(SymbolToTrade, 0, 0) / iClose("{parts[0]}", 0, 0)'
             elif name.startswith('corr_'):
                 parts = name[5:].split('_')
                 if len(parts) == 2:
                     expr = f'PairCorrelation("{parts[0]}", "{parts[1]}")'
+                elif len(parts) == 1:
+                    expr = f'PairCorrelation("{parts[0]}")'
             elif name.startswith('ae') and name[2:].isdigit():
                 idx_ae = int(name[2:])
                 expr = f'GetEncodedFeature({idx_ae})'

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -613,21 +613,21 @@ def test_corr_features(tmp_path: Path):
     _write_log(log_file)
     extra = {"USDCHF": [0.9, 0.8]}
 
-    train(data_dir, out_dir, corr_pairs=[("EURUSD", "USDCHF")], extra_price_series=extra)
+    train(data_dir, out_dir, corr_map={"EURUSD": ["USDCHF"]}, extra_price_series=extra)
 
     with open(out_dir / "model.json") as f:
         data = json.load(f)
     feats = data.get("feature_names", [])
-    assert "ratio_EURUSD_USDCHF" in feats
-    assert "corr_EURUSD_USDCHF" in feats
+    assert "ratio_USDCHF" in feats
+    assert "corr_USDCHF" in feats
 
     df, _, _ = _load_logs(data_dir)
     feature_dicts, *_ = _extract_features(
         df.to_dict("records"),
-        corr_pairs=[("EURUSD", "USDCHF")],
+        corr_map={"EURUSD": ["USDCHF"]},
         extra_price_series=extra,
     )
-    assert feature_dicts[1]["ratio_EURUSD_USDCHF"] == pytest.approx(1.1000 / 0.9)
+    assert feature_dicts[1]["ratio_USDCHF"] == pytest.approx(1.1000 / 0.9)
 
 
 def test_slippage_feature(tmp_path: Path):


### PR DESCRIPTION
## Summary
- Support rolling correlations to user-specified peer symbols in feature extraction
- Extend `--corr-symbols` CLI parsing and feature mapping for dynamic peers
- Map correlation/ratio features in MQL generation and strategy template

## Testing
- `pytest tests/test_train.py::test_corr_features -q`

------
https://chatgpt.com/codex/tasks/task_e_6898ff1a72ac832fa09f42cf2bdfe73d