### PR TITLE
Track decision metadata for trades

### DIFF
--- a/schemas/VERSION_HISTORY.md
+++ b/schemas/VERSION_HISTORY.md
@@ -6,3 +6,6 @@
 
 ## 2
 - Added `exit_reason` and `duration_sec` fields to trade logs for improved exit analysis.
+
+## 3
+- Added `executed_model_idx` field to trade logs to track the model responsible for each decision.

--- a/schemas/trade.avsc
+++ b/schemas/trade.avsc
@@ -32,6 +32,7 @@
     {"name": "book_imbalance", "type": "double"},
     {"name": "sl_hit_dist", "type": "double"},
     {"name": "tp_hit_dist", "type": "double"},
+    {"name": "executed_model_idx", "type": "int", "default": -1},
     {"name": "decision_id", "type": ["int", "null"], "default": null},
     {"name": "exit_reason", "type": "string"},
     {"name": "duration_sec", "type": "int"}

--- a/schemas/trades.py
+++ b/schemas/trades.py
@@ -28,6 +28,7 @@ class TradeEvent(BaseModel):
     profit: float
     comment: str = ""
     remaining_lots: float
+    executed_model_idx: Optional[int] = None
     decision_id: Optional[int] = None
     exit_reason: str = ""
     duration_sec: int = 0
@@ -66,6 +67,7 @@ TRADE_SCHEMA = pa.schema([
     ("book_imbalance", pa.float64()),
     ("sl_hit_dist", pa.float64()),
     ("tp_hit_dist", pa.float64()),
+    ("executed_model_idx", pa.int32()),
     ("decision_id", pa.int32()),
     ("exit_reason", pa.string()),
     ("duration_sec", pa.int32()),

--- a/scripts/train_target_clone.py
+++ b/scripts/train_target_clone.py
@@ -98,7 +98,7 @@ from opentelemetry.sdk.trace.export import BatchSpanProcessor
 from opentelemetry.trace import format_span_id, format_trace_id
 
 
-SCHEMA_VERSION = 2
+SCHEMA_VERSION = 3
 START_EVENT_ID = 0
 
 resource = Resource.create({"service.name": os.getenv("OTEL_SERVICE_NAME", "train_target_clone")})
@@ -746,6 +746,8 @@ def _load_logs(
         "tp_dist",
         "sl_hit_dist",
         "tp_hit_dist",
+        "executed_model_idx",
+        "decision_id",
         "profit",
         "spread",
         "comment",
@@ -928,6 +930,18 @@ def _load_logs(
                 if "magic" in chunk.columns:
                     chunk["magic"] = (
                         pd.to_numeric(chunk["magic"], errors="coerce").fillna(0).astype(int)
+                    )
+                if "executed_model_idx" in chunk.columns:
+                    chunk["executed_model_idx"] = (
+                        pd.to_numeric(chunk["executed_model_idx"], errors="coerce")
+                        .fillna(-1)
+                        .astype(int)
+                    )
+                if "decision_id" in chunk.columns:
+                    chunk["decision_id"] = (
+                        pd.to_numeric(chunk["decision_id"], errors="coerce")
+                        .fillna(0)
+                        .astype(int)
                     )
                 if df_metrics is not None and key_col is not None and "magic" in chunk.columns:
                     if key_col == "magic":


### PR DESCRIPTION
## Summary
- capture executed model index and decision id in Observer_TBot trade logs
- expose decision metadata in training and evaluation scripts for per-model metrics
- document schema change for executed_model_idx

## Testing
- `pytest tests/test_evaluate.py -q`
- `pytest tests/test_train_target_clone_bayes.py tests/test_train_target_clone_features.py tests/test_train_target_clone_validation.py tests/test_evaluate.py -q` *(fails: ModuleNotFoundError: No module named 'opentelemetry.exporter')*

------
https://chatgpt.com/codex/tasks/task_e_68b278bbf37c832fa7b72ba2e2223357