### PR TITLE
feat: add observability logging and metrics

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -2,7 +2,7 @@
 
 ## Viewing logs
 
-The Python services write structured logs to the systemd journal when available. On Ubuntu use `journalctl` to inspect them:
+The Python services write structured logs to the systemd journal when available. Socket send failures and disk write errors are reported here so they can be alerted on. On Ubuntu use `journalctl` to inspect them:
 
 ```bash
 sudo journalctl -u stream-listener.service -f
@@ -29,4 +29,8 @@ scrape_configs:
       - targets: ['localhost:8001']
 ```
 
-CPU and memory utilisation metrics are collected using `psutil` and exported alongside bot performance gauges.
+CPU and memory utilisation metrics are collected using `psutil` and exported alongside bot performance gauges. Arrow Flight queue depth is reported via `bot_metric_queue_depth` and `bot_trade_queue_depth` gauges so backpressure on the message bus is visible.
+
+## Grafana dashboard
+
+Import `grafana/metrics_dashboard.json` into Grafana to visualise the Prometheus data. The dashboard includes CPU and memory usage, Arrow Flight queue depth and error counters for socket and file write failures.

--- a/grafana/metrics_dashboard.json
+++ b/grafana/metrics_dashboard.json
@@ -54,6 +54,30 @@
       "targets": [
         {"expr": "bot_book_refresh_seconds"}
       ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Host CPU %",
+      "id": 7,
+      "targets": [
+        {"expr": "system_cpu_percent"}
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Host Memory %",
+      "id": 8,
+      "targets": [
+        {"expr": "system_memory_percent"}
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Flight Metric Queue Depth",
+      "id": 9,
+      "targets": [
+        {"expr": "bot_metric_queue_depth"}
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- log socket and file write errors to journald in Python services
- expose Prometheus gauges for host utilisation and Arrow Flight queue depth
- document monitoring and ship Grafana dashboard

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_68a145d03500832fb9de032f8c5a1e60