### PR TITLE
feat: add optional uvloop

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,8 @@ A small web dashboard can display trades, metrics and training progress in real 
    ```
 5. Open <http://localhost:8000> in a browser and supply the token when prompted to view live updates.
 
+`uvloop` can be installed to accelerate asyncio event loops. `scripts/stream_listener.py` uses it automatically when available.
+
 ### Arrow Flight Logging
 
 `Observer_TBot` streams trade and metric events over [Apache Arrow Flight](https://arrow.apache.org/).

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,6 +28,7 @@ transformers
 pytorch-forecasting; extra == "tft"
 
 # Optional extras
+uvloop; extra == "uvloop"
 xgboost; extra == "xgboost"
 # Hyperparameter search
 optuna; extra == "optuna"

--- a/scripts/stream_listener.py
+++ b/scripts/stream_listener.py
@@ -13,6 +13,11 @@ from pathlib import Path
 import sys
 
 import asyncio
+try:
+    import uvloop
+    uvloop.install()
+except Exception:
+    pass
 import time
 import pickle
 import subprocess


### PR DESCRIPTION
## Summary
- use uvloop automatically when available in stream_listener
- document optional uvloop dependency in requirements and README

## Testing
- `pytest` *(fails: 22 errors during collection)*


------
https://chatgpt.com/codex/tasks/task_e_689fbd2414a8832fa96a8acecc7063e0