### PR TITLE
Validate schema versions in stream listener

### DIFF
--- a/README.md
+++ b/README.md
@@ -579,6 +579,9 @@ repository and the original files are removed locally. The script uses the
   During initialisation the observer EA writes a small JSON ``hello`` packet
   containing this version to the shared memory ring. ``stream_listener.py``
   verifies the packet before processing events and exits on mismatch.
+  Third-party producers should perform the same handshake and include their
+  ``schema_version`` before streaming events; messages with mismatched versions
+  are logged and ignored.
 * ``GITHUB_TOKEN`` – personal access token with ``repo`` scope used by
   ``upload_logs.py`` to push commits.
 * ``OTEL_EXPORTER_OTLP_ENDPOINT`` – URL of the OTLP collector (Jaeger or Zipkin).

--- a/scripts/stream_listener.py
+++ b/scripts/stream_listener.py
@@ -472,6 +472,19 @@ def process_trade(msg) -> None:
     global current_trace_id, current_span_id
     trace_id = _get(msg, "traceId", "trace_id") or ""
     span_id = ""
+    version = _get(msg, "schemaVersion", "schema_version")
+    if version is not None:
+        try:
+            ver_int = int(version)
+        except (TypeError, ValueError):
+            ver_int = version
+        if ver_int != SCHEMA_VERSION:
+            logger.warning({
+                "error": "schema version mismatch",
+                "expected": SCHEMA_VERSION,
+                "got": version,
+            })
+            return
     try:
         comment = _get(msg, "comment") or ""
         if isinstance(comment, str) and comment.startswith("span="):
@@ -529,6 +542,19 @@ def process_metric(msg) -> None:
     global current_trace_id, current_span_id
     trace_id = _get(msg, "traceId", "trace_id") or ""
     span_id = _get(msg, "spanId", "span_id") or ""
+    version = _get(msg, "schemaVersion", "schema_version")
+    if version is not None:
+        try:
+            ver_int = int(version)
+        except (TypeError, ValueError):
+            ver_int = version
+        if ver_int != SCHEMA_VERSION:
+            logger.warning({
+                "error": "schema version mismatch",
+                "expected": SCHEMA_VERSION,
+                "got": version,
+            })
+            return
     try:
         record = {
             "schema_version": SCHEMA_VERSION,

--- a/tests/test_stream_listener_validation.py
+++ b/tests/test_stream_listener_validation.py
@@ -107,3 +107,65 @@ def test_trade_validation_missing_field(monkeypatch, caplog):
         sl.process_trade(msg)
     assert not records
     assert "invalid trade event" in caplog.text
+
+
+def test_trade_schema_version_mismatch(monkeypatch, caplog):
+    records = []
+
+    def fake_append(path, record):
+        records.append(record)
+
+    monkeypatch.setattr(sl, "append_csv", fake_append)
+
+    msg = SimpleNamespace(
+        schemaVersion=sl.SCHEMA_VERSION + 1,
+        eventId=1,
+        eventTime="t",
+        brokerTime="b",
+        localTime="l",
+        action="OPEN",
+        ticket=1,
+        magic=0,
+        source="src",
+        symbol="X",
+        orderType=0,
+        lots=0.1,
+        price=1.0,
+        sl=0.0,
+        tp=0.0,
+        profit=0.0,
+        comment="",
+        remainingLots=0.0,
+        decisionId=0,
+    )
+    with caplog.at_level(logging.WARNING):
+        sl.process_trade(msg)
+    assert not records
+    assert "schema version mismatch" in caplog.text
+
+
+def test_metric_schema_version_mismatch(monkeypatch, caplog):
+    records = []
+
+    def fake_append(path, record):
+        records.append(record)
+
+    monkeypatch.setattr(sl, "append_csv", fake_append)
+
+    msg = SimpleNamespace(
+        schemaVersion=sl.SCHEMA_VERSION + 1,
+        time="t",
+        magic=0,
+        winRate=0.1,
+        avgProfit=0.2,
+        tradeCount=1,
+        drawdown=0.0,
+        sharpe=0.0,
+        fileWriteErrors=0,
+        socketErrors=0,
+        bookRefreshSeconds=0,
+    )
+    with caplog.at_level(logging.WARNING):
+        sl.process_metric(msg)
+    assert not records
+    assert "schema version mismatch" in caplog.text


### PR DESCRIPTION
## Summary
- reject trade or metric events with mismatched `schema_version`
- test stream listener for schema-version incompatibility
- document handshake requirement for third-party producers

## Testing
- `pytest tests/test_stream_listener_validation.py`


------
https://chatgpt.com/codex/tasks/task_e_68a7e3d2861c832f83f1a7987ec91f08