### PR TITLE
Integrate local autoencoder anomaly scoring with remote fallback

### DIFF
--- a/model.json
+++ b/model.json
@@ -6,31 +6,76 @@
       "parameters": {}
     },
     "sub_policies": {
-      "0": {"algorithm": "PPO", "parameters": {}},
-      "1": {"algorithm": "PPO", "parameters": {}}
+      "0": {
+        "algorithm": "PPO",
+        "parameters": {}
+      },
+      "1": {
+        "algorithm": "PPO",
+        "parameters": {}
+      }
     }
   },
   "training_mode": "lite",
   "mode": "lite",
   "drift_metric": 0.0,
   "teacher_accuracy": 0.0,
-  "student_coefficients": [0.0],
+  "student_coefficients": [
+    0.0
+  ],
   "student_intercept": 0.0,
-  "lot_coefficients": [0.0],
+  "lot_coefficients": [
+    0.0
+  ],
   "lot_intercept": 0.0,
-  "sl_coefficients": [0.0],
+  "sl_coefficients": [
+    0.0
+  ],
   "sl_intercept": 0.0,
-  "tp_coefficients": [0.0],
+  "tp_coefficients": [
+    0.0
+  ],
   "tp_intercept": 0.0,
-  "entry_coefficients": [0.0, 0.0, 0.0, 0.0],
+  "entry_coefficients": [
+    0.0,
+    0.0,
+    0.0,
+    0.0
+  ],
   "entry_intercept": 0.0,
   "entry_threshold": 0.5,
-  "exit_coefficients": [0.0, 0.0, 0.0],
+  "exit_coefficients": [
+    0.0,
+    0.0,
+    0.0
+  ],
   "exit_intercept": 0.0,
   "exit_threshold": 0.0,
   "hourly_thresholds": [
-    0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
-    0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0
   ],
   "threshold_symbols": [],
   "threshold_table": [],
@@ -41,9 +86,61 @@
     "embedding_dim": 0
   },
   "symbol_embeddings": {},
-  "risk_parity_symbols": ["EURUSD", "USDJPY"],
-  "risk_parity_weights": [0.6, 0.4],
-  "risk_covariance_symbols": ["EURUSD", "USDJPY"],
-  "risk_covariance_matrix": [[1.0, 0.2], [0.2, 1.0]],
-  "weighted_by_net_profit": false
+  "risk_parity_symbols": [
+    "EURUSD",
+    "USDJPY"
+  ],
+  "risk_parity_weights": [
+    0.6,
+    0.4
+  ],
+  "risk_covariance_symbols": [
+    "EURUSD",
+    "USDJPY"
+  ],
+  "risk_covariance_matrix": [
+    [
+      1.0,
+      0.2
+    ],
+    [
+      0.2,
+      1.0
+    ]
+  ],
+  "weighted_by_net_profit": false,
+  "ae_weights": [
+    -0.5015436410903931,
+    0.28598496317863464,
+    -0.5015436410903931,
+    0.28598418831825256,
+    -0.5015436410903931,
+    0.2859852612018585,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    -0.4953402280807495,
+    -0.8686990737915039
+  ],
+  "ae_mean": [
+    1.25,
+    1.2000000476837158,
+    1.2999999523162842,
+    1.0,
+    0.10000000149011612,
+    0.01425000000745058
+  ],
+  "ae_std": [
+    0.18027757108211517,
+    0.18027760088443756,
+    0.18027757108211517,
+    9.99999993922529e-09,
+    9.99999993922529e-09,
+    0.0037666396237909794
+  ],
+  "ae_shape": [
+    6,
+    2
+  ]
 }

--- a/scripts/train_anomaly_autoencoder.py
+++ b/scripts/train_anomaly_autoencoder.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Train a tiny PCA-based autoencoder on trade features and store weights in model.json."""
+import argparse
+import json
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+
+def build_features(df: pd.DataFrame) -> np.ndarray:
+    """Generate 6-dim feature vectors from raw trade data."""
+    price = df["bid"].to_numpy()
+    sl = price - 0.05
+    tp = price + 0.05
+    lots = np.ones_like(price)
+    spread = (df["ask"] - df["bid"]).to_numpy()
+    slippage = df["latency"].to_numpy() * 0.001
+    X = np.vstack([price, sl, tp, lots, spread, slippage]).T
+    return X.astype(np.float32)
+
+
+def train_autoencoder(X: np.ndarray, latent_dim: int = 3):
+    """Fit linear autoencoder via SVD and return weights/normalization."""
+    mean = X.mean(axis=0)
+    std = X.std(axis=0) + 1e-8
+    Xs = (X - mean) / std
+    _, _, vt = np.linalg.svd(Xs, full_matrices=False)
+    W = vt[:latent_dim].T
+    return mean, std, W
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description="Train simple autoencoder and update model.json")
+    p.add_argument("input", type=Path, default=Path("tests/fixtures/trades_small.csv"), nargs="?")
+    p.add_argument("--model", type=Path, default=Path("model.json"))
+    p.add_argument("--latent", type=int, default=3)
+    args = p.parse_args()
+
+    df = pd.read_csv(args.input, sep=";")
+    X = build_features(df)
+    mean, std, W = train_autoencoder(X, latent_dim=args.latent)
+
+    if args.model.exists():
+        model = json.loads(args.model.read_text())
+    else:
+        model = {}
+    model["ae_weights"] = W.flatten().tolist()
+    model["ae_mean"] = mean.tolist()
+    model["ae_std"] = std.tolist()
+    model["ae_shape"] = [int(W.shape[0]), int(W.shape[1])]
+    args.model.write_text(json.dumps(model, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- train small PCA-based autoencoder and export weights to `model.json`
- compute anomaly reconstruction error locally in `Observer_TBot` with DLL fallback to remote service
- log local and remote anomaly scores for each trade record

## Testing
- `pytest tests/test_generate.py::test_generate -q`
- `pytest tests/test_anomaly_monitor_cp.py -q` *(fails: ModuleNotFoundError: opentelemetry.exporter)*

------
https://chatgpt.com/codex/tasks/task_e_68ae41ea1a18832fad01280c326c78b1