### PR TITLE
Add graph node metrics and embeddings to features and EA

### DIFF
--- a/experts/StrategyTemplate.mq4
+++ b/experts/StrategyTemplate.mq4
@@ -111,6 +111,7 @@ string GraphSymbols[] = {__GRAPH_SYMBOLS__};
 double GraphDegreeVals[] = {__GRAPH_DEGREE__};
 double GraphPagerankVals[] = {__GRAPH_PAGERANK__};
 int GraphEmbDim = __GRAPH_EMB_DIM__;
+int GraphEmbCount = __GRAPH_EMB_COUNT__;
 double GraphEmbeddings[__GRAPH_EMB_COUNT__][__GRAPH_EMB_DIM__] = {__GRAPH_EMB__};
 string CointBaseSymbols[] = {__COINT_BASE__};
 string CointPeerSymbols[] = {__COINT_PEER__};

--- a/scripts/generate_mql4_from_model.py
+++ b/scripts/generate_mql4_from_model.py
@@ -701,6 +701,9 @@ def generate(
             return 'GraphDegree()'
         if fname == 'graph_pagerank':
             return 'GraphPagerank()'
+        if fname.startswith('graph_emb') and fname[9:].isdigit():
+            idx_g = int(fname[9:])
+            return f'GraphEmbedding({idx_g})'
         if fname.startswith('ae') and fname[2:].isdigit():
             idx_ae = int(fname[2:])
             return f'GetEncodedFeature({idx_ae})'


### PR DESCRIPTION
## Summary
- persist per-symbol graph metrics and embeddings in `build_symbol_graph`
- load graph node metrics/embeddings in feature extractor and expose in generated MQL4 code
- support `graph_emb*` features in generator and template
- test graph-derived features end-to-end including Node2Vec embeddings

## Testing
- `pytest tests/test_graph_features.py::test_graph_features -q`

------
https://chatgpt.com/codex/tasks/task_e_68b4e45a82d0832fbee154e8aa748c6e