### PR TITLE
Handle calendar impacts and event IDs

### DIFF
--- a/scripts/generate_mql4_from_model.py
+++ b/scripts/generate_mql4_from_model.py
@@ -451,15 +451,18 @@ def generate(
     if cal_events:
         time_vals = ', '.join(
             datetime.fromisoformat(t).strftime("D'%Y.%m.%d %H:%M'")
-            for t, _ in cal_events
+            for t, _, _ in cal_events
         )
-        impact_vals = ', '.join(_fmt(float(imp)) for _, imp in cal_events)
+        impact_vals = ', '.join(_fmt(float(imp)) for _, imp, _ in cal_events)
+        id_vals = ', '.join(str(int(eid)) for _, _, eid in cal_events)
     else:
         time_vals = ''
         impact_vals = ''
+        id_vals = ''
     event_window = _fmt(base.get('event_window', 60.0))
     output = output.replace('__CALENDAR_TIMES__', time_vals)
     output = output.replace('__CALENDAR_IMPACTS__', impact_vals)
+    output = output.replace('__CALENDAR_IDS__', id_vals)
     output = output.replace('__EVENT_WINDOW__', event_window)
 
     feature_map = {
@@ -487,8 +490,9 @@ def generate(
         'stochastic_d': 'iStochastic(SymbolToTrade, 0, 14, 3, 3, MODE_SMA, 0, MODE_SIGNAL, 0)',
         'adx': 'iADX(SymbolToTrade, 0, 14, PRICE_CLOSE, MODE_MAIN, 0)',
         'volume': 'iVolume(SymbolToTrade, 0, 0)',
-        'event_flag': 'GetCalendarFlag()',
-        'event_impact': 'GetCalendarImpact()',
+        'event_flag': 'CalendarFlag()',
+        'event_impact': 'CalendarImpact()',
+        'calendar_event_id': 'CalendarEventId()',
         'book_bid_vol': 'BookBidVol()',
         'book_ask_vol': 'BookAskVol()',
         'book_imbalance': 'BookImbalance()',

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -613,7 +613,7 @@ def test_calendar_features(tmp_path: Path):
         "intercept": 0.0,
         "threshold": 0.5,
         "feature_names": ["event_flag", "event_impact"],
-        "calendar_events": [["2024-01-01T00:30:00", 1.0]],
+        "calendar_events": [["2024-01-01T00:30:00", 1.0, 1]],
         "event_window": 60.0,
     }
     model_file = tmp_path / "model.json"
@@ -627,8 +627,8 @@ def test_calendar_features(tmp_path: Path):
     assert len(generated) == 1
     with open(generated[0]) as f:
         content = f.read()
-    assert "GetCalendarFlag()" in content
-    assert "GetCalendarImpact()" in content
+    assert "CalendarFlag()" in content
+    assert "CalendarImpact()" in content
 
 
 def test_on_tick_logistic_inference(tmp_path: Path):


### PR DESCRIPTION
## Summary
- support event IDs in calendar CSV and add calendar impact features in training
- generate MQL4 EAs with calendar arrays and CalendarImpact/CalendarFlag helpers
- log nearby calendar event IDs in Observer_TBot

## Testing
- `pytest tests/test_generate.py::test_calendar_features -q`
- `pip install pandas numpy requests psutil pyarrow grpcio opentelemetry-api opentelemetry-sdk -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas', ...)*

------
https://chatgpt.com/codex/tasks/task_e_68a65ef31480832f8c2ed1560b90ac34