### PR TITLE
Document disk usage detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,11 @@ The EA records trade openings and closings using the `OnTradeTransaction` callba
     stop loss to break-even after `BreakEvenPips` profit and optionally
     trail by `TrailingPips`.
   - `model_interface.mqh` – shared structures.
-- `scripts/` – helper Python scripts.
-  - `train_target_clone.py` – trains a model from exported logs. It detects
-    available CPU, memory, GPU and free disk space (`disk_gb`) and switches to
-    lite mode when less than 5 GB remains.
+ - `scripts/` – helper Python scripts.
+  - `train_target_clone.py` – trains a model from exported logs. Its
+    `detect_resources()` helper reports available CPU, memory, GPU and free disk
+    space via `disk_gb`, automatically enabling lite mode when less than 5 GB
+    remains.
   - `generate_mql4_from_model.py` – renders a new EA from a trained model description.
   - `evaluate_predictions.py` – basic log evaluation utility.
   - `promote_best_models.py` – selects top models by metric and copies them to a best directory.

--- a/scripts/train_target_clone.py
+++ b/scripts/train_target_clone.py
@@ -247,6 +247,7 @@ def detect_resources():
         except Exception:
             pass
 
+    # Estimate free disk space to adjust behavior on low-storage systems
     disk_gb = shutil.disk_usage("/").free / (1024 ** 3)
     lite_mode = mem_gb < 4 or cores < 2 or disk_gb < 5
     heavy_mode = mem_gb >= 8 and cores >= 4


### PR DESCRIPTION
## Summary
- Clarify free disk detection in `detect_resources` and keep disk-based lite mode
- Document `disk_gb` field and lite-mode trigger in README

## Testing
- `pytest tests/test_detect_resources.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0c83dd22c832f8642175a91bf0fc1