### PR TITLE
Add systemd unit for online trainer and enable during setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -661,9 +661,18 @@ Python dependencies and initialise a Wine prefix for MetaTrader:
 ./scripts/setup_ubuntu.sh
 ```
 
+The script installs and enables an `online-trainer.service` unit so the
+incremental trainer starts automatically at boot. Disable or re-enable it with:
+
+```bash
+sudo systemctl disable --now online-trainer.service
+sudo systemctl enable --now online-trainer.service
+```
+
 Example systemd unit files are provided under `docs/systemd/` for running
-`stream_listener.py` and `metrics_collector.py`. After copying them to
-`/etc/systemd/system/`, enable the services with:
+`stream_listener.py`, `metrics_collector.py` and the online trainer. After
+copying the listener and collector units to `/etc/systemd/system/`, enable the
+services with:
 
 ```bash
 sudo systemctl daemon-reload
@@ -673,7 +682,7 @@ sudo systemctl enable --now stream-listener.service metrics-collector.service
 Logs for these services can be viewed with:
 
 ```bash
-journalctl -u stream-listener.service -u metrics-collector.service
+journalctl -u stream-listener.service -u metrics-collector.service -u online-trainer.service
 ```
 
 Adjust the `WorkingDirectory` in the unit files to match where the repository

--- a/docs/systemd/online-trainer.service
+++ b/docs/systemd/online-trainer.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=BotCopier Online Trainer
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory=/opt/BotCopier
+ExecStart=/usr/bin/python3 scripts/online_trainer.py --csv logs/trades_raw.csv
+Restart=on-failure
+Environment=PYTHONUNBUFFERED=1
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/setup_ubuntu.sh
+++ b/scripts/setup_ubuntu.sh
@@ -38,3 +38,8 @@ log "Creating Wine prefix for MetaTrader"
 export WINEPREFIX
 mkdir -p "$WINEPREFIX"
 wineboot --init
+
+log "Installing online trainer service"
+sudo cp docs/systemd/online-trainer.service /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now online-trainer.service


### PR DESCRIPTION
## Summary
- add online-trainer.service for continuous model updates via scripts/online_trainer.py
- install and enable the online trainer during Ubuntu setup
- document how to manage the service in README

## Testing
- `pytest tests/test_online_trainer.py -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_689d655bb4d0832fa799b302707c9e15