### PR TITLE
Add cointegration residual features

### DIFF
--- a/experts/StrategyTemplate.mq4
+++ b/experts/StrategyTemplate.mq4
@@ -108,6 +108,9 @@ int LastCalendarEventId = -1;
 string GraphSymbols[] = {__GRAPH_SYMBOLS__};
 double GraphDegreeVals[] = {__GRAPH_DEGREE__};
 double GraphPagerankVals[] = {__GRAPH_PAGERANK__};
+string CointBaseSymbols[] = {__COINT_BASE__};
+string CointPeerSymbols[] = {__COINT_PEER__};
+double CointBetas[] = {__COINT_BETA__};
 double FeatureHistory[__LSTM_SEQ_LEN__][__FEATURE_COUNT__];
 int FeatureHistorySize = 0;
 int CachedTimeframes[] = {__CACHE_TIMEFRAMES__};
@@ -776,6 +779,27 @@ double PairCorrelation(string sym1, string sym2="", int window=5)
    if(den1 <= 0 || den2 <= 0)
       return(0.0);
    return(num / MathSqrt(den1 * den2));
+}
+
+double CointegrationResidual(string sym1, string sym2="")
+{
+   if(sym2 == "")
+   {
+      sym2 = sym1;
+      sym1 = SymbolToTrade;
+   }
+   double beta = 0.0;
+   for(int i=0; i<ArraySize(CointBaseSymbols); i++)
+   {
+      if(CointBaseSymbols[i] == sym1 && CointPeerSymbols[i] == sym2)
+      {
+         beta = CointBetas[i];
+         break;
+      }
+   }
+   double p1 = iClose(sym1, 0, 0);
+   double p2 = iClose(sym2, 0, 0);
+   return(p1 - beta * p2);
 }
 
 double GraphDegree()

--- a/scripts/generate_mql4_from_model.py
+++ b/scripts/generate_mql4_from_model.py
@@ -437,6 +437,24 @@ def generate(
         output = output.replace('__GRAPH_DEGREE__', '')
         output = output.replace('__GRAPH_PAGERANK__', '')
 
+    coint = graph_data.get('cointegration') or {}
+    if coint:
+        bases: List[str] = []
+        peers: List[str] = []
+        betas: List[str] = []
+        for a, pmap in coint.items():
+            for b, beta in pmap.items():
+                bases.append(f'"{a}"')
+                peers.append(f'"{b}"')
+                betas.append(_fmt(float(beta)))
+        output = output.replace('__COINT_BASE__', ', '.join(bases))
+        output = output.replace('__COINT_PEER__', ', '.join(peers))
+        output = output.replace('__COINT_BETA__', ', '.join(betas))
+    else:
+        output = output.replace('__COINT_BASE__', '')
+        output = output.replace('__COINT_PEER__', '')
+        output = output.replace('__COINT_BETA__', '')
+
     rps = base.get('risk_parity_symbols', [])
     rpw = base.get('risk_parity_weights', [])
     if rps and rpw:
@@ -587,6 +605,14 @@ def generate(
                 return f'PairCorrelation("{sym1}", "{sym2}")'
             if len(parts) == 1:
                 return f'PairCorrelation("{parts[0]}")'
+        if fname.startswith('coint_residual_'):
+            parts = fname[16:].split('_')
+            if len(parts) >= 2:
+                sym1 = parts[0]
+                sym2 = '_'.join(parts[1:])
+                return f'CointegrationResidual("{sym1}", "{sym2}")'
+            if len(parts) == 1:
+                return f'CointegrationResidual("{parts[0]}")'
         if fname.startswith('exit_reason='):
             reason = fname.split('=', 1)[1]
             return f'ExitReasonFlag("{reason}")'


### PR DESCRIPTION
## Summary
- compute cointegration betas between symbol pairs in build_symbol_graph
- generate cointegration residual features in training and embed metadata in models and MQL4 templates
- cover cointegration residuals in unit tests

## Testing
- `pytest` *(fails: No module named 'opentelemetry', 'psutil', 'grpc', 'requests', etc.)*
- `pytest tests/test_graph_features.py` *(fails: No module named 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_e_68b28323dc34832fb038a1262585381d