### PR TITLE
Switch trade stream to Cap'n Proto

### DIFF
--- a/experts/Observer_TBot.mq4
+++ b/experts/Observer_TBot.mq4
@@ -2,7 +2,7 @@
 #include "model_interface.mqh"
 #include <Arrays/ArrayInt.mqh>
 
-#import "observer_proto.dll"
+#import "observer_capnp.dll"
 int SerializeTradeEvent(int schema_version, int event_id, string trace_id, string event_time, string broker_time, string local_time, string action, int ticket, int magic, string source, string symbol, int order_type, double lots, double price, double sl, double tp, double profit, double profit_after_trade, double spread, string comment, double remaining_lots, double slippage, int volume, string open_time, double book_bid_vol, double book_ask_vol, double book_imbalance, double sl_hit_dist, double tp_hit_dist, double equity, double margin_level, double commission, double swap, int decision_id, uchar &out[]);
 int SerializeMetrics(int schema_version, string time, int magic, double win_rate, double avg_profit, int trade_count, double drawdown, double sharpe, int file_write_errors, int socket_errors, int book_refresh_seconds, int var_breach_count, int trade_queue_depth, int metric_queue_depth, uchar &out[]);
 #import

--- a/proto/__init__.py
+++ b/proto/__init__.py
@@ -1,0 +1,22 @@
+# Convenient helpers for loading Cap'n Proto schemas.
+#
+# The stream listener and other utilities import these modules to decode
+# binary messages produced by the observer EA.  ``pycapnp`` performs the
+# schema compilation at runtime so no generated Python files need to be
+# tracked in the repository.
+
+from pathlib import Path
+
+try:  # pragma: no cover - optional dependency
+    import capnp  # type: ignore
+
+    _PROTO_DIR = Path(__file__).resolve().parent
+
+    # Expose loaded schemas as ``trade_capnp`` and ``metrics_capnp`` so other
+    # modules can simply import them from ``proto``.
+    trade_capnp = capnp.load(str(_PROTO_DIR / "trade.capnp"))
+    metrics_capnp = capnp.load(str(_PROTO_DIR / "metrics.capnp"))
+except Exception:  # pragma: no cover - allow running without pycapnp
+    trade_capnp = metrics_capnp = None  # type: ignore
+
+__all__ = ["trade_capnp", "metrics_capnp"]

--- a/proto/metrics.capnp
+++ b/proto/metrics.capnp
@@ -11,4 +11,7 @@ struct Metrics {
   fileWriteErrors @7 :Int32;
   socketErrors @8 :Int32;
   bookRefreshSeconds @9 :Int32;
+  varBreachCount @10 :Int32;
+  tradeQueueDepth @11 :Int32;
+  metricQueueDepth @12 :Int32;
 }

--- a/proto/trade.capnp
+++ b/proto/trade.capnp
@@ -28,7 +28,11 @@ struct TradeEvent {
   bookImbalance @24 :Float64;
   slHitDist @25 :Float64;
   tpHitDist @26 :Float64;
-  decisionId @27 :Int32;
-  traceId @28 :Text;
-  spanId @29 :Text;
+  equity @27 :Float64;
+  marginLevel @28 :Float64;
+  commission @29 :Float64;
+  swap @30 :Float64;
+  decisionId @31 :Int32;
+  traceId @32 :Text;
+  spanId @33 :Text;
 }


### PR DESCRIPTION
## Summary
- Add Cap'n Proto schemas for trade and metric events
- Wire stream listener to decode Cap'n Proto messages
- Document Cap'n Proto subscription example in README

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas' et al.)*

------
https://chatgpt.com/codex/tasks/task_e_689d518b79d4832f8a9ce8111feae5f1