### PR TITLE
Use uvloop when available in stream listener

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ A small web dashboard can display trades, metrics and training progress in real 
    ```
 5. Open <http://localhost:8000> in a browser and supply the token when prompted to view live updates.
 
-`uvloop` can be installed to accelerate asyncio event loops. `scripts/stream_listener.py` uses it automatically when available.
+`uvloop` can be installed (`pip install uvloop` or `pip install '.[uvloop]'`) to accelerate asyncio event loops. `scripts/stream_listener.py` uses it automatically when available.
 
 ### Arrow Flight Logging
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ transformers
 pytorch-forecasting; extra == "tft"
 
 # Optional extras
-uvloop; extra == "uvloop"
+uvloop; extra == "uvloop"  # faster asyncio event loop
 xgboost; extra == "xgboost"
 # Hyperparameter search
 optuna; extra == "optuna"

--- a/scripts/stream_listener.py
+++ b/scripts/stream_listener.py
@@ -2,6 +2,12 @@
 """Listen for observer events from NATS JetStream and append them to CSV logs."""
 from __future__ import annotations
 
+try:
+    import uvloop
+    uvloop.install()
+except Exception:
+    pass
+
 import argparse
 import csv
 import json
@@ -19,11 +25,6 @@ from pathlib import Path
 import sys
 
 import asyncio
-try:
-    import uvloop
-    uvloop.install()
-except Exception:
-    pass
 import time
 import pickle
 import subprocess


### PR DESCRIPTION
## Summary
- Load `uvloop` at startup in stream listener for a faster event loop when installed
- Document optional `uvloop` extra in requirements and README

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_68a0cac90a68832f899d298ea572d4e3