### PR TITLE
Use uvloop in metrics collector

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ A small web dashboard can display trades, metrics and training progress in real 
    ```
 5. Open <http://localhost:8000> in a browser and supply the token when prompted to view live updates.
 
-`uvloop` can be installed (`pip install uvloop` or `pip install '.[uvloop]'`) to accelerate asyncio event loops. `scripts/stream_listener.py` uses it automatically when available.
+`uvloop` can be installed (`pip install uvloop` or `pip install '.[uvloop]'`) to accelerate asyncio event loops. `scripts/stream_listener.py` and `scripts/metrics_collector.py` use it automatically when available to reduce queue handling latency.
 
 ### Arrow Flight Logging
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ transformers
 pytorch-forecasting; extra == "tft"
 
 # Optional extras
-uvloop; extra == "uvloop"  # faster asyncio event loop
+uvloop; extra == "uvloop"  # faster asyncio event loop (stream_listener.py, metrics_collector.py)
 xgboost; extra == "xgboost"
 # Hyperparameter search
 optuna; extra == "optuna"

--- a/scripts/metrics_collector.py
+++ b/scripts/metrics_collector.py
@@ -1,6 +1,12 @@
 #!/usr/bin/env python3
 """Listen for metric messages and store them in a SQLite database."""
 
+try:
+    import uvloop
+    uvloop.install()
+except Exception:
+    pass
+
 import argparse
 import asyncio
 import json


### PR DESCRIPTION
## Summary
- Install uvloop when available in `metrics_collector.py` for a faster event loop
- Document optional uvloop dependency in README and requirements

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*
- Benchmarked queue latency with default loop vs. uvloop


------
https://chatgpt.com/codex/tasks/task_e_68a1279ba23c832fb7deb3a55c90989f