### PR TITLE
Enable correlation and calendar feature support

### DIFF
--- a/scripts/detect_regime.py
+++ b/scripts/detect_regime.py
@@ -21,7 +21,7 @@ try:  # optional dependency
 except Exception:  # pragma: no cover - optional
     hdbscan = None
 
-from train_target_clone import _load_logs, _extract_features  # type: ignore
+from train_target_clone import _load_logs, _extract_features, _load_calendar  # type: ignore
 
 
 def detect_regimes(
@@ -31,6 +31,9 @@ def detect_regimes(
     algorithm: str = "kmeans",
     model_json: Optional[Path] = None,
     assignments_csv: Optional[Path] = None,
+    corr_map: dict[str, list[str]] | None = None,
+    calendar_events: list[tuple] | None = None,
+    event_window: float = 60.0,
 ) -> None:
     """Cluster feature vectors and write regime IDs and centers to ``out_file``.
 
@@ -50,7 +53,12 @@ def detect_regimes(
         that downstream utilities can embed them into generated strategies.
     """
     rows_df, _, _ = _load_logs(data_dir)
-    feats, *_ = _extract_features(rows_df.to_dict("records"))
+    feats, *_ = _extract_features(
+        rows_df.to_dict("records"),
+        corr_map=corr_map,
+        calendar_events=calendar_events,
+        event_window=event_window,
+    )
     if not feats:
         raise ValueError("No features found for clustering")
 
@@ -127,7 +135,22 @@ def main() -> None:
     )
     p.add_argument("--model-json", type=Path, default=Path("model.json"))
     p.add_argument("--assignments", type=Path, help="CSV file to write per-sample regime IDs")
+    p.add_argument("--corr-symbols", help="comma separated correlated symbol pairs e.g. EURUSD:USDCHF")
+    p.add_argument("--calendar-file", help="CSV file with columns time,impact[,id] for events")
+    p.add_argument("--event-window", type=float, default=60.0, help="minutes around events to flag")
     args = p.parse_args()
+    if args.corr_symbols:
+        corr_map = {}
+        for p_sym in args.corr_symbols.split(','):
+            if ':' in p_sym:
+                base, peer = p_sym.split(':', 1)
+                corr_map.setdefault(base, []).append(peer)
+    else:
+        corr_map = None
+    if args.calendar_file:
+        events = _load_calendar(Path(args.calendar_file))
+    else:
+        events = None
     detect_regimes(
         args.data_dir,
         args.out_file,
@@ -135,6 +158,9 @@ def main() -> None:
         args.algorithm,
         args.model_json,
         args.assignments,
+        corr_map=corr_map,
+        calendar_events=events,
+        event_window=args.event_window,
     )
 
 

--- a/scripts/generate_mql4_from_model.py
+++ b/scripts/generate_mql4_from_model.py
@@ -697,7 +697,7 @@ def generate(
                 sym2 = '_'.join(parts[1:])
                 return f'PairCorrelation("{sym1}", "{sym2}")'
             if len(parts) == 1:
-                return f'PairCorrelation("{parts[0]}")'
+                return f'PairCorrelation(SymbolToTrade, "{parts[0]}")'
         if fname.startswith('coint_residual_'):
             parts = fname[16:].split('_')
             if len(parts) >= 2:

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -439,6 +439,29 @@ def test_generate_ratio_feature(tmp_path: Path):
     assert 'iClose("EURUSD", 0, 0) / iClose("USDCHF", 0, 0)' in content
 
 
+def test_generate_corr_feature(tmp_path: Path):
+    model = {
+        "model_id": "corr",
+        "magic": 999,
+        "coefficients": [0.1],
+        "intercept": 0.0,
+        "threshold": 0.5,
+        "feature_names": ["corr_USDCHF"],
+    }
+    model_file = tmp_path / "model.json"
+    with open(model_file, "w") as f:
+        json.dump(model, f)
+
+    out_dir = tmp_path / "out"
+    generate(model_file, out_dir)
+
+    generated = list(out_dir.glob("Generated_corr_*.mq4"))
+    assert len(generated) == 1
+    with open(generated[0]) as f:
+        content = f.read()
+    assert 'PairCorrelation(SymbolToTrade, "USDCHF")' in content
+
+
 def test_generate_rl_fused(tmp_path: Path):
     model = {
         "model_id": "rl_fused",
@@ -690,10 +713,10 @@ def test_calendar_features(tmp_path: Path):
     model = {
         "model_id": "cal",
         "magic": 111,
-        "coefficients": [0.1, 0.2],
+        "coefficients": [0.1, 0.2, 0.3],
         "intercept": 0.0,
         "threshold": 0.5,
-        "feature_names": ["event_flag", "event_impact"],
+        "feature_names": ["event_flag", "event_impact", "calendar_event_id"],
         "calendar_events": [["2024-01-01T00:30:00", 1.0, 1]],
         "event_window": 60.0,
     }
@@ -710,6 +733,7 @@ def test_calendar_features(tmp_path: Path):
         content = f.read()
     assert "CalendarFlag()" in content
     assert "CalendarImpact()" in content
+    assert "CalendarEventId()" in content
 
 
 def test_on_tick_logistic_inference(tmp_path: Path):


### PR DESCRIPTION
## Summary
- Default `_extract_features` populates correlation and calendar signals
- Expose `--corr-symbols` and `--calendar-file` flags for regime scripts
- Generate MQL4 code for correlated price features

## Testing
- `pytest tests/test_generate.py::test_calendar_features tests/test_generate.py::test_generate_corr_feature -q`
- `pytest tests/test_generate.py::test_calendar_features tests/test_generate.py::test_generate_corr_feature tests/test_train.py::test_corr_features tests/test_train_target_clone_features.py::test_feature_extraction_basic -q` *(fails: No module named 'pyarrow')*


------
https://chatgpt.com/codex/tasks/task_e_68b610b594dc832f9e449eb0bf2d1135