### PR TITLE
Add Ubuntu setup and systemd service templates

### DIFF
--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -1,0 +1,17 @@
+FROM ubuntu:22.04
+
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    python3 \
+    python3-pip \
+    wine64 \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /opt/BotCopier
+
+COPY requirements.txt requirements.txt
+RUN pip3 install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+CMD ["bash"]

--- a/README.md
+++ b/README.md
@@ -651,6 +651,33 @@ rg $TRACE_ID logs/*.json
 Matching `trace_id` values let you follow a decision from the logs to its span
 in Jaeger or Zipkin for deeper analysis.
 
+## Ubuntu Setup and Services
+
+Run `scripts/setup_ubuntu.sh` on an Ubuntu host to install system packages,
+Python dependencies and initialise a Wine prefix for MetaTrader:
+
+```bash
+./scripts/setup_ubuntu.sh
+```
+
+Example systemd unit files are provided under `docs/systemd/` for running
+`stream_listener.py` and `metrics_collector.py`. After copying them to
+`/etc/systemd/system/`, enable the services with:
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable --now stream-listener.service metrics-collector.service
+```
+
+Logs for these services can be viewed with:
+
+```bash
+journalctl -u stream-listener.service -u metrics-collector.service
+```
+
+Adjust the `WorkingDirectory` in the unit files to match where the repository
+is located (e.g. `/opt/BotCopier`).
+
 ## Debugging Tips
 
 - Set `EnableDebugLogging` to `true` to print socket status and feature values.

--- a/docs/systemd/metrics-collector.service
+++ b/docs/systemd/metrics-collector.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=BotCopier Metrics Collector
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory=/opt/BotCopier
+ExecStart=/usr/bin/python3 scripts/metrics_collector.py
+Restart=on-failure
+Environment=PYTHONUNBUFFERED=1
+
+[Install]
+WantedBy=multi-user.target

--- a/docs/systemd/stream-listener.service
+++ b/docs/systemd/stream-listener.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=BotCopier Stream Listener
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory=/opt/BotCopier
+ExecStart=/usr/bin/python3 scripts/stream_listener.py
+Restart=on-failure
+Environment=PYTHONUNBUFFERED=1
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/setup_ubuntu.sh
+++ b/scripts/setup_ubuntu.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Navigate to repository root
+REPO_DIR="$(cd "$(dirname "$0")"/.. && pwd)"
+cd "$REPO_DIR"
+
+sudo apt-get update
+sudo apt-get install -y build-essential python3 python3-pip wine64
+
+python3 -m pip install --upgrade pip
+pip3 install --no-cache-dir -r requirements.txt
+
+# Create Wine prefix for MetaTrader
+: "${WINEPREFIX:=$HOME/.wine_mt4}"
+export WINEPREFIX
+mkdir -p "$WINEPREFIX"
+wineboot --init


### PR DESCRIPTION
## Summary
- add Dockerfile for Ubuntu that installs deps and copies repo
- add setup script to install packages and init Wine prefix
- provide systemd units for stream listener and metrics collector
- document Ubuntu services and logs in README

## Testing
- `pytest` *(fails: Interrupted: 20 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_689d5710eecc832faba310a6bb2aa491