### PR TITLE
Add order book derived features

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -24,6 +24,12 @@ Downstream components read these flags to stay in sync:
 * :mod:`scripts.online_trainer.py` filters unsupported features and passes the
   appropriate ``--lite-mode`` flag when regenerating Expert Advisors.
 
+When order‑book logging is active the trainer derives additional features:
+``book_spread`` (ask minus bid volume), ``bid_ask_ratio`` and a rolling
+``book_imbalance_roll`` averaged over the last five updates. These complement
+the raw ``book_bid_vol``, ``book_ask_vol`` and ``book_imbalance`` inputs
+extracted from the Observer EA.
+
 This metadata is persisted in ``model.json`` so that models trained on one
 machine can be safely deployed on another with different capabilities.
 

--- a/experts/StrategyTemplate.mq4
+++ b/experts/StrategyTemplate.mq4
@@ -129,6 +129,12 @@ double CachedBookBidVol = 0.0;
 double CachedBookAskVol = 0.0;
 double CachedBookImbalance = 0.0;
 datetime CachedBookTime = 0;
+double CachedBookSpread = 0.0;
+double CachedBidAskRatio = 0.0;
+double CachedBookImbalanceRoll = 0.0;
+double BookImbalanceHist[5];
+int BookImbPos = 0;
+int BookImbCount = 0;
 double CachedNewsSentiment = 0.0;
 datetime CachedNewsTime = 0;
 double TrendEstimate = 0.0;
@@ -753,6 +759,14 @@ void RefreshBookCache()
       CachedBookBidVol = bid;
       CachedBookAskVol = ask;
       CachedBookImbalance = (bid+ask>0) ? (bid-ask)/(bid+ask) : 0.0;
+      CachedBookSpread = ask - bid;
+      CachedBidAskRatio = (ask>0) ? bid/ask : 0.0;
+      BookImbalanceHist[BookImbPos] = CachedBookImbalance;
+      BookImbPos = (BookImbPos + 1) % 5;
+      if(BookImbCount < 5) BookImbCount++;
+      double sum = 0.0;
+      for(int j=0; j<BookImbCount; j++) sum += BookImbalanceHist[j];
+      CachedBookImbalanceRoll = (BookImbCount>0) ? sum / BookImbCount : 0.0;
       CachedBookTime = t;
    }
 }
@@ -773,6 +787,24 @@ double BookImbalance()
 {
    RefreshBookCache();
    return(CachedBookImbalance);
+}
+
+double BookSpread()
+{
+   RefreshBookCache();
+   return(CachedBookSpread);
+}
+
+double BidAskRatio()
+{
+   RefreshBookCache();
+   return(CachedBidAskRatio);
+}
+
+double BookImbalanceRoll()
+{
+   RefreshBookCache();
+   return(CachedBookImbalanceRoll);
 }
 
 double PairCorrelation(string sym1, string sym2="", int window=5)

--- a/scripts/generate_mql4_from_model.py
+++ b/scripts/generate_mql4_from_model.py
@@ -607,6 +607,9 @@ def generate(
         'book_bid_vol': 'BookBidVol()',
         'book_ask_vol': 'BookAskVol()',
         'book_imbalance': 'BookImbalance()',
+        'book_spread': 'BookSpread()',
+        'bid_ask_ratio': 'BidAskRatio()',
+        'book_imbalance_roll': 'BookImbalanceRoll()',
         'trend_estimate': 'TrendEstimate',
         'trend_variance': 'TrendVariance',
         'duration_sec': 'TradeDuration()',
@@ -616,6 +619,9 @@ def generate(
         feature_map['book_bid_vol'] = '0.0'
         feature_map['book_ask_vol'] = '0.0'
         feature_map['book_imbalance'] = '0.0'
+        feature_map['book_spread'] = '0.0'
+        feature_map['bid_ask_ratio'] = '0.0'
+        feature_map['book_imbalance_roll'] = '0.0'
 
     tf_const = {
         'M1': 'PERIOD_M1',

--- a/scripts/train_target_clone.py
+++ b/scripts/train_target_clone.py
@@ -1228,6 +1228,7 @@ def _extract_features(
     prices = []
     hours = []
     times = []
+    imbalance_history: list[float] = []
     price_map = {sym: [] for sym in (extra_price_series or {}).keys()}
     macd_state = {}
     higher_timeframes = [str(tf).upper() for tf in (higher_timeframes or [])]
@@ -1460,11 +1461,22 @@ def _extract_features(
             feat["dom_cos"] = dom_cos
 
         if use_orderbook:
+            bid_vol = float(r.get("book_bid_vol", 0) or 0)
+            ask_vol = float(r.get("book_ask_vol", 0) or 0)
+            imbalance = float(r.get("book_imbalance", 0) or 0)
+            imbalance_history.append(imbalance)
+            window = 5
+            roll = sum(imbalance_history[-window:]) / min(len(imbalance_history), window)
+            spread_vol = ask_vol - bid_vol
+            ratio = bid_vol / (ask_vol + 1e-9)
             feat.update(
                 {
-                    "book_bid_vol": float(r.get("book_bid_vol", 0) or 0),
-                    "book_ask_vol": float(r.get("book_ask_vol", 0) or 0),
-                    "book_imbalance": float(r.get("book_imbalance", 0) or 0),
+                    "book_bid_vol": bid_vol,
+                    "book_ask_vol": ask_vol,
+                    "book_imbalance": imbalance,
+                    "book_spread": spread_vol,
+                    "bid_ask_ratio": ratio,
+                    "book_imbalance_roll": roll,
                 }
             )
 

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -635,6 +635,30 @@ def test_generate_volume_feature(tmp_path: Path):
     assert "iVolume(SymbolToTrade, 0, 0)" in content
 
 
+def test_generate_orderbook_metrics(tmp_path: Path):
+    model = {
+        "model_id": "obmet",
+        "magic": 55,
+        "coefficients": [0.1, 0.2, 0.3],
+        "intercept": 0.0,
+        "threshold": 0.5,
+        "feature_names": ["book_spread", "bid_ask_ratio", "book_imbalance_roll"],
+    }
+    model_file = tmp_path / "model.json"
+    with open(model_file, "w") as f:
+        json.dump(model, f)
+
+    out_dir = tmp_path / "out"
+    generate(model_file, out_dir)
+
+    generated = list(out_dir.glob("Generated_obmet_*.mq4"))
+    assert len(generated) == 1
+    content = generated[0].read_text()
+    assert "BookSpread()" in content
+    assert "BidAskRatio()" in content
+    assert "BookImbalanceRoll()" in content
+
+
 def test_manage_open_orders_included(tmp_path: Path):
     model = {
         "model_id": "manage",


### PR DESCRIPTION
## Summary
- derive book_spread, bid_ask_ratio and rolling book_imbalance when order book volumes are available
- expose corresponding metrics in generated EAs and strategy template
- document and test new order-book features

## Testing
- `pytest tests/test_generate.py::test_generate_orderbook_metrics -q`
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68b5f6557e68832f8d0e50bec2adec60