### PR TITLE
Add fallback logging for Observer_TBot

### DIFF
--- a/docs/fallback-logging.md
+++ b/docs/fallback-logging.md
@@ -1,0 +1,18 @@
+# Fallback Logging
+
+Observer_TBot retries sending trade and metric messages to the Flight server. After a configurable number of failed attempts (default 5), messages are redirected to a local fallback log.
+
+The bot first tries to forward the original CSV/JSON entry to `systemd` via `systemd-cat`. If `systemd` is unavailable, the entry is appended to `~/.local/share/botcopier/logs/trades_fallback.log` or `metrics_fallback.log`.
+
+Metrics include a `fallback_logging` flag so downstream monitoring can detect when the exporter is writing to the fallback log instead of Flight.
+
+## Viewing logs on Ubuntu
+
+On an Ubuntu VPS, fallback entries written to journald can be retrieved with:
+
+```bash
+sudo journalctl -t botcopier-trades
+sudo journalctl -t botcopier-metrics
+```
+
+Replace the tag with the desired stream. If journald is not available, review the log files in `~/.local/share/botcopier/logs/`.


### PR DESCRIPTION
## Summary
- Write unsent trade and metric messages to journald or local files when retry threshold is exceeded
- Report a fallback_logging flag in metrics to surface degraded connectivity
- Document how fallback logging works and how to fetch logs from journald on Ubuntu

## Testing
- `pytest tests/test_logging_basic.py` *(fails: ModuleNotFoundError: No module named 'scripts.socket_log_service')*


------
https://chatgpt.com/codex/tasks/task_e_68a1252547bc832f921dd0f1ec7e8ae9