### PR TITLE
Auto-select training mode and propagate to tooling

### DIFF
--- a/model.json
+++ b/model.json
@@ -10,6 +10,7 @@
       "1": {"algorithm": "PPO", "parameters": {}}
     }
   },
+  "training_mode": "lite",
   "drift_metric": 0.0,
   "teacher_accuracy": 0.0,
   "student_coefficients": [0.0],

--- a/scripts/generate_mql4_from_model.py
+++ b/scripts/generate_mql4_from_model.py
@@ -545,6 +545,16 @@ def main():
     p.add_argument('--lite-mode', action='store_true')
     p.add_argument('--gating-json')
     args = p.parse_args()
+    if not args.lite_mode:
+        first = Path(args.model_json[0])
+        open_func = gzip.open if str(first).endswith('.gz') else open
+        with open_func(first, 'rt') as f:
+            try:
+                data = json.load(f)
+            except Exception:
+                data = {}
+        if data.get('training_mode') == 'lite':
+            args.lite_mode = True
     generate(
         [Path(m) for m in args.model_json],
         Path(args.out_dir),

--- a/scripts/setup_ubuntu.sh
+++ b/scripts/setup_ubuntu.sh
@@ -43,6 +43,15 @@ log "Installing Python dependencies"
 pip3 install --no-cache-dir -r requirements.txt
 pip3 install --no-cache-dir pyarrow
 
+log "Detecting hardware resources and training mode"
+python3 - <<'PY' | while read line; do log "$line"; done
+from scripts.train_target_clone import detect_resources
+import json
+res = detect_resources()
+print(json.dumps(res))
+print("training_mode=" + ("lite" if res["lite_mode"] else "heavy"))
+PY
+
 if command -v nvidia-smi >/dev/null 2>&1; then
   log "CUDA-capable GPU detected, installing onnxruntime-gpu"
   pip3 install --no-cache-dir onnxruntime-gpu

--- a/tests/test_detect_resources.py
+++ b/tests/test_detect_resources.py
@@ -51,7 +51,7 @@ def test_detect_resources_gpu_threshold(monkeypatch):
     monkeypatch.setattr(tc, "torch", _make_torch(4 * 1024**3))
     res = tc.detect_resources()
     assert res["gpu_mem_gb"] == 4
-    assert res["model_type"] == "lstm"
+    assert res["model_type"] == "logreg"
     assert res["cpu_mhz"] == 3000
 
     monkeypatch.setattr(tc, "torch", _make_torch(12 * 1024**3))
@@ -86,4 +86,4 @@ def test_detect_resources_cpu_threshold(monkeypatch):
     monkeypatch.setattr(tc, "torch", _make_torch(12 * 1024**3))
     res = tc.detect_resources()
     assert res["cpu_mhz"] == 2000
-    assert res["model_type"] == "lstm"
+    assert res["model_type"] == "logreg"


### PR DESCRIPTION
## Summary
- Detect hardware resources early and auto-choose model types
- Carry training mode through model.json to online tools
- Log hardware and training mode during Ubuntu setup

## Testing
- `pytest tests/test_detect_resources.py tests/test_online_trainer.py tests/test_generate.py -q` *(fails: No module named 'opentelemetry.exporter')*
- `pytest -q` *(fails: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_68a11b753378832f9860bb040d8bc78e