### PR TITLE
Raise on unknown features in MQL4 generator

### DIFF
--- a/scripts/generate_mql4_from_model.py
+++ b/scripts/generate_mql4_from_model.py
@@ -14,6 +14,7 @@ behaviour of :mod:`scripts.replay_decisions` directly inside MetaTrader.
 import argparse
 import json
 import gzip
+import logging
 from pathlib import Path
 from datetime import datetime
 from typing import Iterable, List, Union, Optional
@@ -466,6 +467,7 @@ def generate(
     output = output.replace('__EVENT_WINDOW__', event_window)
 
     feature_map = {
+        'hour': 'TimeHour(TimeCurrent())',
         'hour_sin': 'HourSin()',
         'hour_cos': 'HourCos()',
         'dow_sin': 'DowSin()',
@@ -570,7 +572,13 @@ def generate(
             elif name == 'news_sentiment':
                 expr = 'GetNewsSentiment()'
         if expr is None:
-            expr = '0.0'
+            logging.error(
+                "Unknown feature '%s'. Please add a matching GetFeature() case to StrategyTemplate.mq4.",
+                name,
+            )
+            raise ValueError(
+                f"Unknown feature '{name}'. Update StrategyTemplate.mq4 with a matching GetFeature() case."
+            )
         cases.append(
             f"      case {idx}: // {name}\n         raw = ({expr});\n         break;"
         )

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -1,6 +1,7 @@
 import json
 from pathlib import Path
 import sys
+import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from scripts.generate_mql4_from_model import generate
@@ -197,6 +198,24 @@ def test_atr_bollinger_features(tmp_path: Path):
         content = f.read()
     assert "iATR(SymbolToTrade" in content
     assert "iBands(SymbolToTrade" in content
+
+
+def test_unknown_feature_raises(tmp_path: Path):
+    model = {
+        "model_id": "unknown",
+        "magic": 111,
+        "coefficients": [0.1],
+        "intercept": 0.0,
+        "threshold": 0.5,
+        "feature_names": ["mystery_feature"],
+    }
+    model_file = tmp_path / "model.json"
+    with open(model_file, "w") as f:
+        json.dump(model, f)
+
+    out_dir = tmp_path / "out"
+    with pytest.raises(ValueError, match="mystery_feature"):
+        generate(model_file, out_dir)
 
 
 def test_news_sentiment_feature(tmp_path: Path):

--- a/tests/test_meta_strategy.py
+++ b/tests/test_meta_strategy.py
@@ -11,15 +11,15 @@ def test_regime_switch_triggers_model_change():
     df = pd.DataFrame(
         {
             "volatility": [-1.0, -0.8, -0.6, 0.6, 0.8, 1.2],
-            "time": [0, 1, 2, 10, 11, 12],
-            "liquidity": [0.9, 0.85, 0.8, 0.2, 0.15, 0.1],
+            "hour": [0, 1, 2, 10, 11, 12],
+            "spread": [0.9, 0.85, 0.8, 0.2, 0.15, 0.1],
             "best_model": [0, 0, 0, 1, 1, 1],
         }
     )
-    params = train_meta_model(df, ["volatility", "time", "liquidity"], label_col="best_model")
+    params = train_meta_model(df, ["volatility", "hour", "spread"], label_col="best_model")
 
-    low_regime = {"volatility": -1.0, "time": 0, "liquidity": 0.9}
-    high_regime = {"volatility": 1.0, "time": 12, "liquidity": 0.1}
+    low_regime = {"volatility": -1.0, "hour": 0, "spread": 0.9}
+    high_regime = {"volatility": 1.0, "hour": 12, "spread": 0.1}
 
     assert select_model(params, low_regime) != select_model(params, high_regime)
 
@@ -28,12 +28,12 @@ def test_generate_with_gating(tmp_path: Path):
     df = pd.DataFrame(
         {
             "volatility": [-1.0, -0.5, 0.6, 1.2],
-            "time": [0, 1, 10, 11],
-            "liquidity": [0.9, 0.85, 0.2, 0.1],
+            "hour": [0, 1, 10, 11],
+            "spread": [0.9, 0.85, 0.2, 0.1],
             "best_model": [0, 0, 1, 1],
         }
     )
-    gating = train_meta_model(df, ["volatility", "time", "liquidity"], label_col="best_model")
+    gating = train_meta_model(df, ["volatility", "hour", "spread"], label_col="best_model")
     gating_file = tmp_path / "gating.json"
     gating_file.write_text(json.dumps(gating))
 
@@ -42,14 +42,14 @@ def test_generate_with_gating(tmp_path: Path):
         "coefficients": [0.1, 0.0, 0.0],
         "intercept": 0.0,
         "threshold": 0.5,
-        "feature_names": ["volatility", "time", "liquidity"],
+        "feature_names": ["volatility", "hour", "spread"],
     }
     m2 = {
         "model_id": "m2",
         "coefficients": [-0.1, 0.0, 0.0],
         "intercept": 0.0,
         "threshold": 0.5,
-        "feature_names": ["volatility", "time", "liquidity"],
+        "feature_names": ["volatility", "hour", "spread"],
     }
     f1 = tmp_path / "m1.json"
     f2 = tmp_path / "m2.json"

--- a/tests/test_regime_gating.py
+++ b/tests/test_regime_gating.py
@@ -22,15 +22,15 @@ def _select(gating, x):
 def test_regime_gating_selects_models(tmp_path: Path):
     model = {
         "model_id": "regime",
-        "feature_names": ["x"],
+        "feature_names": ["hour"],
         "meta_model": {
-            "feature_names": ["x"],
+            "feature_names": ["hour"],
             "coefficients": [[1.0], [-1.0]],
             "intercepts": [0.0, 0.0],
         },
         "regime_models": [
-            {"regime": 0, "coefficients": [1.0], "intercept": 0.0, "feature_names": ["x"]},
-            {"regime": 1, "coefficients": [-1.0], "intercept": 0.0, "feature_names": ["x"]},
+            {"regime": 0, "coefficients": [1.0], "intercept": 0.0, "feature_names": ["hour"]},
+            {"regime": 1, "coefficients": [-1.0], "intercept": 0.0, "feature_names": ["hour"]},
         ],
         "threshold": 0.5,
     }


### PR DESCRIPTION
## Summary
- prevent silent zeroing of unknown features by raising ValueError with guidance
- add regression test verifying unknown features trigger failure
- update gating tests to use supported feature names

## Testing
- `pytest tests/test_generate.py`
- `pytest tests/test_regime_gating.py tests/test_meta_strategy.py`
- `pytest tests/test_graph_features.py tests/test_regime_gating.py tests/test_meta_strategy.py` *(fails: ModuleNotFoundError: No module named 'opentelemetry.exporter')*

------
https://chatgpt.com/codex/tasks/task_e_68a7e07bc1a0832f93b15a9126aeb574