### PR TITLE
feat: weight training by net profit

### DIFF
--- a/model.json
+++ b/model.json
@@ -44,5 +44,6 @@
   "risk_parity_symbols": ["EURUSD", "USDJPY"],
   "risk_parity_weights": [0.6, 0.4],
   "risk_covariance_symbols": ["EURUSD", "USDJPY"],
-  "risk_covariance_matrix": [[1.0, 0.2], [0.2, 1.0]]
+  "risk_covariance_matrix": [[1.0, 0.2], [0.2, 1.0]],
+  "weighted_by_net_profit": false
 }

--- a/tests/test_graph_features.py
+++ b/tests/test_graph_features.py
@@ -59,7 +59,7 @@ def _write_log(file: Path) -> None:
             "1.1000",
             "1.0950",
             "1.1100",
-            "0",
+            "1",
             "2",
             "",
             "0.1",
@@ -84,7 +84,7 @@ def _write_log(file: Path) -> None:
             "1.2000",
             "1.1950",
             "1.2100",
-            "0",
+            "2",
             "3",
             "",
             "0.1",
@@ -141,6 +141,7 @@ def test_graph_features(tmp_path: Path) -> None:
     assert "graph_degree" in feats
     assert "graph_pagerank" in feats
     assert "corr_EURUSD_USDCHF" in feats
+    assert model.get("weighted_by_net_profit") is True
     graph = model.get("graph") or json.load(open(graph_file))
     assert graph.get("symbols") == ["EURUSD", "USDCHF"]
     metrics = graph.get("metrics", {})

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -62,7 +62,7 @@ def _write_log(file: Path):
             "1.1000",
             "1.0950",
             "1.1100",
-            "0",
+            "1",
             "2",
             "",
             "0.1",
@@ -87,7 +87,7 @@ def _write_log(file: Path):
             "1.2000",
             "1.1950",
             "1.2100",
-            "0",
+            "2",
             "3",
             "",
             "0.1",
@@ -149,7 +149,7 @@ def _write_log_many(file: Path, count: int = 10):
             "1.1000",
             "1.0950",
             "1.1100",
-            "0",
+            str(i + 1),
             "2",
             "",
             "0.1",
@@ -207,7 +207,7 @@ def _write_decay_log(file: Path) -> None:
             "1.0000",
             "0.9000",
             "1.1000",
-            "0",
+            "1",
             "2",
             "",
             "0.1",
@@ -232,7 +232,7 @@ def _write_decay_log(file: Path) -> None:
             "2.0000",
             "1.9000",
             "2.1000",
-            "0",
+            "2",
             "2",
             "",
             "0.1",
@@ -291,6 +291,7 @@ def test_train(tmp_path: Path):
     assert "equity" in data.get("feature_names", [])
     assert "margin_level" in data.get("feature_names", [])
     assert data.get("weighted") is True
+    assert data.get("weighted_by_net_profit") is True
     assert "mean" in data
     assert "std" in data
     assert data.get("data_commit") == "abc123"
@@ -526,7 +527,8 @@ def test_train_xgboost(tmp_path: Path):
     assert data.get("model_type") == "xgboost"
     assert "coefficients" in data
     assert len(data.get("probability_table", [])) == 24
-    assert data.get("weighted") is False
+    assert data.get("weighted") is True
+    assert data.get("weighted_by_net_profit") is True
 
 
 def test_train_lightgbm(tmp_path: Path):
@@ -546,7 +548,8 @@ def test_train_lightgbm(tmp_path: Path):
     assert data.get("model_type") == "lgbm"
     assert "coefficients" in data
     assert len(data.get("probability_table", [])) == 24
-    assert data.get("weighted") is False
+    assert data.get("weighted") is True
+    assert data.get("weighted_by_net_profit") is True
 
 
 def test_train_catboost(tmp_path: Path):
@@ -566,7 +569,8 @@ def test_train_catboost(tmp_path: Path):
     assert data.get("model_type") == "catboost"
     assert "coefficients" in data
     assert len(data.get("probability_table", [])) == 24
-    assert data.get("weighted") is False
+    assert data.get("weighted") is True
+    assert data.get("weighted_by_net_profit") is True
 
 
 def test_train_nn(tmp_path: Path):
@@ -585,7 +589,8 @@ def test_train_nn(tmp_path: Path):
     assert data.get("model_type") == "nn"
     assert "nn_weights" in data
     assert data.get("hidden_size", 0) > 0
-    assert data.get("weighted") is False
+    assert data.get("weighted") is True
+    assert data.get("weighted_by_net_profit") is True
 
 
 def test_train_lite_mode(tmp_path: Path):
@@ -618,7 +623,8 @@ def test_train_lstm(tmp_path: Path):
     assert data.get("model_type") == "lstm"
     assert "lstm_weights" in data
     assert data.get("sequence_length") == 3
-    assert data.get("weighted") is False
+    assert data.get("weighted") is True
+    assert data.get("weighted_by_net_profit") is True
 
 
 @pytest.mark.skipif(not HAS_TF, reason="TensorFlow required")
@@ -638,7 +644,8 @@ def test_train_transformer(tmp_path: Path):
     assert data.get("model_type") == "transformer"
     assert "transformer_weights" in data
     assert data.get("sequence_length") == 3
-    assert data.get("weighted") is False
+    assert data.get("weighted") is True
+    assert data.get("weighted_by_net_profit") is True
 
 
 def test_incremental_train(tmp_path: Path):
@@ -881,7 +888,7 @@ def test_resume_training(tmp_path: Path):
             "price": "1.1000",
             "sl": "1.0950",
             "tp": "1.1100",
-            "profit": "0",
+            "profit": "1",
             "spread": "2",
             "comment": "",
             "remaining_lots": "0.1",
@@ -903,7 +910,7 @@ def test_resume_training(tmp_path: Path):
             "price": "1.2000",
             "sl": "1.1950",
             "tp": "1.2100",
-            "profit": "0",
+            "profit": "2",
             "spread": "3",
             "comment": "",
             "remaining_lots": "0.1",
@@ -939,7 +946,7 @@ def test_resume_training(tmp_path: Path):
             "price": "1.1300",
             "sl": "1.1250",
             "tp": "1.1400",
-            "profit": "0",
+            "profit": "3",
             "spread": "2",
             "comment": "",
             "remaining_lots": "0.1",
@@ -961,7 +968,7 @@ def test_resume_training(tmp_path: Path):
             "price": "1.1400",
             "sl": "1.1350",
             "tp": "1.1500",
-            "profit": "0",
+            "profit": "4",
             "spread": "3",
             "comment": "",
             "remaining_lots": "0.1",

--- a/tests/test_train_target_clone_features.py
+++ b/tests/test_train_target_clone_features.py
@@ -60,7 +60,7 @@ def _write_sample_log(file: Path):
             "1.1000",
             "1.0950",
             "1.1100",
-            "0",
+            "1",
             "2",
             "",
             "0.1",
@@ -92,7 +92,7 @@ def _write_sample_log(file: Path):
             "1.2000",
             "1.1950",
             "1.2100",
-            "0",
+            "2",
             "3",
             "",
             "0.1",
@@ -127,7 +127,9 @@ def test_feature_extraction_basic():
             "price": 1.1000,
             "sl": 1.0950,
             "tp": 1.1100,
-            "profit": 0,
+            "profit": 2.0,
+            "commission": 0.5,
+            "swap": 0.2,
             "spread": 2,
             "slippage": 0.0001,
             "equity": 1000,
@@ -142,6 +144,7 @@ def test_feature_extraction_basic():
     assert "equity" in feats[0] and "margin_level" in feats[0]
     assert "sl_dist" in feats[0] and "tp_dist" in feats[0]
     assert "sl_hit_dist" in feats[0] and "tp_hit_dist" in feats[0]
+    assert feats[0]["net_profit"] == pytest.approx(2.0 - 0.5 - 0.2)
 
 
 def test_model_serialization(tmp_path: Path):
@@ -163,6 +166,7 @@ def test_model_serialization(tmp_path: Path):
     assert "val_accuracy" in data
     assert "spread" in data.get("feature_names", [])
     assert "slippage" in data.get("feature_names", [])
+    assert data.get("weighted_by_net_profit") is True
 
 
 def test_perf_budget_disables_heavy_features(caplog):


### PR DESCRIPTION
## Summary
- track net profit per trade and include it in extracted features
- scale training sample weights by net profit and record weighted_by_net_profit in model metadata
- update tests to cover net profit weighting

## Testing
- `pytest tests/test_train_target_clone_features.py::test_feature_extraction_basic tests/test_train_target_clone_features.py::test_model_serialization tests/test_graph_features.py::test_graph_features tests/test_train.py::test_train -q`


------
https://chatgpt.com/codex/tasks/task_e_68aba2dd50f8832fa79ad5da22fb2e70