### PR TITLE
Handle anomaly requests asynchronously and expose backlog metric

### DIFF
--- a/experts/Observer_TBot.mq4
+++ b/experts/Observer_TBot.mq4
@@ -4,7 +4,7 @@
 
 #import "observer_capnp.dll"
 int SerializeTradeEvent(int schema_version, int event_id, string trace_id, string event_time, string broker_time, string local_time, string action, int ticket, int magic, string source, string symbol, int order_type, double lots, double price, double sl, double tp, double profit, double profit_after_trade, double spread, string comment, double remaining_lots, double slippage, int volume, string open_time, double book_bid_vol, double book_ask_vol, double book_imbalance, double sl_hit_dist, double tp_hit_dist, double equity, double margin_level, double commission, double swap, int decision_id, string exit_reason, int duration_sec, uchar &out[]);
-int SerializeMetrics(int schema_version, string time, int magic, double win_rate, double avg_profit, int trade_count, double drawdown, double sharpe, int file_write_errors, int socket_errors, double cpu_load, int book_refresh_seconds, int var_breach_count, int trade_queue_depth, int metric_queue_depth, int fallback_events, int fallback_logging, int wal_size, int trade_retry_count, int metric_retry_count, uchar &out[]);
+int SerializeMetrics(int schema_version, string time, int magic, double win_rate, double avg_profit, int trade_count, double drawdown, double sharpe, int file_write_errors, int socket_errors, double cpu_load, int book_refresh_seconds, int var_breach_count, int trade_queue_depth, int metric_queue_depth, int fallback_events, int fallback_logging, int wal_size, int trade_retry_count, int metric_retry_count, int anomaly_pending, uchar &out[]);
 #import
 #import "flight_client.dll"
 bool FlightClientInit(string host, int port);
@@ -136,9 +136,12 @@ public:
    string   comment_with_span;
    string   open_time_str;
    datetime start_time;
+   bool     anomaly_sent;
+   string   anomaly_status;
 };
 
 PendingTrade AnomalyQueue[];
+int AnomalyQueueDepth = 0;
 
 uchar   pending_trades[][1];
 string  pending_trade_lines[];
@@ -157,9 +160,12 @@ int     metric_retry_count = 0;
 
 void EnqueueAnomaly(PendingTrade &t)
 {
+   t.anomaly_sent = false;
+   t.anomaly_status = "";
    int n = ArraySize(AnomalyQueue);
    ArrayResize(AnomalyQueue, n+1);
    AnomalyQueue[n] = t;
+    AnomalyQueueDepth = n+1;
 }
 
 void RemoveAnomaly(int index)
@@ -168,6 +174,7 @@ void RemoveAnomaly(int index)
    for(int i=index; i<n-1; i++)
       AnomalyQueue[i] = AnomalyQueue[i+1];
    ArrayResize(AnomalyQueue, n-1);
+   AnomalyQueueDepth = n-1;
 }
 
 
@@ -664,7 +671,7 @@ int CheckAnomaly(double price, double sl, double tp, double lots, double spread,
    uchar result[];
    string headers = "Content-Type: application/json";
    string rheaders = "";
-   int res = WebRequest("POST", AnomalyServiceUrl, headers, 5000, data, ArraySize(data)-1, result, rheaders);
+   int res = WebRequest("POST", AnomalyServiceUrl, headers, AnomalyTimeoutSeconds*1000, data, ArraySize(data)-1, result, rheaders);
    if(res==200)
    {
       string txt = CharArrayToString(result);
@@ -1354,27 +1361,27 @@ void FinalizeTradeEntry(PendingTrade &t, bool is_anom)
 
 void ProcessAnomalyQueue()
 {
-   datetime now = UseBrokerTime ? TimeCurrent() : TimeLocal();
-   int i = 0;
-   while(i < ArraySize(AnomalyQueue))
+   if(ArraySize(AnomalyQueue)==0)
+      return;
+   PendingTrade t = AnomalyQueue[0];
+   if(!t.anomaly_sent)
    {
-      PendingTrade t = AnomalyQueue[i];
       int res = CheckAnomaly(t.price, t.sl, t.tp, t.lots, t.spread, t.slippage);
+      t.anomaly_sent = true;
       if(res >= 0)
       {
          bool is_anom = (res == 1);
          FinalizeTradeEntry(t, is_anom);
-         RemoveAnomaly(i);
-         continue;
+         RemoveAnomaly(0);
+         return;
       }
-      if(now - t.start_time > AnomalyTimeoutSeconds)
-      {
-         FinalizeTradeEntry(t, false);
-         RemoveAnomaly(i);
-         continue;
-      }
-      i++;
+      t.anomaly_status = "timeout";
+      AnomalyQueue[0] = t;
+      return;
    }
+   t.comment_with_span = t.comment_with_span + ";anom_" + t.anomaly_status;
+   FinalizeTradeEntry(t, false);
+   RemoveAnomaly(0);
 }
 
 string FileNameFromPath(string path)
@@ -1751,14 +1758,15 @@ void WriteMetrics(datetime ts)
 
       string span_id = GenId(8);
       int fallback_flag = (trade_retry_count >= FallbackRetryThreshold || metric_retry_count >= FallbackRetryThreshold) ? 1 : 0;
+      int anomaly_pending = AnomalyQueueDepth;
       // emit file/socket errors and retry counts for monitoring
-      string line = StringFormat("%s;%d;%.3f;%.2f;%d;%.2f;%.3f;%.3f;%.2f;%d;%d;%.2f;%d;%d;%d;%d;%d;%d;%d;%d;%s;%s", TimeToString(ts, TIME_DATE|TIME_MINUTES), magic, win_rate, avg_profit, trades, max_dd, sharpe, sortino, expectancy, FileWriteErrors, SocketErrors, CpuLoad, CachedBookRefreshSeconds, var_breach_count, trade_q_depth, metric_q_depth, FallbackEvents, fallback_flag, wal_size, trade_retry_count, metric_retry_count, TraceId, span_id);
+      string line = StringFormat("%s;%d;%.3f;%.2f;%d;%.2f;%.3f;%.3f;%.2f;%d;%d;%.2f;%d;%d;%d;%d;%d;%d;%d;%d;%d;%s;%s", TimeToString(ts, TIME_DATE|TIME_MINUTES), magic, win_rate, avg_profit, trades, max_dd, sharpe, sortino, expectancy, FileWriteErrors, SocketErrors, CpuLoad, CachedBookRefreshSeconds, var_breach_count, trade_q_depth, metric_q_depth, FallbackEvents, fallback_flag, wal_size, trade_retry_count, metric_retry_count, anomaly_pending, TraceId, span_id);
 
       uchar payload[];
       int len = SerializeMetrics(
          SCHEMA_VERSION,
          TimeToString(ts, TIME_DATE|TIME_MINUTES), magic, win_rate, avg_profit,
-         trades, max_dd, sharpe, FileWriteErrors, SocketErrors, CpuLoad, CachedBookRefreshSeconds, var_breach_count, trade_q_depth, metric_q_depth, FallbackEvents, fallback_flag, wal_size, trade_retry_count, metric_retry_count, payload);
+         trades, max_dd, sharpe, FileWriteErrors, SocketErrors, CpuLoad, CachedBookRefreshSeconds, var_breach_count, trade_q_depth, metric_q_depth, FallbackEvents, fallback_flag, wal_size, trade_retry_count, metric_retry_count, anomaly_pending, payload);
       bool sent = false;
       if(len>0)
          sent = SendMetrics(payload, line);
@@ -1773,7 +1781,7 @@ void WriteMetrics(datetime ts)
                h = FileOpen(fname, FILE_CSV|FILE_WRITE|FILE_TXT|FILE_SHARE_WRITE, ';');
                if(h!=INVALID_HANDLE)
                {
-                  int _wr = FileWrite(h, "time;magic;win_rate;avg_profit;trade_count;drawdown;sharpe;sortino;expectancy;file_write_errors;socket_errors;cpu_load;book_refresh_seconds;var_breach_count;trade_queue_depth;metric_queue_depth;fallback_events;fallback_logging;wal_size;trade_retry_count;metric_retry_count;trace_id;span_id");
+                  int _wr = FileWrite(h, "time;magic;win_rate;avg_profit;trade_count;drawdown;sharpe;sortino;expectancy;file_write_errors;socket_errors;cpu_load;book_refresh_seconds;var_breach_count;trade_queue_depth;metric_queue_depth;fallback_events;fallback_logging;wal_size;trade_retry_count;metric_retry_count;anomaly_pending;trace_id;span_id");
                   if(_wr <= 0)
                      FileWriteErrors++;
                }


### PR DESCRIPTION
## Summary
- Track pending anomaly checks and process one per timer tick
- Mark trades with `anom_timeout` on network failure
- Report `anomaly_pending` count in metrics for backlog insight

## Testing
- `pytest tests/test_logging_basic.py -q` *(fails: ModuleNotFoundError: No module named 'scripts.socket_log_service')*
- `pip install -r requirements.txt` *(fails: ImportError: cannot import name 'build_py_2to3')*

------
https://chatgpt.com/codex/tasks/task_e_68a659456690832fbcf3803893ec6515