### PR TITLE
Instrument services with OpenTelemetry and expose Prometheus metrics

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,32 @@
+# Observability
+
+## Viewing logs
+
+The Python services write structured logs to the systemd journal when available. On Ubuntu use `journalctl` to inspect them:
+
+```bash
+sudo journalctl -u stream-listener.service -f
+sudo journalctl -u metrics-collector.service -f
+sudo journalctl -u online-trainer.service -f
+```
+
+If systemd is unavailable, the services fall back to local `*.log` files in the working directory.
+
+## Scraping metrics
+
+`metrics_collector.py` exposes Prometheus metrics. Start the service with `--prom-port` and then scrape:
+
+```bash
+curl http://localhost:8001/metrics
+```
+
+Add the endpoint to your Prometheus configuration:
+
+```yaml
+scrape_configs:
+  - job_name: botcopier
+    static_configs:
+      - targets: ['localhost:8001']
+```
+
+CPU and memory utilisation metrics are collected using `psutil` and exported alongside bot performance gauges.


### PR DESCRIPTION
## Summary
- add Prometheus exporter in `metrics_collector.py` with psutil CPU/memory gauges and system sampling
- instrument `online_trainer.py` with OpenTelemetry traces and structured logging
- document viewing logs via `journalctl` and scraping Prometheus metrics

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68a134904a6c832fac2d72815f82434d