### PR TITLE
Tag trades with decision IDs and enable decision replay

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -99,10 +99,15 @@ previously hesitated.
 ## Decision Replay
 
 When migrating to a more capable VM or heavier model it can be helpful to
-re‑evaluate historical trades.  Use ``scripts/replay_decisions.py`` to recompute
-probabilities from an archived ``decisions.csv`` against a new ``model.json``.
-The script writes ``divergences.csv`` by default and can tag each mismatch with
-an explicit sample weight::
+re‑evaluate historical trades. Each order comment contains the original
+``decision_id`` so that :mod:`experts.Observer_TBot` can associate fills with
+their source decisions and record the identifier in ``trades_raw.csv`` and the
+Arrow/JSON export.
+
+Use ``scripts/replay_decisions.py`` to recompute probabilities from an archived
+``decisions.csv`` against a new ``model.json``. The script writes
+``divergences.csv`` by default and can tag each mismatch with an explicit sample
+weight::
 
     python scripts/replay_decisions.py decisions.csv model.json --weight 2
 

--- a/experts/Observer_TBot.mq4
+++ b/experts/Observer_TBot.mq4
@@ -1505,6 +1505,7 @@ void LogTrade(int event_id, string action, int ticket, int magic, string source,
    }
    else
       t.comment_with_span = comment;
+   // Extract decision id if present in the order comment
    int decision_id = 0;
    int pos = StringFind(comment, "decision_id=");
    if(pos >= 0)
@@ -1514,7 +1515,7 @@ void LogTrade(int event_id, string action, int ticket, int magic, string source,
       while(end < StringLen(comment))
       {
          string ch = StringMid(comment, end, 1);
-         if(ch < "0" || ch > "9")
+         if(ch==";" || ch=="|")
             break;
          end++;
       }

--- a/experts/StrategyTemplate.mq4
+++ b/experts/StrategyTemplate.mq4
@@ -1409,7 +1409,7 @@ void OnTick()
    string action = (prob > thr) ? "buy" : "sell";
    int decision_id = NextDecisionId;
    LogDecision(feats, prob, action, modelIdx, reg, risk_weight, pv);
-   string order_comment = StringFormat("trace_id=%s;span_id=%s;model=%d|decision_id=%d", LastTraceId, LastSpanId, modelIdx, decision_id);
+   string order_comment = StringFormat("decision_id=%d;trace_id=%s;span_id=%s;model=%d", decision_id, LastTraceId, LastSpanId, modelIdx);
    if(prob > thr)
    {
       ticket = OrderSend(SymbolToTrade, OP_BUY, tradeLots, Ask, 3,

--- a/scripts/replay_decisions.py
+++ b/scripts/replay_decisions.py
@@ -5,9 +5,12 @@ The script loads a decision log produced by the trading bot along with a
 new ``model.json`` file. It re-computes probabilities for each decision
 using the new model and reports any divergences between the original and
 replayed outcomes. Summary statistics such as accuracy and the change in
-profit are printed at the end. Any mismatched decisions are written to
-``divergences.csv`` and can optionally be tagged with a sample ``weight``
-for downstream training.
+profit are printed at the end.
+
+Any mismatched decisions are written to ``divergences.csv`` and can
+optionally be tagged with a sample ``weight``. This file can then be fed
+back into :mod:`scripts.train_target_clone` via ``--replay-file`` to
+emphasise corrections during the next round of training.
 
 When sufficient hardware resources are available, ``detect_resources`` is
 used to determine whether a more complex neural network representation


### PR DESCRIPTION
## Summary
- include decision_id in strategy order comments for later tracking
- parse decision_id in Observer_TBot and persist it to trade logs
- document decision replay workflow and update replay_decisions script docstring

## Testing
- `pytest tests/test_replay_decisions.py`

------
https://chatgpt.com/codex/tasks/task_e_68a54eaedb04832f8d3f86b325c64961