### PR TITLE
Integrate graph-based market features

### DIFF
--- a/experts/StrategyTemplate.mq4
+++ b/experts/StrategyTemplate.mq4
@@ -92,6 +92,9 @@ double RiskParityWeights[] = {__RISK_PARITY_WEIGHTS__};
 datetime CalendarTimes[] = {__CALENDAR_TIMES__};
 double CalendarImpacts[] = {__CALENDAR_IMPACTS__};
 int EventWindowMinutes = __EVENT_WINDOW__;
+string GraphSymbols[] = {__GRAPH_SYMBOLS__};
+double GraphDegreeVals[] = {__GRAPH_DEGREE__};
+double GraphPagerankVals[] = {__GRAPH_PAGERANK__};
 double FeatureHistory[__LSTM_SEQ_LEN__][__FEATURE_COUNT__];
 int FeatureHistorySize = 0;
 int CachedTimeframes[] = {__CACHE_TIMEFRAMES__};
@@ -677,6 +680,22 @@ double PairCorrelation(string sym1, string sym2="", int window=5)
    if(den1 <= 0 || den2 <= 0)
       return(0.0);
    return(num / MathSqrt(den1 * den2));
+}
+
+double GraphDegree()
+{
+   for(int i=0; i<ArraySize(GraphSymbols); i++)
+      if(GraphSymbols[i] == SymbolToTrade)
+         return(GraphDegreeVals[i]);
+   return(0.0);
+}
+
+double GraphPagerank()
+{
+   for(int i=0; i<ArraySize(GraphSymbols); i++)
+      if(GraphSymbols[i] == SymbolToTrade)
+         return(GraphPagerankVals[i]);
+   return(0.0);
 }
 
 double GetNewsSentiment()

--- a/scripts/build_symbol_graph.py
+++ b/scripts/build_symbol_graph.py
@@ -1,61 +1,128 @@
 #!/usr/bin/env python3
-"""Construct a symbol correlation graph.
+"""Build a weighted symbol graph from precomputed correlation features.
 
-This utility reads a CSV file containing price history for multiple symbols and
-computes pairwise Pearson correlations. The resulting undirected graph is
-written to JSON format suitable for consumption by :mod:`train_target_clone`.
+This utility aggregates ``corr_*`` features exported by
+``train_target_clone.py`` into an undirected weighted graph.  It then derives
+simple node metrics (currently degree and PageRank centrality) which can be
+consumed by the training pipeline as additional features.
 
-The input CSV is expected to contain the columns ``timestamp``, ``symbol`` and
-``price``. Timestamps are treated as categorical identifiers; they need only be
-consistent across symbols.
+The input file is expected to be a CSV or Parquet table containing at least the
+columns ``symbol`` and one or more ``corr_<PEER>`` columns.  Each row
+represents a trade for ``symbol`` with an observed correlation value to ``PEER``.
+
+Example
+-------
+>>> build_graph(Path("features.csv"), Path("graph.json"))
+
+The resulting JSON has the structure::
+
+    {
+        "symbols": ["EURUSD", "USDCHF"],
+        "edge_index": [[0, 1], [1, 0]],
+        "edge_weight": [0.9, 0.9],
+        "metrics": {
+            "degree": [0.9, 0.9],
+            "pagerank": [0.5, 0.5]
+        }
+    }
+
 """
+
+from __future__ import annotations
+
 import argparse
 import json
 from pathlib import Path
 
+import numpy as np
 import pandas as pd
 
 
-def build_graph(csv_path: Path, out_path: Path) -> dict:
-    """Build correlation graph from price history.
+def _compute_pagerank(adj: np.ndarray, alpha: float = 0.85, tol: float = 1e-6) -> np.ndarray:
+    """Compute PageRank scores for a weighted adjacency matrix."""
 
-    Parameters
-    ----------
-    csv_path: Path
-        CSV file with columns ``timestamp``, ``symbol`` and ``price``.
-    out_path: Path
-        Destination path for graph JSON.
-    """
-    df = pd.read_csv(csv_path)
-    pivot = df.pivot(index="timestamp", columns="symbol", values="price")
-    corr = pivot.corr().fillna(0.0)
-    symbols = list(corr.columns)
-    edge_index = []
-    edge_weight = []
-    for i in range(len(symbols)):
-        for j in range(i + 1, len(symbols)):
-            w = float(corr.iloc[i, j])
-            edge_index.append([i, j])
-            edge_index.append([j, i])
-            edge_weight.extend([w, w])
+    n = adj.shape[0]
+    if n == 0:
+        return np.zeros(0)
+    pr = np.full(n, 1.0 / n)
+    out_weight = adj.sum(axis=1)
+    out_weight[out_weight == 0.0] = 1.0  # avoid division by zero
+    for _ in range(100):
+        prev = pr.copy()
+        pr = (1 - alpha) / n + alpha * adj.T.dot(pr / out_weight)
+        if np.abs(pr - prev).sum() < tol:
+            break
+    return pr
+
+
+def build_graph(feat_path: Path, out_path: Path) -> dict:
+    """Aggregate correlation features into a weighted graph and compute metrics."""
+
+    if feat_path.suffix == ".parquet":
+        df = pd.read_parquet(feat_path)
+    else:
+        df = pd.read_csv(feat_path)
+
+    symbols = list(df["symbol"].dropna().unique())
+    index = {s: i for i, s in enumerate(symbols)}
+    weights: dict[tuple[str, str], list[float]] = {}
+
+    for _, row in df.iterrows():
+        base = row.get("symbol")
+        if not isinstance(base, str):
+            continue
+        for col, val in row.items():
+            if not col.startswith("corr_"):
+                continue
+            if pd.isna(val):
+                continue
+            peer = col[5:]
+            if peer not in index:
+                index[peer] = len(symbols)
+                symbols.append(peer)
+            pair = tuple(sorted((base, peer)))
+            weights.setdefault(pair, []).append(float(val))
+
+    n = len(symbols)
+    adj = np.zeros((n, n), dtype=float)
+    edge_index: list[list[int]] = []
+    edge_weight: list[float] = []
+
+    for (a, b), vals in weights.items():
+        w = float(np.mean(np.abs(vals)))
+        i, j = index[a], index[b]
+        adj[i, j] = adj[j, i] = w
+        edge_index.append([i, j])
+        edge_index.append([j, i])
+        edge_weight.extend([w, w])
+
+    degree = adj.sum(axis=1)
+    pagerank = _compute_pagerank(adj)
+
     graph = {
         "symbols": symbols,
         "edge_index": edge_index,
         "edge_weight": edge_weight,
+        "metrics": {
+            "degree": degree.tolist(),
+            "pagerank": pagerank.tolist(),
+        },
     }
+
     out_path.parent.mkdir(parents=True, exist_ok=True)
     with open(out_path, "w") as f:
         json.dump(graph, f, indent=2)
     return graph
 
 
-def main():
+def main() -> None:
     p = argparse.ArgumentParser(description=__doc__)
-    p.add_argument("--prices", required=True, help="CSV file with timestamp,symbol,price")
+    p.add_argument("--features", required=True, help="CSV/Parquet file with corr_* features")
     p.add_argument("--out", required=True, help="Output JSON file for graph")
     args = p.parse_args()
-    build_graph(Path(args.prices), Path(args.out))
+    build_graph(Path(args.features), Path(args.out))
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
     main()
+

--- a/scripts/generate_mql4_from_model.py
+++ b/scripts/generate_mql4_from_model.py
@@ -390,6 +390,21 @@ def generate(
         output = output.replace('__SYM_EMB_SYMBOLS__', '')
         output = output.replace('__SYM_EMB_VALUES__', '')
 
+    graph_data = base.get('graph', {})
+    metrics = graph_data.get('metrics') or {}
+    if metrics:
+        g_symbols = graph_data.get('symbols', [])
+        sym_list = ', '.join(f'"{s}"' for s in g_symbols)
+        deg_vals = metrics.get('degree', [0.0] * len(g_symbols))
+        pr_vals = metrics.get('pagerank', [0.0] * len(g_symbols))
+        output = output.replace('__GRAPH_SYMBOLS__', sym_list)
+        output = output.replace('__GRAPH_DEGREE__', ', '.join(_fmt(v) for v in deg_vals))
+        output = output.replace('__GRAPH_PAGERANK__', ', '.join(_fmt(v) for v in pr_vals))
+    else:
+        output = output.replace('__GRAPH_SYMBOLS__', '')
+        output = output.replace('__GRAPH_DEGREE__', '')
+        output = output.replace('__GRAPH_PAGERANK__', '')
+
     rps = base.get('risk_parity_symbols', [])
     rpw = base.get('risk_parity_weights', [])
     if rps and rpw:
@@ -503,6 +518,10 @@ def generate(
                     expr = f'PairCorrelation("{parts[0]}", "{parts[1]}")'
                 elif len(parts) == 1:
                     expr = f'PairCorrelation("{parts[0]}")'
+            elif name == 'graph_degree':
+                expr = 'GraphDegree()'
+            elif name == 'graph_pagerank':
+                expr = 'GraphPagerank()'
             elif name.startswith('ae') and name[2:].isdigit():
                 idx_ae = int(name[2:])
                 expr = f'GetEncodedFeature({idx_ae})'

--- a/tests/test_graph_features.py
+++ b/tests/test_graph_features.py
@@ -1,0 +1,147 @@
+import csv
+import json
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from scripts.build_symbol_graph import build_graph
+from scripts.generate_mql4_from_model import generate
+from scripts.train_target_clone import train, _load_logs, _extract_features
+from tests import HAS_NUMPY
+
+pytestmark = pytest.mark.skipif(not HAS_NUMPY, reason="NumPy is required for training tests")
+
+
+def _write_log(file: Path) -> None:
+    fields = [
+        "schema_version",
+        "event_id",
+        "event_time",
+        "broker_time",
+        "local_time",
+        "action",
+        "ticket",
+        "magic",
+        "source",
+        "symbol",
+        "order_type",
+        "lots",
+        "price",
+        "sl",
+        "tp",
+        "profit",
+        "spread",
+        "comment",
+        "remaining_lots",
+        "slippage",
+        "volume",
+        "sl_hit_dist",
+        "tp_hit_dist",
+    ]
+    rows = [
+        [
+            "1",
+            "1",
+            "2024.01.01 00:00:00",
+            "",
+            "",
+            "OPEN",
+            "1",
+            "",
+            "",
+            "EURUSD",
+            "0",
+            "0.1",
+            "1.1000",
+            "1.0950",
+            "1.1100",
+            "0",
+            "2",
+            "",
+            "0.1",
+            "0.0001",
+            "100",
+            "0",
+            "0",
+        ],
+        [
+            "1",
+            "2",
+            "2024.01.01 01:00:00",
+            "",
+            "",
+            "OPEN",
+            "2",
+            "",
+            "",
+            "EURUSD",
+            "1",
+            "0.1",
+            "1.2000",
+            "1.1950",
+            "1.2100",
+            "0",
+            "3",
+            "",
+            "0.1",
+            "0.0002",
+            "200",
+            "0",
+            "0",
+        ],
+    ]
+    with open(file, "w", newline="") as f:
+        writer = csv.writer(f, delimiter=";")
+        writer.writerow(fields)
+        writer.writerows(rows)
+
+
+def test_graph_features(tmp_path: Path) -> None:
+    data_dir = tmp_path / "logs"
+    out_dir = tmp_path / "out"
+    data_dir.mkdir()
+
+    log_file = data_dir / "trades_corr.csv"
+    _write_log(log_file)
+
+    corr_map = {"EURUSD": ["USDCHF"]}
+    extra = {"USDCHF": [0.9, 0.8]}
+
+    df, _, _ = _load_logs(data_dir)
+    feat_dicts, *_ = _extract_features(
+        df.to_dict("records"),
+        corr_map=corr_map,
+        extra_price_series=extra,
+    )
+    feat_df = pd.DataFrame(feat_dicts)
+    feat_csv = tmp_path / "features.csv"
+    feat_df.to_csv(feat_csv, index=False)
+
+    graph_file = tmp_path / "graph.json"
+    build_graph(feat_csv, graph_file)
+
+    train(
+        data_dir,
+        out_dir,
+        corr_map=corr_map,
+        extra_price_series=extra,
+        symbol_graph=graph_file,
+    )
+
+    with open(out_dir / "model.json") as f:
+        model = json.load(f)
+    feats = model.get("feature_names", [])
+    assert "graph_degree" in feats
+    assert "graph_pagerank" in feats
+
+    generate(out_dir / "model.json", out_dir)
+    mq4_files = list(out_dir.glob("Generated_*.mq4"))
+    assert mq4_files, "EA file not generated"
+    text = mq4_files[0].read_text()
+    assert "GraphDegree()" in text
+    assert "GraphPagerank()" in text
+


### PR DESCRIPTION
## Summary
- aggregate corr_* feature history into a weighted symbol graph and compute degree/pagerank metrics
- merge precomputed graph metrics into training features and serialized model
- expose graph metrics in generated MQL4 code with helper functions
- add regression test for graph-derived features and EA generation

## Testing
- `python -m pytest tests/test_graph_features.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a26a2823c4832fb2f058f91edc165b