### PR TITLE
feat: add regime clustering and logging utilities

### DIFF
--- a/experts/StrategyTemplate.mq4
+++ b/experts/StrategyTemplate.mq4
@@ -390,7 +390,7 @@ int OnInit()
          if(DecisionLogHandle != INVALID_HANDLE)
          {
             if(FileSize(DecisionLogHandle) == 0)
-               FileWrite(DecisionLogHandle, "event_id;timestamp;model_version;action;probability;features");
+               FileWrite(DecisionLogHandle, "event_id;timestamp;model_version;action;probability;sl_dist;tp_dist;model_idx;regime;features");
             FileSeek(DecisionLogHandle, 0, SEEK_END);
          }
          else
@@ -401,7 +401,7 @@ int OnInit()
    if(UncertainLogHandle != INVALID_HANDLE)
    {
       if(FileSize(UncertainLogHandle) == 0)
-         FileWrite(UncertainLogHandle, "event_id;timestamp;model_version;action;probability;sl_dist;tp_dist;features");
+         FileWrite(UncertainLogHandle, "event_id;timestamp;model_version;action;probability;sl_dist;tp_dist;model_idx;regime;features");
       FileSeek(UncertainLogHandle, 0, SEEK_END);
    }
    else

--- a/scripts/detect_regime.py
+++ b/scripts/detect_regime.py
@@ -30,6 +30,7 @@ def detect_regimes(
     clusters: int = 3,
     algorithm: str = "kmeans",
     model_json: Optional[Path] = None,
+    assignments_csv: Optional[Path] = None,
 ) -> None:
     """Cluster feature vectors and write regime IDs and centers to ``out_file``.
 
@@ -91,6 +92,9 @@ def detect_regimes(
     }
     out_file.write_text(json.dumps(model))
 
+    if assignments_csv is not None:
+        rows_df.assign(regime=labels).to_csv(assignments_csv, index=False)
+
     if model_json is not None:
         update = {
             "regime_feature_names": model["feature_names"],
@@ -122,6 +126,7 @@ def main() -> None:
         help="clustering algorithm",
     )
     p.add_argument("--model-json", type=Path, default=Path("model.json"))
+    p.add_argument("--assignments", type=Path, help="CSV file to write per-sample regime IDs")
     args = p.parse_args()
     detect_regimes(
         args.data_dir,
@@ -129,6 +134,7 @@ def main() -> None:
         args.clusters,
         args.algorithm,
         args.model_json,
+        args.assignments,
     )
 
 

--- a/scripts/generate_mql4_from_model.py
+++ b/scripts/generate_mql4_from_model.py
@@ -81,6 +81,8 @@ def generate(
     if gating_json:
         with open(gating_json, 'rt') as f:
             gating_data = json.load(f)
+    if gating_data and 'feature_names' not in gating_data:
+        gating_data['feature_names'] = base.get('feature_names', [])
 
     has_gpu_weights = any(
         m.get('transformer_weights')

--- a/scripts/train_target_clone.py
+++ b/scripts/train_target_clone.py
@@ -3643,6 +3643,7 @@ def main():
     p.add_argument('--prune-warn', type=float, default=0.5, help='warn if more than this fraction of features are pruned')
     p.add_argument('--compress-model', action='store_true', help='write model.json.gz')
     p.add_argument('--regime-model', help='JSON file with precomputed regime centers')
+    p.add_argument('--regime-json', help='regime detection JSON produced by detect_regime.py')
     p.add_argument('--moe', action='store_true', help='train mixture-of-experts model per symbol')
     p.add_argument('--federated-server', help='URL of federated averaging server')
     p.add_argument('--use-encoder', action='store_true', help='apply pretrained contrastive encoder')
@@ -3715,7 +3716,13 @@ def main():
             prune_threshold=args.prune_threshold,
             prune_warn=args.prune_warn,
             compress_model=args.compress_model,
-            regime_model_file=Path(args.regime_model) if args.regime_model else None,
+            regime_model_file=(
+                Path(args.regime_json)
+                if args.regime_json
+                else Path(args.regime_model)
+                if args.regime_model
+                else None
+            ),
             moe=args.moe,
             flight_uri=args.flight_uri,
             use_encoder=args.use_encoder,


### PR DESCRIPTION
## Summary
- extend regime detection script to optionally dump per-sample assignments and merge metadata into model files
- allow train_target_clone to accept detect_regime output via --regime-json
- preserve gating feature names when generating MQL4 strategies
- log regime and model identifiers in decision logs for strategies

## Testing
- `pytest tests/test_regime_gating.py tests/test_generate.py -q`
- `pytest tests/test_train_target_clone_features.py tests/test_train_target_clone_validation.py tests/test_train_target_clone_bayes.py -q` *(fails: ModuleNotFoundError: No module named 'opentelemetry')*


------
https://chatgpt.com/codex/tasks/task_e_68a23a5f52ac832f92c1a781ed133c35