### PR TITLE
Add separate entry/exit/lot models with risk parity weights

### DIFF
--- a/experts/StrategyTemplate.mq4
+++ b/experts/StrategyTemplate.mq4
@@ -835,7 +835,7 @@ double ComputeEntryScore()
    return(1.0 / (1.0 + MathExp(-z)));
 }
 
-double ComputeExitScore(double sl_dist, double tp_dist, double profit)
+double ComputeExitTime(double sl_dist, double tp_dist, double profit)
 {
    double z = ExitIntercept;
    double feats[3];
@@ -845,7 +845,8 @@ double ComputeExitScore(double sl_dist, double tp_dist, double profit)
    int n = MathMin(3, ArraySize(ExitCoefficients));
    for(int i=0; i<n; i++)
       z += ExitCoefficients[i] * feats[i];
-   return(1.0 / (1.0 + MathExp(-z)));
+   if(z < 0) z = 0;
+   return(z);
 }
 
 double ComputeNNScore()
@@ -1434,8 +1435,9 @@ void ManageOpenOrders()
       if(OrderTakeProfit() > 0)
          tp_dist = isBuy ? (OrderTakeProfit() - price)/Point : (price - OrderTakeProfit())/Point;
       double cur_profit = OrderProfit() + OrderSwap() + OrderCommission();
-      double exit_prob = ComputeExitScore(sl_dist, tp_dist, cur_profit);
-      if(exit_prob < ExitThreshold)
+      double exit_time = ComputeExitTime(sl_dist, tp_dist, cur_profit);
+      double age = TimeCurrent() - OrderOpenTime();
+      if(exit_time <= 0 || age >= exit_time)
       {
          if(!OrderClose(OrderTicket(), OrderLots(), price, 3))
             Print("OrderClose error: ", GetLastError());

--- a/model.json
+++ b/model.json
@@ -27,7 +27,7 @@
   "entry_threshold": 0.5,
   "exit_coefficients": [0.0, 0.0, 0.0],
   "exit_intercept": 0.0,
-  "exit_threshold": 0.5,
+  "exit_threshold": 0.0,
   "hourly_thresholds": [
     0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
     0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0
@@ -41,8 +41,8 @@
     "embedding_dim": 0
   },
   "symbol_embeddings": {},
-  "risk_parity_symbols": [],
-  "risk_parity_weights": [],
-  "risk_covariance_symbols": [],
-  "risk_covariance_matrix": []
+  "risk_parity_symbols": ["EURUSD", "USDJPY"],
+  "risk_parity_weights": [0.6, 0.4],
+  "risk_covariance_symbols": ["EURUSD", "USDJPY"],
+  "risk_covariance_matrix": [[1.0, 0.2], [0.2, 1.0]]
 }

--- a/scripts/generate_mql4_from_model.py
+++ b/scripts/generate_mql4_from_model.py
@@ -269,6 +269,12 @@ def generate(
     output = output.replace('__EXIT_INTERCEPT__', _fmt(base.get('exit_intercept', 0.0)))
     output = output.replace('__EXIT_THRESHOLD__', _fmt(base.get('exit_threshold', 0.5)))
 
+    # Lot size model
+    lot_coeff = base.get('lot_coefficients', [])
+    lot_str = ', '.join(_fmt(c) for c in lot_coeff)
+    output = output.replace('__LOT_COEFFICIENTS__', lot_str)
+    output = output.replace('__LOT_INTERCEPT__', _fmt(base.get('lot_intercept', 0.0)))
+
     nn_weights = base.get('nn_weights', [])
     if nn_weights:
         l1_w = ', '.join(_fmt(v) for row in nn_weights[0] for v in row)


### PR DESCRIPTION
## Summary
- Train_target_clone now splits logs into entry/exit sets, fits direction, exit timing and lot size models, and computes per-symbol risk parity weights
- Generate_mql4_from_model emits Entry*, Exit*, Lot* arrays and risk parity data
- StrategyTemplate uses entry model for new trades, exit timing model to close orders, and scales lots by risk parity weight

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_68a5181f7f68832f91753aa868ae8566