### PR TITLE
Add unified WAL and ACK-aware flight server

### DIFF
--- a/scripts/flight_server.py
+++ b/scripts/flight_server.py
@@ -102,14 +102,11 @@ class FlightServer(flight.FlightServerBase):
             conn.executemany(self._sqlite_sql[path], [list(r.values()) for r in rows])
             conn.commit()
             logger.info("stored %d %s rows", batch.num_rows, path)
-            try:
-                if path == "trades":
-                    ack_id = batch.column("event_id")[0].as_py()
-                else:
-                    ack_id = batch.column("time")[0].as_py()
-                writer.write_metadata(pa.py_buffer(str(ack_id).encode()))
-            except Exception:
-                pass
+            if path == "trades":
+                ack_id = batch.column("event_id")[batch.num_rows - 1].as_py()
+            else:
+                ack_id = batch.column("time")[batch.num_rows - 1].as_py()
+            writer.write(pa.py_buffer(str(ack_id).encode()))
 
     # ------------------------------------------------------------------
     def do_get(


### PR DESCRIPTION
## Summary
- Persist queued trades and metrics to a unified WAL that reloads on startup and rewrites after each successful send
- Return record IDs from flight server batches so clients can acknowledge writes
- Surface WAL size and retry counts in periodic metrics

## Testing
- `pytest` *(fails: missing optional dependencies)*
- `pytest tests/test_flight_server.py`


------
https://chatgpt.com/codex/tasks/task_e_68a29a8bd0b0832f8d796b0fd04f167f