### PR TITLE
feat: add trace context and OTLP collector

### DIFF
--- a/README.md
+++ b/README.md
@@ -594,6 +594,26 @@ plt.show()
 - When running Python scripts, verify the paths to log files and models are correct.
 - Use the Experts and Journal tabs inside MT4 for additional debugging information.
 
+### Trace Correlation
+
+Traces exported via OpenTelemetry can be inspected to investigate anomalies or
+specific trades. First locate the `trace_id` in `logs/metrics.csv` or
+`logs/trades_raw.csv`, then query the collector:
+
+```bash
+TRACE_ID="your-trace-id"
+curl -s "http://localhost:16686/api/traces/$TRACE_ID" | jq '.data[0]'
+```
+
+Filter JSON logs for the same trace to see related events:
+
+```bash
+rg $TRACE_ID logs/*.json
+```
+
+Matching `trace_id` values let you follow a decision from the logs to its span
+in Jaeger or Zipkin for deeper analysis.
+
 ## Debugging Tips
 
 - Set `EnableDebugLogging` to `true` to print socket status and feature values.

--- a/docs/docker-compose.yml
+++ b/docs/docker-compose.yml
@@ -1,0 +1,18 @@
+version: "3.8"
+services:
+  otel-collector:
+    image: otel/opentelemetry-collector:0.87.0
+    command: ["--config=/etc/otel-collector.yaml"]
+    volumes:
+      - ./otel-collector.yaml:/etc/otel-collector.yaml
+    ports:
+      - "4317:4317"
+      - "4318:4318"
+  jaeger:
+    image: jaegertracing/all-in-one:1.54
+    ports:
+      - "16686:16686"
+  zipkin:
+    image: openzipkin/zipkin:2.24
+    ports:
+      - "9411:9411"

--- a/docs/otel-collector.yaml
+++ b/docs/otel-collector.yaml
@@ -1,0 +1,18 @@
+receivers:
+  otlp:
+    protocols:
+      http:
+      grpc:
+
+exporters:
+  jaeger:
+    endpoint: http://jaeger:14250
+    insecure: true
+  zipkin:
+    endpoint: http://zipkin:9411/api/v2/spans
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      exporters: [jaeger, zipkin]

--- a/experts/Observer_TBot.mq4
+++ b/experts/Observer_TBot.mq4
@@ -199,7 +199,13 @@ bool CheckAnomaly(double price, double sl, double tp, double lots, double spread
    {
       string txt = CharArrayToString(result);
       double err = StrToDouble(txt);
-      return(err > AnomalyThreshold);
+      if(err > AnomalyThreshold)
+      {
+         string span_id = GenId(8);
+         SendOtelSpan(TraceId, span_id, "anomaly_detected");
+         return(true);
+      }
+      return(false);
    }
    return(false);
 }

--- a/scripts/stream_listener.py
+++ b/scripts/stream_listener.py
@@ -424,7 +424,10 @@ def process_metric(msg) -> None:
                 if det.drift_detected:
                     drift_features.append(feat)
             if drift_features:
-                logger.warning({"alert": "drift detected", "features": drift_features})
+                logger.warning(
+                    {"alert": "drift detected", "features": drift_features},
+                    extra=extra,
+                )
                 _trigger_retrain()
             _save_adwin()
 


### PR DESCRIPTION
## Summary
- emit OpenTelemetry spans for anomaly checks in MQL observer
- propagate trace IDs through stream listener and training scripts
- add OTLP collector docker-compose example with Jaeger/Zipkin and trace troubleshooting docs

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_68997773e788832fa828da8281717fc9