### PR TITLE
Filter non-cointegrated pairs from symbol graph

### DIFF
--- a/scripts/generate_mql4_from_model.py
+++ b/scripts/generate_mql4_from_model.py
@@ -519,10 +519,14 @@ def generate(
         peers: List[str] = []
         betas: List[str] = []
         for a, pmap in coint.items():
-            for b, beta in pmap.items():
+            for b, stats in pmap.items():
+                if isinstance(stats, dict):
+                    beta_val = stats.get('beta', 0.0)
+                else:
+                    beta_val = stats
                 bases.append(f'"{a}"')
                 peers.append(f'"{b}"')
-                betas.append(_fmt(float(beta)))
+                betas.append(_fmt(float(beta_val)))
         output = output.replace('__COINT_BASE__', ', '.join(bases))
         output = output.replace('__COINT_PEER__', ', '.join(peers))
         output = output.replace('__COINT_BETA__', ', '.join(betas))


### PR DESCRIPTION
## Summary
- run Engle–Granger tests when building symbol graphs to drop non-cointegrated pairs and store beta/p-value metadata
- use cointegration stats in `_extract_features` to ignore unpaired edges and compute residuals
- expand tests to cover non-cointegrated pairs and ensure they are filtered out

## Testing
- `pytest tests/test_graph_features.py::test_graph_features -q`

------
https://chatgpt.com/codex/tasks/task_e_68b4d248bfac832f898f0260a83cfc44