### PR TITLE
Implement shared memory ring buffer and Python/MT4 integration

### DIFF
--- a/scripts/shm_ring.py
+++ b/scripts/shm_ring.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Simple shared memory ring buffer used to pass events between processes.
+
+The implementation is intentionally small and only supports a single
+producer and single consumer.  Messages are stored as ``[length][type][data]``
+where ``length`` is a 32bit little endian integer of the number of bytes
+following (``type`` + ``data``).
+
+The layout of the shared memory region matches the structure defined in
+``shm_ring.h`` so that lightweight C/MQL producers can write directly to
+it while Python readers consume with minimal copying.
+"""
+from __future__ import annotations
+
+import mmap
+import os
+import struct
+from typing import Optional, Tuple
+
+MAGIC = 0x52494E47  # 'RING'
+HEADER_FMT = "<IIII"  # magic, size, head, tail
+HEADER_SIZE = struct.calcsize(HEADER_FMT)
+
+TRADE_MSG = 0
+METRIC_MSG = 1
+
+
+class ShmRing:
+    """Shared memory backed ring buffer.
+
+    The ring is a fixed size buffer with a small header containing the
+    read (``head``) and write (``tail``) offsets.  The class exposes
+    ``push`` and ``pop`` methods for the producer and consumer
+    respectively.  Only a single producer and single consumer are
+    supported.
+    """
+
+    def __init__(self, mm: mmap.mmap, size: int) -> None:
+        self._mm = mm
+        self.size = size
+
+    # ------------------------------------------------------------------
+    # construction helpers
+    # ------------------------------------------------------------------
+    @classmethod
+    def create(cls, path: str, size: int) -> "ShmRing":
+        """Create a new shared memory ring at ``path`` with ``size`` bytes."""
+        fd = os.open(path, os.O_CREAT | os.O_RDWR)
+        total = HEADER_SIZE + size
+        os.ftruncate(fd, total)
+        mm = mmap.mmap(fd, total)
+        struct.pack_into(HEADER_FMT, mm, 0, MAGIC, size, 0, 0)
+        return cls(mm, size)
+
+    @classmethod
+    def open(cls, path: str) -> "ShmRing":
+        """Open an existing ring located at ``path``."""
+        fd = os.open(path, os.O_RDWR)
+        mm = mmap.mmap(fd, 0)
+        magic, size, _, _ = struct.unpack_from(HEADER_FMT, mm, 0)
+        if magic != MAGIC:
+            raise ValueError("invalid shm ring")
+        return cls(mm, size)
+
+    # ------------------------------------------------------------------
+    # low level helpers
+    # ------------------------------------------------------------------
+    def _space(self, head: int, tail: int) -> int:
+        if tail >= head:
+            return self.size - (tail - head) - 1
+        return head - tail - 1
+
+    # ------------------------------------------------------------------
+    # producer API
+    # ------------------------------------------------------------------
+    def push(self, msg_type: int, payload: bytes) -> bool:
+        """Append ``payload`` with ``msg_type`` to the ring.
+
+        Returns ``True`` on success, ``False`` if there was insufficient
+        space.  The caller may retry later.
+        """
+        if isinstance(payload, memoryview):
+            payload = payload.tobytes()
+        data_len = len(payload) + 1  # include type byte
+        needed = 4 + data_len
+        magic, size, head, tail = struct.unpack_from(HEADER_FMT, self._mm, 0)
+        free = self._space(head, tail)
+        if needed > free:
+            return False
+        if tail + needed > size:
+            # mark wrap
+            struct.pack_into("<I", self._mm, HEADER_SIZE + tail, 0)
+            tail = 0
+        struct.pack_into("<I", self._mm, HEADER_SIZE + tail, data_len)
+        tail += 4
+        struct.pack_into("B", self._mm, HEADER_SIZE + tail, msg_type)
+        self._mm[HEADER_SIZE + tail + 1 : HEADER_SIZE + tail + data_len] = payload
+        tail = (tail + data_len) % size
+        struct.pack_into("<II", self._mm, 8, head, tail)
+        return True
+
+    # ------------------------------------------------------------------
+    # consumer API
+    # ------------------------------------------------------------------
+    def pop(self) -> Optional[Tuple[int, memoryview]]:
+        """Retrieve the next message from the ring.
+
+        Returns ``(msg_type, memoryview)`` or ``None`` when the ring is
+        empty.
+        """
+        magic, size, head, tail = struct.unpack_from(HEADER_FMT, self._mm, 0)
+        if head == tail:
+            return None
+        if head + 4 > size:
+            head = 0
+        length = struct.unpack_from("<I", self._mm, HEADER_SIZE + head)[0]
+        if length == 0:  # wrapped
+            head = 0
+            length = struct.unpack_from("<I", self._mm, HEADER_SIZE + head)[0]
+        start = head + 4
+        msg_type = struct.unpack_from("B", self._mm, HEADER_SIZE + start)[0]
+        payload = memoryview(self._mm)[HEADER_SIZE + start + 1 : HEADER_SIZE + start + length]
+        head = (start + length) % size
+        struct.pack_into("<II", self._mm, 8, head, tail)
+        return msg_type, payload
+
+    # ------------------------------------------------------------------
+    def close(self) -> None:
+        self._mm.close()
+
+
+__all__ = ["ShmRing", "TRADE_MSG", "METRIC_MSG"]

--- a/shm_ring.h
+++ b/shm_ring.h
@@ -1,0 +1,114 @@
+#ifndef SHM_RING_H
+#define SHM_RING_H
+
+/*
+ * Simple shared memory ring buffer used to exchange variable sized
+ * messages between a single producer and single consumer.  The layout
+ * matches the implementation used by scripts/shm_ring.py.
+ *
+ *  +--------------+---------------------------------------------------+
+ *  | field        | description                                      |
+ *  +--------------+---------------------------------------------------+
+ *  | magic        | constant 0x52494E47 ('RING')                      |
+ *  | size         | size of data region in bytes                      |
+ *  | head         | read offset                                       |
+ *  | tail         | write offset                                      |
+ *  | data[size]   | ring storage                                      |
+ *  +--------------+---------------------------------------------------+
+ *
+ *  Each message is stored as:
+ *       uint32_t length  - number of bytes following (type+payload)
+ *       uint8_t  type    - message type (0 trade, 1 metric)
+ *       uint8_t  payload[length-1]
+ *
+ *  A zero length message is used as a wrap marker when the producer
+ *  reaches the end of the buffer.
+ */
+
+#include <stdint.h>
+#include <string.h>
+
+#define SHM_RING_MAGIC 0x52494E47u
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+    uint32_t magic;
+    uint32_t size;
+    volatile uint32_t head;
+    volatile uint32_t tail;
+    uint8_t  data[1]; /* flexible array member */
+} shm_ring_t;
+
+#define SHM_RING_HEADER (sizeof(shm_ring_t) - 1)
+
+static inline size_t shm_ring_buffer_size(size_t capacity) {
+    return SHM_RING_HEADER + capacity;
+}
+
+static inline uint32_t shm_ring_space(const shm_ring_t *r) {
+    uint32_t head = r->head, tail = r->tail, size = r->size;
+    if (tail >= head)
+        return size - (tail - head) - 1;
+    return head - tail - 1;
+}
+
+static inline int shm_ring_write(shm_ring_t *r, uint8_t type,
+                                 const void *data, uint32_t len) {
+    uint32_t payload = len + 1; /* include type */
+    uint32_t needed = 4 + payload;
+    if (needed > r->size)
+        return -1; /* message too large */
+    if (shm_ring_space(r) < needed)
+        return 0; /* insufficient space */
+
+    uint32_t tail = r->tail;
+    if (tail + needed > r->size) {
+        /* mark wrap and start from beginning */
+        *(uint32_t *)(r->data + tail) = 0;
+        tail = 0;
+    }
+    *(uint32_t *)(r->data + tail) = payload;
+    tail += 4;
+    r->data[tail] = type;
+    memcpy(r->data + tail + 1, data, len);
+    tail = (tail + payload) % r->size;
+    r->tail = tail;
+    return 1;
+}
+
+static inline int shm_ring_read(shm_ring_t *r, uint8_t *type,
+                                void *out, uint32_t *len) {
+    uint32_t head = r->head;
+    uint32_t tail = r->tail;
+    uint32_t size = r->size;
+    if (head == tail)
+        return 0; /* empty */
+    if (head + 4 > size)
+        head = 0;
+    uint32_t payload = *(uint32_t *)(r->data + head);
+    if (payload == 0) {
+        head = 0;
+        payload = *(uint32_t *)(r->data + head);
+    }
+    uint32_t start = head + 4;
+    if (payload < 1)
+        return -1; /* corrupt */
+    if (type)
+        *type = r->data[start];
+    if (out && len && *len >= payload - 1)
+        memcpy(out, r->data + start + 1, payload - 1);
+    if (len)
+        *len = payload - 1;
+    head = (start + payload) % size;
+    r->head = head;
+    return 1;
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SHM_RING_H */

--- a/tests/test_shm_ring.py
+++ b/tests/test_shm_ring.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+
+import sys
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from scripts.shm_ring import ShmRing, TRADE_MSG, METRIC_MSG
+
+
+def test_ring_roundtrip(tmp_path):
+    path = tmp_path / "ring"
+    ring = ShmRing.create(str(path), 1024)
+    assert ring.push(TRADE_MSG, b"abc")
+    assert ring.push(METRIC_MSG, b"xyz")
+    t = ring.pop()
+    assert t is not None
+    t_type, t_payload = t
+    assert t_type == TRADE_MSG
+    assert bytes(t_payload) == b"abc"
+    del t_payload, t
+    m = ring.pop()
+    assert m is not None
+    m_type, m_payload = m
+    assert m_type == METRIC_MSG
+    assert bytes(m_payload) == b"xyz"
+    del m_payload, m
+    assert ring.pop() is None
+    ring.close()


### PR DESCRIPTION
## Summary
- Add shared memory ring buffer implementation (`shm_ring.h`, `scripts/shm_ring.py`)
- Write observer events to ring buffer and fall back to NATS (`Observer_TBot.mq4`)
- Update stream listener to read from shared memory when available with graceful dependency fallbacks
- Include tests for ring buffer round-trip

## Testing
- `pytest tests/test_shm_ring.py -q`
- `pytest tests/test_stream_listener_validation.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas', 'numpy', 'requests', 'pyarrow', 'grpc', 'scripts.socket_log_service', and others)*

------
https://chatgpt.com/codex/tasks/task_e_68992d935990832fbee2b8cfd4fdb7b7