### PR TITLE
Check and create log directory in Observer_TBot

### DIFF
--- a/experts/Observer_TBot.mq4
+++ b/experts/Observer_TBot.mq4
@@ -575,7 +575,15 @@ int OnInit()
       track_symbols[j] = StringTrimLeft(StringTrimRight(parts[j]));
 
    string log_dir = StringReplace(LogDirectoryName, "\\", "/");
-   DirectoryCreate(log_dir);
+   if(!FileIsExist(log_dir))
+   {
+      if(FolderCreate(log_dir))
+         Print("Created log directory: " + log_dir);
+      else
+         Print("Failed to create log directory: " + log_dir);
+   }
+   else
+      Print("Log directory exists: " + log_dir);
    // initialise shared memory ring buffer (1MB by default)
    ShmRingInit("tbot_events", 1<<20);
    string hello = StringFormat("{\"type\":\"hello\",\"schema_version\":%d}", SCHEMA_VERSION);


### PR DESCRIPTION
## Summary
- Verify the configured log directory exists on start
- Create the log directory if missing and log success or failure for easier debugging

## Testing
- `pytest tests/test_logging_basic.py::test_logging_roundtrip -q` *(fails: ModuleNotFoundError: No module named 'scripts.socket_log_service')*


------
https://chatgpt.com/codex/tasks/task_e_689e8975c574832f84ab8ba0ad1a8a46