### PR TITLE
feat: add WAL persistence and metrics

### DIFF
--- a/scripts/flight_server.py
+++ b/scripts/flight_server.py
@@ -102,6 +102,14 @@ class FlightServer(flight.FlightServerBase):
             conn.executemany(self._sqlite_sql[path], [list(r.values()) for r in rows])
             conn.commit()
             logger.info("stored %d %s rows", batch.num_rows, path)
+            try:
+                if path == "trades":
+                    ack_id = batch.column("event_id")[0].as_py()
+                else:
+                    ack_id = batch.column("time")[0].as_py()
+                writer.write_metadata(pa.py_buffer(str(ack_id).encode()))
+            except Exception:
+                pass
 
     # ------------------------------------------------------------------
     def do_get(


### PR DESCRIPTION
## Summary
- mirror trade/metric queue items to WAL files and reload on startup
- flight server acks received IDs for WAL pruning
- export WAL size and retry counters via metrics collector

## Testing
- `python -m py_compile scripts/flight_server.py scripts/metrics_collector.py`
- `pytest` *(fails: missing dependencies)*


------
https://chatgpt.com/codex/tasks/task_e_68a26cb2ec50832f810d060ab021a6b3