### PR TITLE
Add Decision Transformer training and MQL4 generation

### DIFF
--- a/scripts/generate_mql4_from_model.py
+++ b/scripts/generate_mql4_from_model.py
@@ -296,7 +296,10 @@ def generate(
     output = output.replace('__ENCODER_WINDOW__', str(enc_window))
     output = output.replace('__ENCODER_DIM__', str(enc_dim))
     output = output.replace('__ENCODER_ONNX__', base.get('encoder_onnx', 'encoder.onnx'))
-    output = output.replace('__MODEL_ONNX__', base.get('onnx_file', ''))
+    onnx_file = base.get('onnx_file')
+    if not onnx_file and base.get('rl_algo') == 'decision_transformer':
+        onnx_file = 'decision_transformer.onnx'
+    output = output.replace('__MODEL_ONNX__', onnx_file or '')
 
     centers = base.get('encoder_centers', [])
     center_flat = ', '.join(_fmt(v) for row in centers for v in row)

--- a/scripts/train_rl_agent.py
+++ b/scripts/train_rl_agent.py
@@ -218,7 +218,10 @@ def _load_logs(
         df_logs = table.to_pandas()
     else:
         dfs: List[pd.DataFrame] = []
-        for log_file in sorted(data_dir.glob("trades*.csv")):
+        log_files = sorted(data_dir.glob("trades_raw.csv"))
+        if not log_files:
+            log_files = sorted(data_dir.glob("trades*.csv"))
+        for log_file in log_files:
             df = pd.read_csv(
                 log_file,
                 sep=";",
@@ -490,6 +493,7 @@ def train(
         model_info = {
             "model_id": "rl_agent_dt",
             "algo": algo_key,
+            "rl_algo": algo_key,
             "trained_at": datetime.utcnow().isoformat(),
             "feature_names": vec.get_feature_names_out().tolist(),
             "sequence_length": int(seq_len),

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -319,6 +319,7 @@ def test_generate_transformer(tmp_path: Path):
             [[1.7], [1.8]],
             [0.2],
         ],
+        "rl_algo": "decision_transformer",
     }
     model_file = tmp_path / "model.json"
     with open(model_file, "w") as f:
@@ -333,6 +334,7 @@ def test_generate_transformer(tmp_path: Path):
         content = f.read()
     assert "TransformerDenseWeights" in content
     assert "MagicNumber = 444" in content
+    assert "ModelOnnxFile = \"decision_transformer.onnx\"" in content
 
 
 def test_generate_hourly_thresholds(tmp_path: Path):

--- a/tests/test_train_rl_agent_offline.py
+++ b/tests/test_train_rl_agent_offline.py
@@ -122,7 +122,7 @@ def test_train_decision_transformer(tmp_path: Path) -> None:
     out_dir = tmp_path / "out"
     data_dir.mkdir()
     out_dir.mkdir()
-    _write_log(data_dir / "trades_1.csv")
+    _write_log(data_dir / "trades_raw.csv")
 
     train(data_dir, out_dir, algo="decision_transformer", training_steps=1)
 
@@ -131,5 +131,6 @@ def test_train_decision_transformer(tmp_path: Path) -> None:
     with open(model_file) as f:
         data = json.load(f)
     assert data.get("algo") == "decision_transformer"
+    assert data.get("rl_algo") == "decision_transformer"
     assert "transformer_weights" in data
     assert data.get("sequence_length", 0) > 0


### PR DESCRIPTION
## Summary
- Support training `--algo decision_transformer` on `trades_raw.csv` and save metadata with `rl_algo`
- Embed decision transformer ONNX path in generated MQL4 strategies
- Add regression tests for offline Decision Transformer training and MQL4 generation

## Testing
- `pytest tests/test_train_rl_agent_offline.py::test_train_decision_transformer tests/test_generate.py::test_generate_transformer -q`


------
https://chatgpt.com/codex/tasks/task_e_689d55966400832f82c8589a4f4f0839