### PR TITLE
Automate online training backtesting and model promotion

### DIFF
--- a/docs/systemd/auto-retrain.service
+++ b/docs/systemd/auto-retrain.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=BotCopier Auto Retrain
+After=network.target
+
+[Service]
+Type=oneshot
+WorkingDirectory=/opt/BotCopier
+ExecStart=/usr/bin/python3 scripts/auto_retrain.py
+Environment=PYTHONUNBUFFERED=1
+
+[Install]
+WantedBy=multi-user.target

--- a/docs/systemd/auto-retrain.timer
+++ b/docs/systemd/auto-retrain.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=Scheduled Auto Retrain
+
+[Timer]
+OnCalendar=hourly
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/docs/systemd/online-trainer.service
+++ b/docs/systemd/online-trainer.service
@@ -5,7 +5,7 @@ After=network.target
 [Service]
 Type=simple
 WorkingDirectory=/opt/BotCopier
-ExecStart=/usr/bin/python3 scripts/online_trainer.py --csv logs/trades_raw.csv
+ExecStart=/usr/bin/python3 scripts/online_trainer.py --flight 127.0.0.1:8815
 Restart=on-failure
 WatchdogSec=60
 Environment=PYTHONUNBUFFERED=1

--- a/docs/systemd/promote-best-models.service
+++ b/docs/systemd/promote-best-models.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=BotCopier Promote Best Models
+After=network.target
+
+[Service]
+Type=oneshot
+WorkingDirectory=/opt/BotCopier
+ExecStart=/usr/bin/python3 scripts/promote_best_models.py models best --metric sharpe --files-dir /opt/mt4/Files
+Environment=PYTHONUNBUFFERED=1
+
+[Install]
+WantedBy=multi-user.target

--- a/docs/systemd/promote-best-models.timer
+++ b/docs/systemd/promote-best-models.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=Schedule Promotion of Best Models
+
+[Timer]
+OnCalendar=daily
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/scripts/backtest_strategy.py
+++ b/scripts/backtest_strategy.py
@@ -305,6 +305,18 @@ def run_backtest(
     return result
 
 
+def backtest_model(model_path: Path, log_file: Path) -> Dict[str, float]:
+    """Convenience helper to backtest ``model_path`` against ``log_file``.
+
+    The function delegates to :func:`run_backtest` and returns the resulting
+    Sharpe ratio and win rate.  The evaluation JSON next to ``model_path`` is
+    updated as a side effect.
+    """
+
+    metrics = run_backtest(model_path, log_file)
+    return {"sharpe": metrics.get("sharpe", 0.0), "win_rate": metrics.get("win_rate", 0.0)}
+
+
 def check_performance(
     metrics: Dict[str, float],
     min_win_rate: float = 0.0,

--- a/scripts/online_trainer.py
+++ b/scripts/online_trainer.py
@@ -243,7 +243,7 @@ class OnlineTrainer:
         y = [int(rec["y"]) for rec in batch]
         return np.asarray(X), np.asarray(y)
 
-    def update(self, batch: List[Dict[str, Any]]) -> None:
+    def update(self, batch: List[Dict[str, Any]]) -> bool:
         with tracer.start_as_current_span("train_batch") as span:
             X, y = self._vectorise(batch)
             if not hasattr(self.clf, "classes_"):
@@ -266,6 +266,7 @@ class OnlineTrainer:
                 },
                 extra={"trace_id": ctx.trace_id, "span_id": ctx.span_id},
             )
+            return changed
 
     # ------------------------------------------------------------------
     # Data sources


### PR DESCRIPTION
## Summary
- Track coefficient changes in `online_trainer` and persist updated `model.json`
- Provide helper to backtest models against recent logs and rank promotions by Sharpe or other metrics
- Add systemd units for online training, periodic retraining and model promotion

## Testing
- `pytest tests/test_online_trainer.py tests/test_backtest_strategy.py tests/test_promote_best_models.py`

------
https://chatgpt.com/codex/tasks/task_e_68a24bb5f844832fb163e11ba25c10bd