### PR TITLE
Log commission and swap

### DIFF
--- a/scripts/train_target_clone.py
+++ b/scripts/train_target_clone.py
@@ -481,7 +481,13 @@ def _load_logs_db(db_file: Path) -> pd.DataFrame:
         df_logs["trade_duration"] = (
             pd.to_datetime(df_logs["event_time"]) - pd.to_datetime(df_logs["open_time"])
         ).dt.total_seconds().fillna(0)
-    for col in ["book_bid_vol", "book_ask_vol", "book_imbalance"]:
+    for col in [
+        "book_bid_vol",
+        "book_ask_vol",
+        "book_imbalance",
+        "commission",
+        "swap",
+    ]:
         if col not in df_logs.columns:
             df_logs[col] = 0.0
         else:
@@ -616,6 +622,8 @@ def _load_logs(
         "book_imbalance",
         "equity",
         "margin_level",
+        "commission",
+        "swap",
         "is_anomaly",
     ]
 
@@ -709,7 +717,15 @@ def _load_logs(
                     ).dt.total_seconds().fillna(0)
                 else:
                     chunk["trade_duration"] = 0.0
-                for col in ["book_bid_vol", "book_ask_vol", "book_imbalance", "equity", "margin_level"]:
+                for col in [
+                    "book_bid_vol",
+                    "book_ask_vol",
+                    "book_imbalance",
+                    "equity",
+                    "margin_level",
+                    "commission",
+                    "swap",
+                ]:
                     chunk[col] = pd.to_numeric(chunk.get(col, 0.0), errors="coerce").fillna(0.0)
                 chunk["is_anomaly"] = pd.to_numeric(chunk.get("is_anomaly", 0), errors="coerce").fillna(0)
                 for col in ["source", "comment"]:
@@ -1015,6 +1031,8 @@ def _extract_features(
         slippage = _safe_float(r.get("slippage", 0))
         account_equity = _safe_float(r.get("equity", 0))
         margin_level = _safe_float(r.get("margin_level", 0))
+        commission = _safe_float(r.get("commission", 0))
+        swap = _safe_float(r.get("swap", 0))
 
         hour_sin = math.sin(2 * math.pi * t.hour / 24)
         hour_cos = math.cos(2 * math.pi * t.hour / 24)
@@ -1045,6 +1063,8 @@ def _extract_features(
             "book_bid_vol": float(r.get("book_bid_vol", 0) or 0),
             "book_ask_vol": float(r.get("book_ask_vol", 0) or 0),
             "book_imbalance": float(r.get("book_imbalance", 0) or 0),
+            "commission": commission,
+            "swap": swap,
         }
 
         if calendar_events is not None:

--- a/tests/test_news_sentiment.py
+++ b/tests/test_news_sentiment.py
@@ -35,6 +35,8 @@ def _write_sample_log(file: Path):
         "book_imbalance",
         "sl_hit_dist",
         "tp_hit_dist",
+        "commission",
+        "swap",
     ]
     rows = [
         [
@@ -64,6 +66,8 @@ def _write_sample_log(file: Path):
             "0",
             "0",
             "0",
+            "0",
+            "0",
         ],
         [
             "2",
@@ -87,6 +91,8 @@ def _write_sample_log(file: Path):
             "0.0002",
             "200",
             "",
+            "0",
+            "0",
             "0",
             "0",
             "0",

--- a/tests/test_train_target_clone_features.py
+++ b/tests/test_train_target_clone_features.py
@@ -39,6 +39,8 @@ def _write_sample_log(file: Path):
         "book_imbalance",
         "sl_hit_dist",
         "tp_hit_dist",
+        "commission",
+        "swap",
     ]
     rows = [
         [
@@ -68,6 +70,8 @@ def _write_sample_log(file: Path):
             "0",
             "0",
             "0",
+            "0",
+            "0",
         ],
         [
             "2",
@@ -91,6 +95,8 @@ def _write_sample_log(file: Path):
             "0.0002",
             "200",
             "",
+            "0",
+            "0",
             "0",
             "0",
             "0",

--- a/tests/test_train_target_clone_optuna.py
+++ b/tests/test_train_target_clone_optuna.py
@@ -37,6 +37,8 @@ def _write_sample_log(file: Path):
         "book_imbalance",
         "sl_hit_dist",
         "tp_hit_dist",
+        "commission",
+        "swap",
     ]
     rows = [
         [
@@ -66,6 +68,8 @@ def _write_sample_log(file: Path):
             "0",
             "0",
             "0",
+            "0",
+            "0",
         ],
         [
             "2",
@@ -89,6 +93,8 @@ def _write_sample_log(file: Path):
             "0.0002",
             "200",
             "",
+            "0",
+            "0",
             "0",
             "0",
             "0",


### PR DESCRIPTION
## Summary
- Log commission and swap for closed trades and persist them to SQLite and CSV logs
- Parse commission and swap in training pipeline and expose as model features
- Update test fixtures for expanded schema

## Testing
- `pytest tests/test_train_target_clone_features.py tests/test_news_sentiment.py tests/test_train_target_clone_optuna.py tests/test_train_target_clone_validation.py`

------
https://chatgpt.com/codex/tasks/task_e_689bf023e538832f97f3f6b5385c2e4c