### PR TITLE
Improve Flight logging reliability

### DIFF
--- a/experts/Observer_TBot.mq4
+++ b/experts/Observer_TBot.mq4
@@ -382,9 +382,7 @@ void FlushPending(datetime now)
             string line = ArraySize(pending_trade_lines) > 0 ? pending_trade_lines[0] : "";
             FallbackLog("trades", pending_trades[0], line);
             FallbackEvents++;
-            RemoveFirst(pending_trades);
-            RemoveFirstStr(pending_trade_lines);
-            trade_retry_count = FallbackRetryThreshold;
+            trade_retry_count = 0;
          }
       }
    }
@@ -410,9 +408,7 @@ void FlushPending(datetime now)
             string line = ArraySize(pending_metric_lines) > 0 ? pending_metric_lines[0] : "";
             FallbackLog("metrics", pending_metrics[0], line);
             FallbackEvents++;
-            RemoveFirst(pending_metrics);
-            RemoveFirstStr(pending_metric_lines);
-            metric_retry_count = FallbackRetryThreshold;
+            metric_retry_count = 0;
          }
       }
    }

--- a/scripts/flight_server.py
+++ b/scripts/flight_server.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 """Arrow Flight server exposing trade and metric streams.
 
-The server stores incoming record batches in memory and supports two
-paths:
+Incoming record batches are retained in memory for clients and mirrored
+to both SQLite databases and Parquet datasets. Two logical paths are
+served:
 
 * ``trades``
 * ``metrics``

--- a/scripts/metrics_collector.py
+++ b/scripts/metrics_collector.py
@@ -404,7 +404,7 @@ def serve(
                             await queue.put(row)
                     last = len(rows)
                 except Exception as e:  # pragma: no cover - network issues
-                    logger.warning({"error": "socket error", "details": str(e)})
+                    logger.warning({"error": "flight error", "details": str(e)})
                     await asyncio.sleep(1)
                     continue
                 await asyncio.sleep(1)

--- a/scripts/setup_ubuntu.sh
+++ b/scripts/setup_ubuntu.sh
@@ -45,6 +45,7 @@ python3 -m pip install --upgrade pip
 
 log "Installing Python dependencies"
 pip3 install --no-cache-dir -r requirements.txt
+# pyarrow is required for Arrow Flight support
 pip3 install --no-cache-dir pyarrow
 
 log "Detecting hardware resources and training mode"

--- a/scripts/stream_listener.py
+++ b/scripts/stream_listener.py
@@ -609,7 +609,7 @@ def main() -> int:
                         handler(SimpleNamespace(**row))
                     last = len(rows)
                 except Exception as e:  # pragma: no cover - network issues
-                    logger.warning({"error": "socket error", "details": str(e), "path": path})
+                    logger.warning({"error": "flight error", "details": str(e), "path": path})
                     await asyncio.sleep(1)
                     continue
                 await asyncio.sleep(1)


### PR DESCRIPTION
## Summary
- retry and log trade/metric batches when Arrow Flight send fails
- document Flight server persistence to SQLite and Parquet
- clarify Flight error handling in listeners
- install pyarrow for Flight support in setup script

## Testing
- `python -m py_compile scripts/flight_server.py scripts/stream_listener.py scripts/metrics_collector.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'pydantic', etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68a232461514832f9078f8cc9b2ecd20