### PR TITLE
feat: add Bayesian optimization for hyperparameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,14 +266,14 @@ classifier is refit on the reduced set. A warning is emitted when pruning
 eliminates more than the fraction specified via ``--prune-warn``.
 
 Hyperparameters, model type, decision threshold and feature selection can be
-optimised automatically when `optuna` is installed. If `optuna` is missing the
-script trains with default parameters and continues. The best trial's
-parameters and validation score are saved to `model.json` along with a summary
-of the study:
+optimised automatically with Bayesian methods when `optuna` is installed. If
+`optuna` is missing the script trains with default parameters and continues. The
+best trial's parameters and validation score are saved to `model.json` along
+with a summary of the search:
 
 ```bash
 pip install optuna
-python scripts/train_target_clone.py --data-dir "C:\\path\\to\\observer_logs" --out-dir models --optuna-trials 50
+python scripts/train_target_clone.py --data-dir "C:\\path\\to\\observer_logs" --out-dir models --bayes-steps 50
 ```
 
 Optuna explores learning rate, tree depth or regularisation strength depending

--- a/tests/test_train_target_clone_bayes.py
+++ b/tests/test_train_target_clone_bayes.py
@@ -107,19 +107,19 @@ def _write_sample_log(file: Path):
         writer.writerow(fields)
         writer.writerows(rows)
 
-def test_optuna_study_serialization(tmp_path: Path):
+def test_bayes_study_serialization(tmp_path: Path):
     pytest.importorskip("optuna")
     data_dir = tmp_path / "logs"
     out_dir = tmp_path / "out"
     data_dir.mkdir()
     _write_sample_log(data_dir / "trades_sample.csv")
 
-    train(data_dir, out_dir, optuna_trials=1)
+    train(data_dir, out_dir, bayes_steps=1)
 
     model_file = out_dir / "model.json"
     assert model_file.exists()
     with open(model_file) as f:
         data = json.load(f)
-    assert "optuna_best_params" in data
-    assert "optuna_trials" in data and data["optuna_trials"]
-    assert data.get("optuna_study", {}).get("n_trials") == 1
+    assert "bayes_best_params" in data
+    assert "bayes_history" in data and data["bayes_history"]
+    assert data.get("bayes_study", {}).get("n_trials") == 1


### PR DESCRIPTION
## Summary
- add `--bayes-steps` flag to enable Optuna-based Bayesian hyperparameter search
- persist best parameters and trial history in `model.json`
- document and test Bayesian optimization workflow

## Testing
- `pytest tests/test_train_target_clone_bayes.py -q`
- `pytest tests/test_train_target_clone_bayes.py tests/test_train_target_clone_features.py tests/test_train_target_clone_validation.py tests/test_train.py -q` *(fails: AttributeError: 'types.SimpleNamespace' object has no attribute 'Table')*


------
https://chatgpt.com/codex/tasks/task_e_689d1b585c98832fb533fd14ed4adc71