### PR TITLE
Add WAL retry and bounded trade buffer

### DIFF
--- a/scripts/metrics_collector.py
+++ b/scripts/metrics_collector.py
@@ -338,7 +338,7 @@ def serve(
                 while True:
                     try:
                         size = 0
-                        for fn in ("pending_trades.wal", "pending_metrics.wal"):
+                        for fn in ("pending_trades.wal", "pending_metrics.wal", "trades_raw.wal"):
                             fp = wal_dir / fn
                             if fp.exists():
                                 size += fp.stat().st_size


### PR DESCRIPTION
## Summary
- add configurable MAX_TRADE_BUFFER and flush when exceeded
- persist failed Flight send or file writes to WAL and replay on startup
- export WAL size via metrics collector

## Testing
- `pytest` *(fails: 25 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b20811f08c832fac1c98da1310d25b