### PR TITLE
Add telemetry correlation dashboard and system metrics tracing

### DIFF
--- a/schemas/metric.avsc
+++ b/schemas/metric.avsc
@@ -4,6 +4,7 @@
   "namespace": "bot",
   "fields": [
     {"name": "schema_version", "type": "int"},
+    {"name": "trace_id", "type": "string", "default": ""},
     {"name": "time", "type": "string"},
     {"name": "magic", "type": "int"},
     {"name": "win_rate", "type": "double"},

--- a/schemas/metrics.py
+++ b/schemas/metrics.py
@@ -28,6 +28,7 @@ class MetricEvent(BaseModel):
 
 METRIC_SCHEMA = pa.schema([
     ("schema_version", pa.int32()),
+    ("trace_id", pa.string()),
     ("time", pa.string()),
     ("magic", pa.int32()),
     ("win_rate", pa.float64()),

--- a/scripts/telemetry_dashboard.py
+++ b/scripts/telemetry_dashboard.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Visualize correlations between system telemetry and trading metrics."""
+
+import argparse
+import csv
+from datetime import datetime
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+
+
+def _load_csv(path: Path):
+    rows = []
+    with path.open(newline="") as f:
+        reader = csv.DictReader(f)
+        for r in reader:
+            rows.append(r)
+    return rows
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description="Plot telemetry vs metrics correlations")
+    p.add_argument("--metrics", default="logs/metrics.csv", help="Path to metrics log")
+    p.add_argument(
+        "--telemetry",
+        default="logs/system_telemetry.csv",
+        help="Path to system telemetry log",
+    )
+    args = p.parse_args()
+
+    metrics = {r.get("trace_id"): r for r in _load_csv(Path(args.metrics))}
+    telem = _load_csv(Path(args.telemetry))
+
+    rows = []
+    for t in telem:
+        m = metrics.get(t.get("trace_id"))
+        if not m:
+            continue
+        try:
+            ts = datetime.fromisoformat(t["time"])
+        except Exception:
+            ts = None
+        rows.append(
+            {
+                "time": ts,
+                "cpu": float(t.get("cpu_percent", 0) or 0),
+                "mem": float(t.get("mem_percent", 0) or 0),
+                "socket_errors": int(m.get("socket_errors", 0) or 0),
+            }
+        )
+
+    if not rows:
+        print("No overlapping telemetry and metric records")
+        return
+
+    rows.sort(key=lambda r: r["time"] or datetime.min)
+    times = [r["time"] for r in rows]
+    cpu = [r["cpu"] for r in rows]
+    sock = [r["socket_errors"] for r in rows]
+
+    fig, ax1 = plt.subplots()
+    ax1.plot(times, cpu, label="CPU %")
+    ax1.set_ylabel("CPU %")
+
+    ax2 = ax1.twinx()
+    ax2.plot(times, sock, color="r", label="Socket Errors")
+    ax2.set_ylabel("Socket Errors")
+
+    ax1.legend(loc="upper left")
+    ax2.legend(loc="upper right")
+    plt.title("CPU usage vs Socket Errors")
+    plt.xticks(rotation=45)
+    plt.tight_layout()
+    plt.show()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_system_telemetry.py
+++ b/tests/test_system_telemetry.py
@@ -1,0 +1,36 @@
+from types import SimpleNamespace
+
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from scripts import stream_listener as sl
+
+
+def test_capture_system_metrics_includes_trace(monkeypatch):
+    sl.current_trace_id = "trace123"
+
+    monkeypatch.setattr(sl.psutil, "cpu_percent", lambda interval=None: 10.0)
+    monkeypatch.setattr(sl.psutil, "virtual_memory", lambda: SimpleNamespace(percent=20.0))
+    monkeypatch.setattr(
+        sl.psutil,
+        "net_io_counters",
+        lambda: SimpleNamespace(bytes_sent=1, bytes_recv=2),
+    )
+
+    records = []
+
+    def fake_append(path, record):
+        records.append(record)
+
+    monkeypatch.setattr(sl, "append_csv", fake_append)
+
+    sl.capture_system_metrics()
+
+    assert records
+    rec = records[0]
+    assert rec["trace_id"] == "trace123"
+    assert rec["cpu_percent"] == 10.0
+    assert rec["mem_percent"] == 20.0
+    assert rec["bytes_sent"] == 1
+    assert rec["bytes_recv"] == 2


### PR DESCRIPTION
## Summary
- Capture CPU, memory and network stats in `stream_listener` using psutil
- Propagate trace IDs to metrics, trades and system telemetry
- Provide `telemetry_dashboard.py` to visualise CPU vs socket errors

## Testing
- `pip install psutil >/tmp/psutil.log && tail -n 20 /tmp/psutil.log`
- `pip install 'pydantic<2' >/tmp/pydantic.log && tail -n 20 /tmp/pydantic.log`
- `pytest -q` *(fails: No module named 'pandas')*
- `pytest tests/test_stream_listener_validation.py::test_trade_validation tests/test_stream_listener_validation.py::test_metric_validation tests/test_system_telemetry.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689d335a8e90832faec9492097af45db