### PR TITLE
Enhance symbol graph utilities with embeddings and Parquet output

### DIFF
--- a/tests/test_graph_features.py
+++ b/tests/test_graph_features.py
@@ -123,6 +123,9 @@ def test_graph_features(tmp_path: Path) -> None:
 
     graph_file = tmp_path / "graph.json"
     build_graph(feat_csv, graph_file)
+    graph_parquet = tmp_path / "graph.parquet"
+    build_graph(feat_csv, graph_parquet)
+    assert graph_parquet.exists()
 
     train(
         data_dir,


### PR DESCRIPTION
## Summary
- extend `build_symbol_graph.py` with optional Node2Vec embeddings and ability to emit graph metrics to JSON or Parquet
- allow `train_target_clone.py` to consume precomputed graph embeddings and apply them as training features
- test that symbol graph can be written to Parquet and that generated EA exposes graph features

## Testing
- `pytest tests/test_graph_features.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a2a3c4a90c832f903b8629ccb87aa5