### PR TITLE
Capture exit reason and trade duration in logs and models

### DIFF
--- a/experts/Observer_TBot.mq4
+++ b/experts/Observer_TBot.mq4
@@ -1506,7 +1506,7 @@ void LogTrade(int event_id, string action, int ticket, int magic, string source,
       else if(sl!=0.0 && MathAbs(price - sl) <= pt*2)
          exit_reason = "SL";
       if(open_time>0)
-         duration_sec = (int)(TimeCurrent() - open_time);
+         duration_sec = (int)(time_event - open_time);
    }
    t.exit_reason = exit_reason;
    t.duration_sec = duration_sec;

--- a/experts/StrategyTemplate.mq4
+++ b/experts/StrategyTemplate.mq4
@@ -65,6 +65,7 @@ double EntryThreshold = __ENTRY_THRESHOLD__;
 double ExitCoefficients[] = {__EXIT_COEFFICIENTS__};
 double ExitIntercept = __EXIT_INTERCEPT__;
 double ExitThreshold = __EXIT_THRESHOLD__;
+string ExitReasonContext = "";
 int ModelHiddenSize = __NN_HIDDEN_SIZE__;
 double NNLayer1Weights[] = {__NN_L1_WEIGHTS__};
 double NNLayer1Bias[] = {__NN_L1_BIAS__};
@@ -498,6 +499,21 @@ double GetTPDistance()
             return(Ask - OrderTakeProfit());
       }
    return(0.0);
+}
+
+double TradeDuration()
+{
+   for(int i = OrdersTotal() - 1; i >= 0; i--)
+      if(OrderSelect(i, SELECT_BY_POS) &&
+         OrderMagicNumber() == MagicNumber &&
+         OrderSymbol() == SymbolToTrade)
+         return(TimeCurrent() - OrderOpenTime());
+   return(0.0);
+}
+
+double ExitReasonFlag(string reason)
+{
+   return(StringCompare(ExitReasonContext, reason) == 0 ? 1.0 : 0.0);
 }
 
 double GetCalendarFlag()

--- a/scripts/generate_mql4_from_model.py
+++ b/scripts/generate_mql4_from_model.py
@@ -480,6 +480,7 @@ def generate(
         'book_imbalance': 'BookImbalance()',
         'trend_estimate': 'TrendEstimate',
         'trend_variance': 'TrendVariance',
+        'duration_sec': 'TradeDuration()',
     }
 
     if lite_mode:
@@ -538,6 +539,9 @@ def generate(
                     expr = f'PairCorrelation("{sym1}", "{sym2}")'
                 elif len(parts) == 1:
                     expr = f'PairCorrelation("{parts[0]}")'
+            elif name.startswith('exit_reason='):
+                reason = name.split('=', 1)[1]
+                expr = f'ExitReasonFlag("{reason}")'
             elif name == 'graph_degree':
                 expr = 'GraphDegree()'
             elif name == 'graph_pagerank':

--- a/scripts/train_target_clone.py
+++ b/scripts/train_target_clone.py
@@ -1349,6 +1349,8 @@ def _extract_features(
         tp_dist = _safe_float(r.get("tp_dist", tp - price))
         sl_hit = _safe_float(r.get("sl_hit_dist", 0.0))
         tp_hit = _safe_float(r.get("tp_hit_dist", 0.0))
+        exit_reason = str(r.get("exit_reason", "") or "").upper()
+        duration_sec = int(float(r.get("duration_sec", 0) or 0))
 
         feat = {
             "symbol": symbol,
@@ -1370,6 +1372,8 @@ def _extract_features(
             "swap": swap,
             "trend_estimate": trend_est,
             "trend_variance": trend_var,
+            "exit_reason": exit_reason,
+            "duration_sec": duration_sec,
             "event_id": int(float(r.get("event_id", 0) or 0)),
         }
 

--- a/tests/test_train_target_clone_features.py
+++ b/tests/test_train_target_clone_features.py
@@ -41,6 +41,8 @@ def _write_sample_log(file: Path):
         "tp_hit_dist",
         "commission",
         "swap",
+        "exit_reason",
+        "duration_sec",
     ]
     rows = [
         [
@@ -72,6 +74,8 @@ def _write_sample_log(file: Path):
             "0",
             "0",
             "0",
+            "",
+            "0",
         ],
         [
             "2",
@@ -101,6 +105,8 @@ def _write_sample_log(file: Path):
             "0",
             "0",
             "0",
+            "0",
+            "",
             "0",
         ],
     ]


### PR DESCRIPTION
## Summary
- Derive exit reason (TP, SL, MANUAL) and time-in-trade for closes in `Observer_TBot` and export them in CSV and JSON
- Parse new `exit_reason` and `duration_sec` fields during feature extraction and expose them to models and generated EAs
- Map runtime accessors for these features and extend tests with updated log format

## Testing
- `pytest tests/test_train_target_clone_features.py tests/test_generate.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a3d8190010832fb605d14ec9b7ebf9