### PR TITLE
Track IO error metrics and expose collector endpoint

### DIFF
--- a/docs/metrics_dashboard.json
+++ b/docs/metrics_dashboard.json
@@ -1,0 +1,83 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "schemaVersion": 38,
+  "title": "Bot Metrics",
+  "uid": "bot-metrics",
+  "version": 0,
+  "panels": [
+    {
+      "type": "timeseries",
+      "title": "Win Rate",
+      "id": 1,
+      "targets": [
+        {"expr": "bot_win_rate"}
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Drawdown",
+      "id": 2,
+      "targets": [
+        {"expr": "bot_drawdown"}
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Socket Errors",
+      "id": 3,
+      "targets": [
+        {"expr": "bot_socket_errors_total"}
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "File Write Errors",
+      "id": 4,
+      "targets": [
+        {"expr": "bot_file_write_errors_total"}
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "CPU Load",
+      "id": 5,
+      "targets": [
+        {"expr": "bot_cpu_load"}
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Book Refresh Seconds",
+      "id": 6,
+      "targets": [
+        {"expr": "bot_book_refresh_seconds"}
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Host CPU %",
+      "id": 7,
+      "targets": [
+        {"expr": "system_cpu_percent"}
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Host Memory %",
+      "id": 8,
+      "targets": [
+        {"expr": "system_memory_percent"}
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Flight Metric Queue Depth",
+      "id": 9,
+      "targets": [
+        {"expr": "bot_metric_queue_depth"}
+      ]
+    }
+  ]
+}

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -33,4 +33,8 @@ CPU and memory utilisation metrics are collected using `psutil` and exported alo
 
 ## Grafana dashboard
 
-Import `grafana/metrics_dashboard.json` into Grafana to visualise the Prometheus data. The dashboard includes CPU and memory usage, Arrow Flight queue depth and error counters for socket and file write failures.
+Import `metrics_dashboard.json` from the `docs/` directory into Grafana to visualise the Prometheus data. The dashboard includes CPU and memory usage, Arrow Flight queue depth and error counters for socket and file write failures.
+
+## OpenTelemetry exporter
+
+`otel-exporter.yaml` provides a minimal OTLP exporter configuration that forwards traces, metrics and logs to a collector running on `localhost:4318`.

--- a/docs/otel-exporter.yaml
+++ b/docs/otel-exporter.yaml
@@ -1,0 +1,14 @@
+exporters:
+  otlp:
+    endpoint: http://localhost:4318
+    protocol: http/protobuf
+    compression: gzip
+
+service:
+  pipelines:
+    traces:
+      exporters: [otlp]
+    metrics:
+      exporters: [otlp]
+    logs:
+      exporters: [otlp]


### PR DESCRIPTION
## Summary
- include file and socket error counters in MQ4 metrics
- allow metrics_collector to ingest JSON with trace context and serve Prometheus metrics
- document sample Grafana dashboard and OpenTelemetry exporter

## Testing
- `pytest` *(fails: ModuleNotFoundError: ruptures, sklearn, uvicorn, pydantic, scripts.socket_log_service, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a15308aa48832fa384cf0827094bac