### PR TITLE
Add resource-aware training modes and logging

### DIFF
--- a/model.json
+++ b/model.json
@@ -11,6 +11,7 @@
     }
   },
   "training_mode": "lite",
+  "mode": "lite",
   "drift_metric": 0.0,
   "teacher_accuracy": 0.0,
   "student_coefficients": [0.0],

--- a/scripts/generate_mql4_from_model.py
+++ b/scripts/generate_mql4_from_model.py
@@ -557,7 +557,8 @@ def main():
                 data = json.load(f)
             except Exception:
                 data = {}
-        if data.get('training_mode') == 'lite':
+        mode = data.get('mode') or data.get('training_mode')
+        if mode == 'lite':
             args.lite_mode = True
     generate(
         [Path(m) for m in args.model_json],

--- a/scripts/online_trainer.py
+++ b/scripts/online_trainer.py
@@ -97,7 +97,7 @@ class OnlineTrainer:
             data = json.loads(self.model_path.read_text())
         except Exception:
             return
-        self.training_mode = data.get("training_mode", "lite")
+        self.training_mode = data.get("mode") or data.get("training_mode", "lite")
         self.feature_names = data.get("feature_names", [])
         coef = data.get("coefficients")
         intercept = data.get("intercept")
@@ -114,6 +114,7 @@ class OnlineTrainer:
             "coefficients": self.clf.coef_[0].tolist(),
             "intercept": float(self.clf.intercept_[0]),
             "training_mode": self.training_mode,
+            "mode": self.training_mode,
         }
         self.model_path.write_text(json.dumps(payload))
 


### PR DESCRIPTION
## Summary
- detect RAM, swap, GPU and CPU to select lite, heavy, deep or rl modes
- save selected mode in model.json and honour it in generator and online trainer
- add optional swap creation and hardware logging to Ubuntu setup script

## Testing
- `pytest` *(fails: ModuleNotFoundError: requests et al during full suite)*
- `pytest tests/test_detect_resources.py tests/test_generate.py tests/test_online_trainer.py`


------
https://chatgpt.com/codex/tasks/task_e_68a12fd4f15c832fa3e25efa436671b9