### PR TITLE
Use ArraySort for calendar events and add performance test

### DIFF
--- a/experts/Observer_TBot.mq4
+++ b/experts/Observer_TBot.mq4
@@ -147,23 +147,20 @@ void LoadCalendar()
    FileClose(h);
    // sort events by time while keeping impacts and ids paired
    int n = ArraySize(CalendarTimes);
-   for(int i=1; i<n; i++)
+   int order[];
+   ArrayResize(order, n);
+   ArraySort(CalendarTimes, WHOLE_ARRAY, 0, MODE_ASCEND, order);
+   double impTmp[];
+   int idTmp[];
+   ArrayResize(impTmp, n);
+   ArrayResize(idTmp, n);
+   for(int i=0; i<n; i++)
    {
-      datetime t = CalendarTimes[i];
-      double imp = CalendarImpacts[i];
-      int eid = CalendarIds[i];
-      int j = i - 1;
-      while(j >= 0 && CalendarTimes[j] > t)
-      {
-         CalendarTimes[j+1] = CalendarTimes[j];
-         CalendarImpacts[j+1] = CalendarImpacts[j];
-         CalendarIds[j+1] = CalendarIds[j];
-         j--;
-      }
-      CalendarTimes[j+1] = t;
-      CalendarImpacts[j+1] = imp;
-      CalendarIds[j+1] = eid;
+      impTmp[i] = CalendarImpacts[order[i]];
+      idTmp[i] = CalendarIds[order[i]];
    }
+   ArrayCopy(CalendarImpacts, impTmp);
+   ArrayCopy(CalendarIds, idTmp);
 }
 
 int CalendarEventIdAt(datetime ts)

--- a/tests/test_calendar_events.py
+++ b/tests/test_calendar_events.py
@@ -1,5 +1,8 @@
 import csv
-from datetime import datetime
+import random
+import time
+from collections import defaultdict
+from datetime import datetime, timedelta
 from pathlib import Path
 
 
@@ -21,6 +24,36 @@ def _load_calendar(file: Path):
     times = [times[i] for i in order]
     impacts = [impacts[i] for i in order]
     ids = [ids[i] for i in order]
+    return times, impacts, ids
+
+
+def _load_calendar_manual(file: Path):
+    times = []
+    impacts = []
+    ids = []
+    with open(file, newline="") as f:
+        reader = csv.reader(f)
+        header = next(reader, None)
+        for row in reader:
+            if not row:
+                continue
+            ts, impact, eid = row
+            times.append(datetime.strptime(ts, "%Y-%m-%d %H:%M:%S"))
+            impacts.append(float(impact))
+            ids.append(int(eid))
+    for i in range(1, len(times)):
+        t = times[i]
+        imp = impacts[i]
+        eid = ids[i]
+        j = i - 1
+        while j >= 0 and times[j] > t:
+            times[j + 1] = times[j]
+            impacts[j + 1] = impacts[j]
+            ids[j + 1] = ids[j]
+            j -= 1
+        times[j + 1] = t
+        impacts[j + 1] = imp
+        ids[j + 1] = eid
     return times, impacts, ids
 
 
@@ -71,3 +104,29 @@ def test_event_id_lookup(tmp_path: Path):
     assert eid2 == 2
     ts3 = datetime(2024, 1, 1, 8, 0)
     assert _calendar_event_id_at(times, impacts, ids, ts3, window_minutes=59) == -1
+
+
+def test_large_calendar_sort(tmp_path: Path):
+    random.seed(0)
+    cal = tmp_path / "calendar.csv"
+    base = datetime(2024, 1, 1)
+    with open(cal, "w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(["time", "impact", "id"])
+        for i in range(2000):
+            ts = base + timedelta(minutes=random.randint(0, 1000))
+            writer.writerow([ts.strftime("%Y-%m-%d %H:%M:%S"), "1.0", str(i)])
+    start = time.perf_counter()
+    _load_calendar_manual(cal)
+    manual_time = time.perf_counter() - start
+    start = time.perf_counter()
+    times, impacts, ids = _load_calendar(cal)
+    sorted_time = time.perf_counter() - start
+    assert times == sorted(times)
+    groups = defaultdict(list)
+    for t, eid in zip(times, ids):
+        groups[t].append(eid)
+    for eids in groups.values():
+        if len(eids) > 1:
+            assert eids == sorted(eids)
+    assert sorted_time < manual_time


### PR DESCRIPTION
## Summary
- Simplify calendar loading by sorting times with ArraySort and reordering impacts/ids using returned indices
- Add regression test generating a large calendar to ensure stable order and faster sort performance

## Testing
- `pytest tests/test_calendar_events.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b259d86dc8832f81271f4e565bf52c