### PR TITLE
Add active learning labeling pipeline

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -63,7 +63,8 @@ Grafana dashboards can then be built on top of the Prometheus data. Import ``doc
 Strategies exported from this project can highlight trades where the model is
 unsure of the correct action. When the absolute difference between the model
 probability and the trade threshold is below ``UncertaintyMargin`` a snapshot of
-the current feature vector is written to ``uncertain_decisions.csv``.
+the current feature vector is written to ``uncertain_decisions.csv`` along with
+an empty ``label`` column ready for later annotation.
 
 These records can be labeled offline with::
 

--- a/experts/StrategyTemplate.mq4
+++ b/experts/StrategyTemplate.mq4
@@ -404,7 +404,8 @@ int OnInit()
    if(UncertainLogHandle != INVALID_HANDLE)
    {
       if(FileSize(UncertainLogHandle) == 0)
-         FileWrite(UncertainLogHandle, "event_id;timestamp;model_version;action;probability;threshold;sl_dist;tp_dist;model_idx;regime;features");
+         FileWrite(UncertainLogHandle,
+                   "event_id;timestamp;model_version;action;probability;threshold;sl_dist;tp_dist;model_idx;regime;features;label");
       FileSeek(UncertainLogHandle, 0, SEEK_END);
    }
    else
@@ -1114,7 +1115,7 @@ void LogDecision(double &feats[], double prob, string action, int modelIdx, int 
    {
       // capture feature snapshot for active learning
       FileWrite(UncertainLogHandle, NextDecisionId, TimeToString(now, TIME_DATE|TIME_SECONDS),
-                ModelVersion, action, prob, thr, sl_dist, tp_dist, modelIdx, regime, feat_vals);
+                ModelVersion, action, prob, thr, sl_dist, tp_dist, modelIdx, regime, feat_vals, "");
       FileFlush(UncertainLogHandle);
    }
    if(DecisionSocket != INVALID_HANDLE)

--- a/scripts/label_uncertain.py
+++ b/scripts/label_uncertain.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
 """Label uncertain model decisions.
 
-Reads ``uncertain_decisions.csv`` and writes ``uncertain_decisions_labeled.csv``
-with an additional ``label`` column. Labels may be provided interactively or
-set for all rows via ``--label`` to support simple heuristic labeling.
+Reads ``uncertain_decisions.csv`` produced by the Expert Advisor and writes a
+new ``uncertain_decisions_labeled.csv`` with the ``label`` column populated. The
+input file already contains an empty ``label`` field for each record; this tool
+fills it either interactively or via ``--label`` to support simple heuristic
+labeling.
 """
 from __future__ import annotations
 

--- a/scripts/train_target_clone.py
+++ b/scripts/train_target_clone.py
@@ -3716,8 +3716,16 @@ def main():
     p.add_argument('--moe', action='store_true', help='train mixture-of-experts model per symbol')
     p.add_argument('--federated-server', help='URL of federated averaging server')
     p.add_argument('--use-encoder', action='store_true', help='apply pretrained contrastive encoder')
-    p.add_argument('--uncertain-file', help='CSV with labeled uncertain decisions')
-    p.add_argument('--uncertain-weight', type=float, default=2.0, help='sample weight multiplier for labeled uncertainties')
+    p.add_argument(
+        '--uncertain-file',
+        help='CSV with labeled uncertain decisions to emphasize during training',
+    )
+    p.add_argument(
+        '--uncertain-weight',
+        type=float,
+        default=2.0,
+        help='sample weight multiplier for labeled uncertainties',
+    )
     p.add_argument(
         '--half-life-days',
         type=float,


### PR DESCRIPTION
## Summary
- Log uncertain decisions with a label placeholder for later annotation
- Document active-learning loop with `label_uncertain.py` and training integration
- Clarify training CLI for emphasizing labeled uncertain decisions

## Testing
- `python -m py_compile scripts/label_uncertain.py scripts/train_target_clone.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68a2a643c408832f918c2e069323b4c8