### PR TITLE
Add swapfile setup for low-memory machines

### DIFF
--- a/scripts/setup_ubuntu.sh
+++ b/scripts/setup_ubuntu.sh
@@ -10,6 +10,15 @@ REPO_DIR="$(cd "$(dirname "$0")"/.. && pwd)"
 cd "$REPO_DIR"
 
 log "Updating package list"
+mem_kb=$(grep MemTotal /proc/meminfo | awk '{print $2}')
+if [ "$mem_kb" -lt $((2 * 1024 * 1024)) ]; then
+  sudo fallocate -l 2G /swapfile
+  sudo chmod 600 /swapfile
+  sudo mkswap /swapfile
+  sudo swapon /swapfile
+  echo '/swapfile none swap sw 0 0' | sudo tee -a /etc/fstab
+  log "Activated 2G swapfile due to low memory"
+fi
 sudo apt-get update
 
 log "Installing system packages"


### PR DESCRIPTION
## Summary
- add memory check to setup script and activate a 2G swapfile when RAM is below 2GB

## Testing
- `pytest tests/test_logging_basic.py -q` *(fails: ModuleNotFoundError: No module named 'scripts.socket_log_service')*

------
https://chatgpt.com/codex/tasks/task_e_689ea6661da8832fb8dc0fb06d049614