### PR TITLE
Detect disk space to trigger lite mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@ The EA records trade openings and closings using the `OnTradeTransaction` callba
     trail by `TrailingPips`.
   - `model_interface.mqh` – shared structures.
 - `scripts/` – helper Python scripts.
-  - `train_target_clone.py` – trains a model from exported logs.
+  - `train_target_clone.py` – trains a model from exported logs. It detects
+    available CPU, memory, GPU and free disk space (`disk_gb`) and switches to
+    lite mode when less than 5 GB remains.
   - `generate_mql4_from_model.py` – renders a new EA from a trained model description.
   - `evaluate_predictions.py` – basic log evaluation utility.
   - `promote_best_models.py` – selects top models by metric and copies them to a best directory.

--- a/scripts/train_target_clone.py
+++ b/scripts/train_target_clone.py
@@ -18,6 +18,7 @@ from typing import Iterable, List, Optional
 import sqlite3
 import logging
 import subprocess
+import shutil
 import sys
 
 import importlib.util
@@ -232,7 +233,8 @@ def detect_resources():
         except Exception:
             pass
 
-    lite_mode = mem_gb < 4 or cores < 2
+    disk_gb = shutil.disk_usage("/").free / (1024 ** 3)
+    lite_mode = mem_gb < 4 or cores < 2 or disk_gb < 5
     heavy_mode = mem_gb >= 8 and cores >= 4
 
     gpu_mem_gb = 0.0
@@ -299,6 +301,7 @@ def detect_resources():
         "model_type": model_type,
         "bayes_steps": bayes_steps,
         "mem_gb": mem_gb,
+        "disk_gb": disk_gb,
         "cores": cores,
         "has_gpu": has_gpu,
         "gpu_mem_gb": gpu_mem_gb,

--- a/tests/test_detect_resources.py
+++ b/tests/test_detect_resources.py
@@ -34,6 +34,9 @@ def _fake_find_spec(name):
 def test_detect_resources_gpu_threshold(monkeypatch):
     monkeypatch.setattr(tc.psutil, "virtual_memory", lambda: DummyVM)
     monkeypatch.setattr(tc.psutil, "cpu_count", lambda logical=False: 8)
+    monkeypatch.setattr(
+        tc.shutil, "disk_usage", lambda path: types.SimpleNamespace(free=10 * 1024**3)
+    )
     global _orig_find_spec
     _orig_find_spec = importlib.util.find_spec
     monkeypatch.setattr(importlib.util, "find_spec", _fake_find_spec)
@@ -48,3 +51,14 @@ def test_detect_resources_gpu_threshold(monkeypatch):
     res = tc.detect_resources()
     assert res["gpu_mem_gb"] == 12
     assert res["model_type"] == "transformer"
+
+
+def test_detect_resources_low_disk(monkeypatch):
+    monkeypatch.setattr(tc.psutil, "virtual_memory", lambda: DummyVM)
+    monkeypatch.setattr(tc.psutil, "cpu_count", lambda logical=False: 8)
+    monkeypatch.setattr(
+        tc.shutil, "disk_usage", lambda path: types.SimpleNamespace(free=4 * 1024**3)
+    )
+    res = tc.detect_resources()
+    assert res["disk_gb"] == 4
+    assert res["lite_mode"]


### PR DESCRIPTION
## Summary
- measure free disk space in `detect_resources` using `shutil.disk_usage`
- mark lite mode when less than 5 GB remains and expose `disk_gb`
- document disk space detection in README and add tests

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pytest tests/test_detect_resources.py`

------
https://chatgpt.com/codex/tasks/task_e_689ea8e02d70832fa7ec1fcdf20c4a38