### PR TITLE
Queue gRPC batches and drop direct file logging

### DIFF
--- a/scripts/metrics_collector.py
+++ b/scripts/metrics_collector.py
@@ -338,7 +338,7 @@ def serve(
                 while True:
                     try:
                         size = 0
-                        for fn in ("pending_trades.wal", "pending_metrics.wal", "trades_raw.wal"):
+                        for fn in ("pending_trades.wal", "pending_metrics.wal"):
                             fp = wal_dir / fn
                             if fp.exists():
                                 size += fp.stat().st_size


### PR DESCRIPTION
## Summary
- Route trade/metric events through an in-memory queue instead of writing CSVs directly
- Batch transmit queued payloads on timer ticks with retry/backoff and WAL persistence
- Trim metrics collector to monitor remaining WAL files only

## Testing
- `pytest tests/test_metric_wal_replay.py tests/test_logging_basic.py tests/test_upload_logs.py -q` *(fails: ModuleNotFoundError: No module named 'scripts.socket_log_service'; No module named 'opentelemetry')*
- `pytest tests/test_metric_wal_replay.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b609839c20832f95087f9b517fbd1f