### PR TITLE
Normalize path handling and resource detection

### DIFF
--- a/scripts/upload_logs.py
+++ b/scripts/upload_logs.py
@@ -22,7 +22,12 @@ import tarfile
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
-LOG_DIR = REPO_ROOT / "logs"
+
+if os.name != "nt" and (xdg := os.getenv("XDG_DATA_HOME")):
+    LOG_DIR = Path(xdg) / "botcopier" / "logs"
+else:
+    LOG_DIR = REPO_ROOT / "logs"
+
 TRADES_FILE = LOG_DIR / "trades_raw.csv"
 METRICS_FILE = LOG_DIR / "metrics.csv"
 MODEL_FILE = REPO_ROOT / "model.json"


### PR DESCRIPTION
## Summary
- Normalize observer log paths for Wine/Linux by replacing backslashes and using a sanitized `log_dir`.
- Respect `XDG_DATA_HOME` and Path-based joins in upload and training scripts.
- Inspect `/proc` for memory and CPU details to enable/disable heavy models.

## Testing
- `pytest tests/test_upload_logs.py -q`
- `pytest tests/test_upload_logs.py tests/test_train_target_clone_validation.py tests/test_train_target_clone_features.py tests/test_train_target_clone_bayes.py -q` *(fails: AttributeError: 'types.SimpleNamespace' object has no attribute 'schema')*


------
https://chatgpt.com/codex/tasks/task_e_689d58bd5adc832f97bc2f28880c18c6