### PR TITLE
feat: export system metrics and tracing

### DIFF
--- a/docs/docker-compose.yml
+++ b/docs/docker-compose.yml
@@ -8,6 +8,7 @@ services:
     ports:
       - "4317:4317"
       - "4318:4318"
+      - "9464:9464"
   jaeger:
     image: jaegertracing/all-in-one:1.54
     ports:

--- a/docs/otel-collector.yaml
+++ b/docs/otel-collector.yaml
@@ -10,9 +10,19 @@ exporters:
     insecure: true
   zipkin:
     endpoint: http://zipkin:9411/api/v2/spans
+  prometheus:
+    endpoint: "0.0.0.0:9464"
+  logging:
+    loglevel: info
 
 service:
   pipelines:
     traces:
       receivers: [otlp]
       exporters: [jaeger, zipkin]
+    metrics:
+      receivers: [otlp]
+      exporters: [prometheus]
+    logs:
+      receivers: [otlp]
+      exporters: [logging]

--- a/tests/test_system_telemetry.py
+++ b/tests/test_system_telemetry.py
@@ -9,6 +9,7 @@ from scripts import stream_listener as sl
 
 def test_capture_system_metrics_includes_trace(monkeypatch):
     sl.current_trace_id = "trace123"
+    sl.current_span_id = "span456"
 
     monkeypatch.setattr(sl.psutil, "cpu_percent", lambda interval=None: 10.0)
     monkeypatch.setattr(sl.psutil, "virtual_memory", lambda: SimpleNamespace(percent=20.0))
@@ -30,6 +31,7 @@ def test_capture_system_metrics_includes_trace(monkeypatch):
     assert records
     rec = records[0]
     assert rec["trace_id"] == "trace123"
+    assert rec["span_id"] == "span456"
     assert rec["cpu_percent"] == 10.0
     assert rec["mem_percent"] == 20.0
     assert rec["bytes_sent"] == 1


### PR DESCRIPTION
## Summary
- export CPU, memory and network metrics via OTLP
- trace log uploads and stream listener events with trace/span IDs
- document OpenTelemetry collector and docker-compose for Ubuntu

## Testing
- `pytest tests/test_system_telemetry.py tests/test_upload_logs.py`


------
https://chatgpt.com/codex/tasks/task_e_689d5b3b3a5c832f91acabbb1c3cd3cb