### PR TITLE
Integrate symbol graph features into model extraction

### DIFF
--- a/experts/StrategyTemplate.mq4
+++ b/experts/StrategyTemplate.mq4
@@ -93,6 +93,7 @@ double RiskParityWeights[] = {__RISK_PARITY_WEIGHTS__};
 datetime CalendarTimes[] = {__CALENDAR_TIMES__};
 double CalendarImpacts[] = {__CALENDAR_IMPACTS__};
 int EventWindowMinutes = __EVENT_WINDOW__;
+// Pre-computed graph metrics injected at build time
 string GraphSymbols[] = {__GRAPH_SYMBOLS__};
 double GraphDegreeVals[] = {__GRAPH_DEGREE__};
 double GraphPagerankVals[] = {__GRAPH_PAGERANK__};

--- a/scripts/generate_mql4_from_model.py
+++ b/scripts/generate_mql4_from_model.py
@@ -519,8 +519,10 @@ def generate(
                     expr = f'iClose(SymbolToTrade, 0, 0) / iClose("{parts[0]}", 0, 0)'
             elif name.startswith('corr_'):
                 parts = name[5:].split('_')
-                if len(parts) == 2:
-                    expr = f'PairCorrelation("{parts[0]}", "{parts[1]}")'
+                if len(parts) >= 2:
+                    sym1 = parts[0]
+                    sym2 = '_'.join(parts[1:])
+                    expr = f'PairCorrelation("{sym1}", "{sym2}")'
                 elif len(parts) == 1:
                     expr = f'PairCorrelation("{parts[0]}")'
             elif name == 'graph_degree':

--- a/tests/test_graph_features.py
+++ b/tests/test_graph_features.py
@@ -140,6 +140,7 @@ def test_graph_features(tmp_path: Path) -> None:
     feats = model.get("feature_names", [])
     assert "graph_degree" in feats
     assert "graph_pagerank" in feats
+    assert "corr_EURUSD_USDCHF" in feats
 
     generate(out_dir / "model.json", out_dir)
     mq4_files = list(out_dir.glob("Generated_*.mq4"))
@@ -147,4 +148,5 @@ def test_graph_features(tmp_path: Path) -> None:
     text = mq4_files[0].read_text()
     assert "GraphDegree()" in text
     assert "GraphPagerank()" in text
+    assert 'PairCorrelation("EURUSD", "USDCHF")' in text
 


### PR DESCRIPTION
## Summary
- support loading weighted symbol graphs in `_extract_features` and inject `corr_<SYM1>_<SYM2>` plus `graph_degree`/`graph_pagerank`
- export pairwise correlations in generated EAs and template
- cover graph feature extraction in regression tests

## Testing
- `pytest tests/test_graph_features.py::test_graph_features -q` *(fails: ModuleNotFoundError: No module named 'opentelemetry.exporter')*


------
https://chatgpt.com/codex/tasks/task_e_68a3c12eadd8832fafa8c4008c30723a