### PR TITLE
Store feature scaling parameters in model and EA

### DIFF
--- a/experts/StrategyTemplate.mq4
+++ b/experts/StrategyTemplate.mq4
@@ -913,6 +913,7 @@ __FEATURE_CASES__      default:
          raw = 0.0;
          break;
    }
+   // Apply standardization using training set parameters when available
    if(index < ArraySize(FeatureMean) && index < ArraySize(FeatureStd) && FeatureStd[index] != 0)
       return((raw - FeatureMean[index]) / FeatureStd[index]);
    return(raw);

--- a/scripts/generate_mql4_from_model.py
+++ b/scripts/generate_mql4_from_model.py
@@ -450,8 +450,8 @@ def generate(
     reg_thr_str = ', '.join(_fmt(t) for t in reg_thr) if reg_thr else ''
     output = output.replace('__REGIME_THRESHOLDS__', reg_thr_str)
 
-    mean_vals = base.get('mean', base.get('feature_mean', []))
-    std_vals = base.get('std', base.get('feature_std', []))
+    mean_vals = base.get('feature_mean', base.get('mean', []))
+    std_vals = base.get('feature_std', base.get('std', []))
 
     if hash_size:
         mean_vec = [_fmt(m) for m in mean_vals]

--- a/scripts/train_target_clone.py
+++ b/scripts/train_target_clone.py
@@ -1900,6 +1900,8 @@ def _train_lite_mode(
         "feature_importance": {},
         "mean": scaler.mean_.astype(np.float32).tolist(),
         "std": scaler.scale_.astype(np.float32).tolist(),
+        "feature_mean": scaler.mean_.astype(np.float32).tolist(),
+        "feature_std": scaler.scale_.astype(np.float32).tolist(),
         "coefficients": clf.coef_[0].astype(np.float32).tolist(),
         "intercept": float(clf.intercept_[0]),
         "classes": [int(c) for c in clf.classes_],
@@ -2323,6 +2325,8 @@ def train(
                 "feature_names": vec_reg.get_feature_names_out().tolist(),
                 "mean": reg_mean.astype(np.float32).tolist(),
                 "std": reg_std.astype(np.float32).tolist(),
+                "feature_mean": reg_mean.astype(np.float32).tolist(),
+                "feature_std": reg_std.astype(np.float32).tolist(),
                 "centers": reg_centers.astype(np.float32).tolist(),
             }
     except Exception as exc:
@@ -2358,6 +2362,8 @@ def train(
             "bias": [b.astype(np.float32).tolist() for b in ae_model.intercepts_],
             "mean": ae_mean.astype(np.float32).tolist(),
             "std": ae_std.astype(np.float32).tolist(),
+            "feature_mean": ae_mean.astype(np.float32).tolist(),
+            "feature_std": ae_std.astype(np.float32).tolist(),
             "threshold": ae_threshold,
             "feature_order": ae_feature_order,
         }
@@ -2809,6 +2815,8 @@ def train(
             "last_event_id": int(last_event_id),
             "mean": feature_mean.astype(np.float32).tolist(),
             "std": feature_std.astype(np.float32).tolist(),
+            "feature_mean": feature_mean.astype(np.float32).tolist(),
+            "feature_std": feature_std.astype(np.float32).tolist(),
             "mode": mode,
             "class_weight": class_weight or "none",
             "train_accuracy": float("nan"),
@@ -2989,6 +2997,8 @@ def train(
             "last_event_id": int(last_event_id),
             "mean": feature_mean.astype(np.float32).tolist(),
             "std": feature_std.astype(np.float32).tolist(),
+            "feature_mean": feature_mean.astype(np.float32).tolist(),
+            "feature_std": feature_std.astype(np.float32).tolist(),
             "hourly_thresholds": hourly_thresholds,
             "conformal_lower": conformal_lower,
             "conformal_upper": conformal_upper,
@@ -3730,6 +3740,8 @@ def train(
         "feature_importance": feature_importance,
         "mean": feature_mean.astype(np.float32).tolist(),
         "std": feature_std.astype(np.float32).tolist(),
+        "feature_mean": feature_mean.astype(np.float32).tolist(),
+        "feature_std": feature_std.astype(np.float32).tolist(),
     }
     model["split_sizes"] = split_sizes
     model["validation_metrics"] = {

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -1,4 +1,5 @@
 import json
+import re
 from pathlib import Path
 import sys
 import pytest
@@ -494,8 +495,8 @@ def test_generate_scaling_arrays(tmp_path: Path):
         "intercept": 0.0,
         "threshold": 0.5,
         "feature_names": ["hour"],
-        "mean": [12.0],
-        "std": [3.0],
+        "feature_mean": [12.0],
+        "feature_std": [3.0],
     }
     model_file = tmp_path / "model.json"
     with open(model_file, "w") as f:
@@ -508,8 +509,11 @@ def test_generate_scaling_arrays(tmp_path: Path):
     assert len(generated) == 1
     with open(generated[0]) as f:
         content = f.read()
-    assert "FeatureMean[]" in content
-    assert "FeatureStd[]" in content
+    m_mean = re.search(r"double FeatureMean\[] = {([^}]*)};", content)
+    m_std = re.search(r"double FeatureStd\[] = {([^}]*)};", content)
+    assert m_mean and m_std
+    assert m_mean.group(1) == "12"
+    assert m_std.group(1) == "3"
 
 
 def test_generate_account_features(tmp_path: Path):
@@ -716,8 +720,8 @@ def test_on_tick_logistic_inference(tmp_path: Path):
         "intercept": 0.05,
         "threshold": 0.6,
         "feature_names": ["hour", "spread"],
-        "mean": [12.0, 1.5],
-        "std": [3.0, 0.5],
+        "feature_mean": [12.0, 1.5],
+        "feature_std": [3.0, 0.5],
         "sl_coefficients": [0.2, 0.3],
         "sl_intercept": 0.01,
         "tp_coefficients": [0.4, 0.5],

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -297,8 +297,8 @@ def test_train(tmp_path: Path):
     assert "margin_level" in data.get("feature_names", [])
     assert data.get("weighted") is True
     assert data.get("weighted_by_net_profit") is True
-    assert "mean" in data
-    assert "std" in data
+    assert "feature_mean" in data
+    assert "feature_std" in data
     assert data.get("data_commit") == "abc123"
     assert data.get("data_checksum") == checksum
 

--- a/tests/test_train_target_clone_features.py
+++ b/tests/test_train_target_clone_features.py
@@ -241,8 +241,8 @@ def test_model_serialization(tmp_path: Path):
     with open(model_file) as f:
         data = json.load(f)
     assert "feature_names" in data
-    assert "mean" in data
-    assert "std" in data
+    assert "feature_mean" in data
+    assert "feature_std" in data
     assert "threshold" in data
     assert "val_accuracy" in data
     assert "spread" in data.get("feature_names", [])


### PR DESCRIPTION
## Summary
- Persist `feature_mean` and `feature_std` alongside existing statistics during training
- Generate MQL4 source with `FeatureMean[]` and `FeatureStd[]` arrays and standardize features at runtime
- Exercise scaling round-trip with updated tests

## Testing
- `pytest tests/test_generate.py::test_generate_scaling_arrays tests/test_generate.py::test_on_tick_logistic_inference -q`
- `pytest` *(fails: ModuleNotFoundError: No module named 'opentelemetry')*


------
https://chatgpt.com/codex/tasks/task_e_68b5fc75e5b0832f9561a453e146098a