### PR TITLE
Add meta strategy audit and model selection logging

### DIFF
--- a/scripts/meta_strategy_audit.py
+++ b/scripts/meta_strategy_audit.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Aggregate decision logs to evaluate meta strategy performance.
+
+This utility reads ``decisions.csv`` together with ``trades_raw.csv`` and
+computes win rate and profit for both the model that was actually chosen and
+all shadow models that were merely evaluated.  Results can optionally be
+persisted to a JSON summary and used to update the bandit router's state file
+so future model selection is biased toward higher performing models.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+
+import numpy as np
+import pandas as pd
+
+
+# ---------------------------------------------------------------------------
+# Core analytics
+# ---------------------------------------------------------------------------
+
+def aggregate_decisions(
+    decisions_file: Path, trades_file: Path, threshold: float = 0.5
+) -> List[Dict[str, Any]]:
+    """Return win rate and profit statistics for each model.
+
+    Parameters
+    ----------
+    decisions_file : Path
+        CSV log produced by :func:`LogDecision`.
+    trades_file : Path
+        CSV trade log containing ``decision_id`` and ``profit`` columns.
+    threshold : float, default 0.5
+        Probability threshold used to derive buy/sell actions for shadow
+        models.
+    """
+
+    decisions = pd.read_csv(decisions_file, sep=";")
+    decisions = decisions.rename(columns={"event_id": "decision_id"})
+    trades = pd.read_csv(trades_file)
+    merged = decisions.merge(trades[["decision_id", "profit"]], on="decision_id", how="left")
+    merged["profit"] = merged["profit"].fillna(0.0)
+
+    thr = float(threshold)
+
+    def _pred_action(row: pd.Series) -> str:
+        if int(row.get("chosen", 0)) == 1:
+            return str(row.get("action", ""))
+        prob = float(row.get("probability", 0.0))
+        return "buy" if prob > thr else "sell"
+
+    merged["pred_action"] = merged.apply(_pred_action, axis=1)
+    merged["model_profit"] = np.where(
+        merged["pred_action"] == merged["action"],
+        merged["profit"],
+        -merged["profit"],
+    )
+    merged["win"] = merged["model_profit"] > 0
+
+    results: List[Dict[str, Any]] = []
+    for model_idx, group in merged.groupby("model_idx"):
+        chosen_g = group[group["chosen"] == 1]
+        shadow_g = group[group["chosen"] == 0]
+
+        def _stats(g: pd.DataFrame) -> Dict[str, Any]:
+            trades = int(len(g))
+            wins = int(g["win"].sum())
+            profit = float(g["model_profit"].sum())
+            win_rate = wins / trades if trades else 0.0
+            return {
+                "trades": trades,
+                "wins": wins,
+                "win_rate": win_rate,
+                "profit": profit,
+            }
+
+        results.append(
+            {
+                "model_idx": int(model_idx),
+                "chosen": _stats(chosen_g),
+                "shadow": _stats(shadow_g),
+            }
+        )
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Bandit refinement
+# ---------------------------------------------------------------------------
+
+def update_bandit_state(metrics: List[Dict[str, Any]], state_file: Path) -> None:
+    """Update ``state_file`` with statistics from ``metrics``.
+
+    Existing counts are incremented with the number of trades and wins for the
+    chosen model of each entry.
+    """
+
+    if state_file.exists():
+        try:
+            state = json.loads(state_file.read_text())
+        except Exception:
+            state = {"total": [], "wins": []}
+    else:
+        state = {"total": [], "wins": []}
+
+    total = list(state.get("total", []))
+    wins = list(state.get("wins", []))
+    max_idx = max((m["model_idx"] for m in metrics), default=-1)
+    if len(total) <= max_idx:
+        total.extend([0] * (max_idx + 1 - len(total)))
+        wins.extend([0] * (max_idx + 1 - len(wins)))
+
+    for m in metrics:
+        idx = m["model_idx"]
+        total[idx] += m["chosen"]["trades"]
+        wins[idx] += m["chosen"]["wins"]
+
+    state_file.write_text(json.dumps({"total": total, "wins": wins}))
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main(argv: List[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description="Audit meta strategy decisions")
+    p.add_argument("--decisions", type=Path, required=True, help="Path to decisions.csv")
+    p.add_argument("--trades", type=Path, required=True, help="Path to trades_raw.csv")
+    p.add_argument("--threshold", type=float, default=0.5, help="Decision threshold")
+    p.add_argument("--out", type=Path, help="Optional JSON file to write summary")
+    p.add_argument("--bandit-state", type=Path, help="Optional bandit state file to update")
+    args = p.parse_args(argv)
+
+    metrics = aggregate_decisions(args.decisions, args.trades, args.threshold)
+    if args.out is not None:
+        args.out.write_text(json.dumps(metrics, indent=2))
+    if args.bandit_state is not None:
+        update_bandit_state(metrics, args.bandit_state)
+    print(json.dumps(metrics, indent=2))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/tests/test_meta_strategy_audit.py
+++ b/tests/test_meta_strategy_audit.py
@@ -1,0 +1,34 @@
+import json
+from pathlib import Path
+
+from scripts.meta_strategy_audit import aggregate_decisions, update_bandit_state
+
+
+def _write_logs(tmpdir: Path) -> tuple[Path, Path]:
+    decisions = tmpdir / "decisions.csv"
+    trades = tmpdir / "trades_raw.csv"
+    decisions.write_text(
+        """event_id;timestamp;model_version;action;probability;sl_dist;tp_dist;model_idx;regime;chosen;risk_weight;variance;lots_predicted;executed_model_idx;features;trace_id;span_id
+1;2024-01-01T00:00:00;v1;buy;0.8;0;0;0;0;1;1;0.1;0;0;;t;s
+1;2024-01-01T00:00:00;v1;shadow;0.3;0;0;1;0;0;1;0.1;0;0;;t;s
+2;2024-01-01T00:01:00;v1;sell;0.2;0;0;0;0;1;1;0.1;0;0;;t;s
+2;2024-01-01T00:01:00;v1;shadow;0.7;0;0;1;0;0;1;0.1;0;0;;t;s
+"""
+    )
+    trades.write_text("decision_id,profit\n1,10\n2,-5\n")
+    return decisions, trades
+
+
+def test_aggregate_and_bandit(tmp_path: Path) -> None:
+    decisions, trades = _write_logs(tmp_path)
+    metrics = aggregate_decisions(decisions, trades, threshold=0.5)
+    by_model = {m["model_idx"]: m for m in metrics}
+    assert by_model[0]["chosen"]["profit"] == 5.0
+    assert by_model[0]["chosen"]["win_rate"] == 0.5
+    assert by_model[1]["shadow"]["profit"] == -5.0
+
+    state_file = tmp_path / "bandit.json"
+    update_bandit_state(metrics, state_file)
+    state = json.loads(state_file.read_text())
+    assert state["total"][0] == by_model[0]["chosen"]["trades"]
+    assert state["wins"][0] == by_model[0]["chosen"]["wins"]


### PR DESCRIPTION
## Summary
- log whether each model was chosen or only evaluated by adding a `chosen` field to decision logs
- provide `scripts/meta_strategy_audit.py` to compute win rate and profit for chosen vs shadow models and update bandit state
- test audit utilities with sample logs

## Testing
- `pytest tests/test_meta_strategy_audit.py tests/test_meta_strategy.py`


------
https://chatgpt.com/codex/tasks/task_e_68b27b79be4c832fb7996ba498b98aa6