### PR TITLE
Track error metrics and improve observability

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -27,3 +27,25 @@ Downstream components read these flags to stay in sync:
 This metadata is persisted in ``model.json`` so that models trained on one
 machine can be safely deployed on another with different capabilities.
 
+## Observability
+
+Runtime services emit structured logs to the systemd journal when available. Inspect them with:
+
+```
+sudo journalctl -u stream-listener.service -f
+sudo journalctl -u metrics-collector.service -f
+```
+
+Without systemd the services fall back to local ``*.log`` files.
+
+When :mod:`scripts.metrics_collector` is launched with ``--prom-port`` it exposes Prometheus gauges and counters. Add the endpoint to your scrape configuration:
+
+```
+scrape_configs:
+  - job_name: botcopier
+    static_configs:
+      - targets: ['localhost:8001']
+```
+
+Grafana dashboards can then be built on top of the Prometheus data. Import ``docs/metrics_dashboard.json`` for a starter layout showing CPU/memory usage, Arrow Flight queue depth and error counters.
+

--- a/scripts/stream_listener.py
+++ b/scripts/stream_listener.py
@@ -263,6 +263,27 @@ handler.setFormatter(JsonFormatter())
 logger.addHandler(handler)
 logger.setLevel(logging.INFO)
 
+
+class TraceAdapter(logging.LoggerAdapter):
+    """Inject current trace/span IDs into log records."""
+
+    def process(self, msg, kwargs):
+        extra = kwargs.get("extra", {})
+        if current_trace_id:
+            try:
+                extra.setdefault("trace_id", int(current_trace_id, 16))
+            except ValueError:
+                pass
+        if current_span_id:
+            try:
+                extra.setdefault("span_id", int(current_span_id, 16))
+            except ValueError:
+                pass
+        kwargs["extra"] = extra
+        return msg, kwargs
+
+logger = TraceAdapter(logger, {})
+
 # optional dashboard websocket connections
 ws_trades: WebSocket | None = None
 ws_metrics: WebSocket | None = None


### PR DESCRIPTION
## Summary
- track file/socket errors and pending queue depth in Observer_TBot metrics
- expose Prometheus metrics via `start_http_server` and keep trace context
- journal-aware logs with trace IDs and observability documentation

## Testing
- `pytest` *(fails: No module named 'pandas', 'numpy', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a2585d8ca8832f85115340f43cbd5d