### PR TITLE
Detect GPU memory and gate heavy models

### DIFF
--- a/tests/test_detect_resources.py
+++ b/tests/test_detect_resources.py
@@ -1,0 +1,50 @@
+import importlib
+import types
+import scripts.train_target_clone as tc
+
+
+class DummyVM:
+    available = 16 * 1024**3
+
+
+def _make_torch(mem):
+    class Props:
+        def __init__(self, m):
+            self.total_memory = m
+
+    class Cuda:
+        def __init__(self, m):
+            self._m = m
+
+        def is_available(self):
+            return True
+
+        def get_device_properties(self, idx):
+            return Props(self._m)
+
+    return types.SimpleNamespace(cuda=Cuda(mem))
+
+
+def _fake_find_spec(name):
+    if name in {"transformers", "pytorch_forecasting", "torch", "sklearn"}:
+        return types.SimpleNamespace()
+    return _orig_find_spec(name)
+
+
+def test_detect_resources_gpu_threshold(monkeypatch):
+    monkeypatch.setattr(tc.psutil, "virtual_memory", lambda: DummyVM)
+    monkeypatch.setattr(tc.psutil, "cpu_count", lambda logical=False: 8)
+    global _orig_find_spec
+    _orig_find_spec = importlib.util.find_spec
+    monkeypatch.setattr(importlib.util, "find_spec", _fake_find_spec)
+    monkeypatch.setattr(tc, "_HAS_TORCH", True)
+
+    monkeypatch.setattr(tc, "torch", _make_torch(4 * 1024**3))
+    res = tc.detect_resources()
+    assert res["gpu_mem_gb"] == 4
+    assert res["model_type"] == "lstm"
+
+    monkeypatch.setattr(tc, "torch", _make_torch(12 * 1024**3))
+    res = tc.detect_resources()
+    assert res["gpu_mem_gb"] == 12
+    assert res["model_type"] == "transformer"


### PR DESCRIPTION
## Summary
- record GPU memory via torch or `nvidia-smi` and expose `gpu_mem_gb`
- allow transformer/TFT selection only when GPU memory exceeds 8GB
- add tests for GPU memory gating in `detect_resources`

## Testing
- `python -m py_compile scripts/train_target_clone.py tests/test_detect_resources.py`
- `pytest tests/test_detect_resources.py`
- `pytest tests/test_detect_resources.py tests/test_train_target_clone_features.py tests/test_train_target_clone_validation.py tests/test_train_target_clone_bayes.py` *(fails: ModuleNotFoundError: No module named 'pyarrow.pandas_compat')*


------
https://chatgpt.com/codex/tasks/task_e_689e9fce301c832f9a2ac2a5f6131c34