### PR TITLE
Use systemd journal for logging with file fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -635,6 +635,7 @@ plt.show()
 - Ensure the MT4 terminal has permission to write files in `MQL4\Files`.
 - When running Python scripts, verify the paths to log files and models are correct.
 - Use the Experts and Journal tabs inside MT4 for additional debugging information.
+- For services managed by systemd, view logs with `journalctl -u <service>`.
 
 ### Trace Correlation
 

--- a/scripts/metrics_collector.py
+++ b/scripts/metrics_collector.py
@@ -8,6 +8,12 @@ import os
 import sqlite3
 import logging
 from pathlib import Path
+
+try:  # prefer systemd journal if available
+    from systemd.journal import JournalHandler
+    logging.basicConfig(handlers=[JournalHandler()], level=logging.INFO)
+except Exception:  # pragma: no cover - fallback to file logging
+    logging.basicConfig(filename="metrics_collector.log", level=logging.INFO)
 from typing import Callable, Optional
 from asyncio import Queue
 from aiohttp import web

--- a/scripts/online_trainer.py
+++ b/scripts/online_trainer.py
@@ -20,6 +20,7 @@ import argparse
 import asyncio
 import csv
 import json
+import logging
 import subprocess
 import sys
 import time
@@ -27,6 +28,12 @@ import os
 import threading
 from pathlib import Path
 from typing import Iterable, List, Dict, Any
+
+try:  # prefer systemd journal if available
+    from systemd.journal import JournalHandler
+    logging.basicConfig(handlers=[JournalHandler()], level=logging.INFO)
+except Exception:  # pragma: no cover - fallback to file logging
+    logging.basicConfig(filename="online_trainer.log", level=logging.INFO)
 
 import numpy as np
 import psutil

--- a/scripts/stream_listener.py
+++ b/scripts/stream_listener.py
@@ -8,6 +8,12 @@ import json
 import logging
 import os
 import platform
+
+try:  # prefer systemd journal if available
+    from systemd.journal import JournalHandler
+    logging.basicConfig(handlers=[JournalHandler()], level=logging.INFO)
+except Exception:  # pragma: no cover - fallback to file logging
+    logging.basicConfig(filename="stream_listener.log", level=logging.INFO)
 import pkgutil
 from pathlib import Path
 import sys


### PR DESCRIPTION
## Summary
- log metrics_collector, stream_listener and online_trainer to systemd journal when available
- fall back to local log files if journal access is missing
- mention `journalctl -u <service>` in troubleshooting tips

## Testing
- `pytest` *(fails: 22 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68a009815f70832fab0b82a63b8084a1