### PR TITLE
Install and log Chrony in Ubuntu setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -659,7 +659,10 @@ in Jaeger or Zipkin for deeper analysis.
 ## Ubuntu Setup and Services
 
 Run `scripts/setup_ubuntu.sh` on an Ubuntu host to install system packages,
-Python dependencies and initialise a Wine prefix for MetaTrader:
+Python dependencies and initialise a Wine prefix for MetaTrader. The script
+also installs and enables [Chrony](https://chrony.tuxfamily.org/) so the system
+clock remains synchronised. You can review synchronisation details in the
+output of `chronyc tracking`:
 
 ```bash
 ./scripts/setup_ubuntu.sh

--- a/scripts/setup_ubuntu.sh
+++ b/scripts/setup_ubuntu.sh
@@ -25,6 +25,13 @@ log "Installing system packages"
 sudo apt-get install -y build-essential python3 python3-pip wine64 \
   protobuf-compiler libcapnp-dev nats-server git
 
+log "Installing and enabling Chrony for time synchronization"
+sudo apt-get install -y chrony
+sudo systemctl enable --now chrony
+log "chrony service status: $(systemctl is-active chrony)"
+log "Chrony tracking summary"
+chronyc tracking || true
+
 log "Enabling and starting nats-server"
 sudo systemctl enable nats-server && sudo systemctl start nats-server
 


### PR DESCRIPTION
## Summary
- Install and enable Chrony in `setup_ubuntu.sh` to ensure system time sync
- Log Chrony service and tracking status for user verification
- Document Chrony requirement in the Ubuntu setup section of the README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas', etc.)*


------
https://chatgpt.com/codex/tasks/task_e_689fc45546d4832f8b5fe21e0700f141