### PR TITLE
Ensure slippage feature is generated and mapped

### DIFF
--- a/experts/StrategyTemplate.mq4
+++ b/experts/StrategyTemplate.mq4
@@ -121,6 +121,7 @@ double CachedNewsSentiment = 0.0;
 datetime CachedNewsTime = 0;
 double TrendEstimate = 0.0;
 double TrendVariance = 1.0;
+double LastSlippage = 0.0;
 int EncoderWindow = __ENCODER_WINDOW__;
 int EncoderDim = __ENCODER_DIM__;
 double EncoderWeights[] = {__ENCODER_WEIGHTS__};
@@ -499,6 +500,11 @@ double GetTPDistance()
             return(Ask - OrderTakeProfit());
       }
    return(0.0);
+}
+
+double GetSlippage()
+{
+   return(LastSlippage);
 }
 
 double TradeDuration()
@@ -1484,6 +1490,7 @@ void OnTradeTransaction(const MqlTradeTransaction &trans,
       return;
    if(!HistoryDealSelect(trans.deal))
       return;
+   LastSlippage = trans.price - req.price;
    string comment = HistoryDealGetString(trans.deal, DEAL_COMMENT);
    int idx = ExtractModelIndex(comment);
    if(idx < 0) return;

--- a/scripts/generate_mql4_from_model.py
+++ b/scripts/generate_mql4_from_model.py
@@ -468,6 +468,7 @@ def generate(
         'dow_sin': 'DowSin()',
         'dow_cos': 'DowCos()',
         'spread': 'MarketInfo(SymbolToTrade, MODE_SPREAD)',
+        'slippage': 'GetSlippage()',
         'lots': 'Lots',
         'sl_dist': 'GetSLDistance()',
         'tp_dist': 'GetTPDistance()',
@@ -566,7 +567,9 @@ def generate(
                 expr = 'GetNewsSentiment()'
         if expr is None:
             expr = '0.0'
-        cases.append(f"      case {idx}:\n         val = ({expr});\n         break;")
+        cases.append(
+            f"      case {idx}: // {name}\n         raw = ({expr});\n         break;"
+        )
     case_block = "\n".join(cases)
     if case_block:
         case_block += "\n"

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -483,6 +483,32 @@ def test_generate_account_features(tmp_path: Path):
     assert "AccountMarginLevel()" in content
 
 
+def test_slippage_equity_features(tmp_path: Path):
+    model = {
+        "model_id": "se",
+        "magic": 303,
+        "coefficients": [0.1, -0.2, 0.3],
+        "intercept": 0.0,
+        "threshold": 0.5,
+        "feature_names": ["spread", "slippage", "equity"],
+    }
+    model_file = tmp_path / "model.json"
+    with open(model_file, "w") as f:
+        json.dump(model, f)
+
+    out_dir = tmp_path / "out"
+    generate(model_file, out_dir)
+
+    generated = list(out_dir.glob("Generated_se_*.mq4"))
+    assert len(generated) == 1
+    content = generated[0].read_text()
+    for i, name in enumerate(model["feature_names"]):
+        assert f"case {i}:" in content
+    assert "MarketInfo(SymbolToTrade, MODE_SPREAD)" in content
+    assert "GetSlippage()" in content
+    assert "AccountEquity()" in content
+
+
 def test_generate_lite_mode(tmp_path: Path):
     model = {
         "model_id": "lite",


### PR DESCRIPTION
## Summary
- Map slippage feature in MQL4 generator and emit per-feature switch cases
- Track last trade slippage in StrategyTemplate and expose via `GetSlippage`
- Add regression test checking spread, slippage, and equity feature cases

## Testing
- `pytest tests/test_generate.py::test_slippage_equity_features -q`
- `pytest tests/test_generate.py::test_generate tests/test_generate.py::test_generate_account_features -q`

------
https://chatgpt.com/codex/tasks/task_e_68a53de75678832f9b80d7f4d68a94e1