### PR TITLE
Auto-configure training mode from hardware resources

### DIFF
--- a/scripts/train_target_clone.py
+++ b/scripts/train_target_clone.py
@@ -1513,6 +1513,7 @@ def _train_lite_mode(
     compress_model: bool = False,
     regime_model: dict | None = None,
     flight_uri: str | None = None,
+    mode: str = "lite",
 ) -> None:
     """Stream features and train an SGD classifier incrementally."""
 
@@ -1615,6 +1616,8 @@ def _train_lite_mode(
         "feature_names": feature_names,
         "model_type": "logreg",
         "weighted": False,
+        "training_mode": "lite",
+        "mode": mode,
         "train_accuracy": float("nan"),
         "val_accuracy": float("nan"),
         "threshold": 0.5,
@@ -1752,6 +1755,7 @@ def train(
             compress_model=compress_model,
             regime_model=regime_model,
             flight_uri=flight_uri,
+            mode=mode,
         )
         return
     feature_flags = {
@@ -3536,8 +3540,10 @@ def main():
         else:
             higher_tfs = None
         lite_mode = resources["lite_mode"]
-        use_sma = use_rsi = use_macd = use_atr = use_bollinger = use_stochastic = use_adx = not lite_mode
-        grid_search = args.grid_search and not lite_mode
+        heavy_mode = resources["heavy_mode"]
+        use_sma = use_rsi = use_macd = use_atr = use_bollinger = use_stochastic = use_adx = heavy_mode
+        use_volume = heavy_mode
+        grid_search = args.grid_search and heavy_mode
         model_type = args.model_type or resources["model_type"]
         bayes_steps = 0 if lite_mode else (args.bayes_steps or resources["bayes_steps"])
         train(
@@ -3552,6 +3558,7 @@ def main():
             use_bollinger=use_bollinger,
             use_stochastic=use_stochastic,
             use_adx=use_adx,
+            use_volume=use_volume,
             higher_timeframes=higher_tfs,
             volatility_series=vol_data,
             grid_search=grid_search,


### PR DESCRIPTION
## Summary
- Auto-select heavy indicators and deep models based on `detect_resources()` output in `train_target_clone.py`
- Persist selected mode and feature flags into `model.json` for downstream scripts
- Document automatic feature/model activation on powerful machines and lightweight defaults on constrained VPSes

## Testing
- `pytest -q` *(fails: No module named 'pandas')*
- `pip install -r requirements.txt` *(fails: ImportError: cannot import name 'build_py_2to3')*

------
https://chatgpt.com/codex/tasks/task_e_68a13c695520832f848ede17f154f533