### PR TITLE
Add vectorized environment option for RL training

### DIFF
--- a/tests/test_train_rl_agent.py
+++ b/tests/test_train_rl_agent.py
@@ -105,6 +105,7 @@ def test_train_rl_agent_sb3(tmp_path: Path, algo: str) -> None:
         training_steps=10,
         learning_rate=0.2,
         gamma=0.95,
+        num_envs=2,
     )
 
     model_file = out_dir / "model.json"


### PR DESCRIPTION
## Summary
- add `--num-envs` flag to control parallel TradeEnv workers
- use `sb3.make_vec_env`/`SubprocVecEnv` to train on multiple TradeEnv instances
- exercise vectorized mode in RL unit test

## Testing
- `pytest tests/test_train_rl_agent.py -q` *(skipped: stable-baselines3 not installed)*
- `pytest tests/test_train_rl_agent_offline.py::test_train_cql -q`
- `pytest tests/test_train_with_rl.py::test_rl_refinement -q` *(fails: Cannot have number of splits n_splits=3 greater than the number of samples: n_samples=2)*

------
https://chatgpt.com/codex/tasks/task_e_68b25e4ac0dc832f81c184c848891530