### PR TITLE
Enable incremental caching and auto retrain publishing

### DIFF
--- a/scripts/auto_retrain.py
+++ b/scripts/auto_retrain.py
@@ -224,16 +224,11 @@ def retrain_if_needed(
         except Exception:
             pass
 
-        # Backtest to ensure new model improves over previous metrics
         backtest_file = tick_file or (log_dir / "trades_raw.csv")
         try:
-            result = run_backtest(model_json, backtest_file)
+            run_backtest(model_json, backtest_file)
         except Exception:
-            return False
-
-        if result.get("win_rate", 0) <= metrics["win_rate"] or result.get("drawdown", 1) >= metrics["drawdown"]:
-            logger.info("backtest did not improve metrics")
-            return False
+            logger.info("backtest failed", exc_info=True)
 
         publish(model_onnx if model_onnx.exists() else model_json, files_dir)
         tc.START_EVENT_ID = 0

--- a/tests/test_auto_retrain.py
+++ b/tests/test_auto_retrain.py
@@ -122,9 +122,9 @@ def test_retrain_no_improvement(monkeypatch, tmp_path: Path):
 
     result = retrain_if_needed(log_dir, out_dir, files_dir)
 
-    assert result is False
+    assert result is True
     assert called.get("train") is True
-    assert called.get("publish") is None
+    assert called.get("publish") is True
     assert called.get("backtest") is True
 
 


### PR DESCRIPTION
## Summary
- cache extracted features to gzip-compressed parquet and reuse when metadata matches
- stream training logs in chunks to reduce memory use
- auto-retrain now always publishes new model after retraining

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'opentelemetry.exporter')*

------
https://chatgpt.com/codex/tasks/task_e_68a136a25d48832f8ba92521ab16c00a