### PR TITLE
Add conformal probability bounds and coverage metrics

### DIFF
--- a/experts/StrategyTemplate.mq4
+++ b/experts/StrategyTemplate.mq4
@@ -53,6 +53,8 @@ double CalibrationIntercept = __CAL_INTERCEPT__;
 double ModelThreshold[] = {__HOURLY_THRESHOLDS__};
 double DefaultThreshold = __THRESHOLD__;
 double ProbabilityLookup[__MODEL_COUNT__][24] = {__PROBABILITY_TABLE__};
+double ConformalLower = __CONFORMAL_LOWER__;
+double ConformalUpper = __CONFORMAL_UPPER__;
 string ThresholdSymbols[];
 double ThresholdTable[][24];
 double SLModelCoefficients[] = {__SL_COEFFICIENTS__};
@@ -339,6 +341,8 @@ bool ParseModelJson(string json)
    TPModelIntercept = ExtractJsonNumber(json, "\"tp_intercept\"");
    LotModelIntercept = ExtractJsonNumber(json, "\"lot_intercept\"");
    DefaultThreshold = ExtractJsonNumber(json, "\"threshold\"");
+   ConformalLower = ExtractJsonNumber(json, "\"conformal_lower\"");
+   ConformalUpper = ExtractJsonNumber(json, "\"conformal_upper\"");
    ModelCount = 1;
    return(true);
 }
@@ -1500,6 +1504,12 @@ void OnTick()
    double prob = probs[modelIdx];
    double pv = pvs[modelIdx];
    double risk_weight = risk_weights[modelIdx];
+
+   if(prob < ConformalLower || prob > ConformalUpper)
+      Print("Probability outside conformal bounds: " +
+            DoubleToString(prob,4) + " not in [" +
+            DoubleToString(ConformalLower,4) + "," +
+            DoubleToString(ConformalUpper,4) + "]");
 
    if(EnableDebugLogging)
    {

--- a/scripts/train_target_clone.py
+++ b/scripts/train_target_clone.py
@@ -2911,6 +2911,16 @@ def train(
                 t = threshold
             hourly_thresholds.append(float(t))
 
+        if len(y_val) > 0:
+            scores = np.abs(y_val - proba_val)
+            lower_bounds = np.clip(proba_val - scores, 0.0, 1.0)
+            upper_bounds = np.clip(proba_val + scores, 0.0, 1.0)
+            conformal_lower = float(np.quantile(lower_bounds, 0.05))
+            conformal_upper = float(np.quantile(upper_bounds, 0.95))
+        else:
+            conformal_lower = 0.0
+            conformal_upper = 1.0
+
         model = {
             "model_id": (existing_model.get("model_id") if existing_model else "target_clone"),
             "trained_at": datetime.utcnow().isoformat(),
@@ -2940,6 +2950,8 @@ def train(
             "mean": feature_mean.astype(np.float32).tolist(),
             "std": feature_std.astype(np.float32).tolist(),
             "hourly_thresholds": hourly_thresholds,
+            "conformal_lower": conformal_lower,
+            "conformal_upper": conformal_upper,
         }
         model["split_sizes"] = split_sizes
         model["validation_metrics"] = {


### PR DESCRIPTION
## Summary
- derive conformal probability bounds during `train_target_clone` and persist them in `model.json`
- evaluate predictions against conformal bounds, reporting coverage and miscoverage
- strategy template logs probabilities outside conformal bounds before trading

## Testing
- `python -m py_compile scripts/train_target_clone.py scripts/evaluate_predictions.py`
- `pip install numpy pandas requests psutil pyarrow grpcio`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'opentelemetry')*

------
https://chatgpt.com/codex/tasks/task_e_68b4c7dc8ba4832f8586199f03b6d72c