### PR TITLE
Install stream listener and metrics collector services

### DIFF
--- a/scripts/setup_ubuntu.sh
+++ b/scripts/setup_ubuntu.sh
@@ -43,3 +43,12 @@ log "Installing online trainer service"
 sudo cp docs/systemd/online-trainer.service /etc/systemd/system/
 sudo systemctl daemon-reload
 sudo systemctl enable --now online-trainer.service
+log "online-trainer.service status: $(systemctl is-active online-trainer.service)"
+
+log "Installing stream listener and metrics collector services"
+sudo cp docs/systemd/stream-listener.service docs/systemd/metrics-collector.service /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now stream-listener.service
+log "stream-listener.service status: $(systemctl is-active stream-listener.service)"
+sudo systemctl enable --now metrics-collector.service
+log "metrics-collector.service status: $(systemctl is-active metrics-collector.service)"


### PR DESCRIPTION
## Summary
- Install stream-listener and metrics-collector systemd units during Ubuntu setup
- Reload systemd and enable these services alongside online-trainer
- Log each service's active status for user visibility

## Testing
- `shellcheck scripts/setup_ubuntu.sh`
- `pytest` *(fails: 21 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_689e8a5f6a34832fb36c307bee9e4be9