### PR TITLE
Integrate uncertain decision feedback into retraining

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,7 +460,7 @@ The calculated drift metric is saved into ``model.json`` for audit purposes.
 Example cron job running every 15 minutes:
 
 ```cron
-*/15 * * * * /path/to/BotCopier/scripts/auto_retrain.py --log-dir /path/to/observer_logs --out-dir /path/to/BotCopier/models --files-dir /path/to/MT4/MQL4/Files --win-rate-threshold 0.4 --drawdown-threshold 0.2 --baseline-file baseline.csv --recent-file recent.csv --drift-threshold 0.2
+*/15 * * * * /path/to/BotCopier/scripts/auto_retrain.py --log-dir /path/to/observer_logs --out-dir /path/to/BotCopier/models --files-dir /path/to/MT4/MQL4/Files --win-rate-threshold 0.4 --drawdown-threshold 0.2 --baseline-file baseline.csv --recent-file recent.csv --drift-threshold 0.2 --uncertain-file /path/to/observer_logs/uncertain_decisions_labeled.csv --uncertain-weight 3.0
 ```
 
 Example systemd service and timer:
@@ -472,7 +472,7 @@ Description=BotCopier auto retrain
 
 [Service]
 Type=simple
-ExecStart=/usr/bin/python /path/to/BotCopier/scripts/auto_retrain.py --log-dir /path/to/observer_logs --out-dir /path/to/BotCopier/models --files-dir /path/to/MT4/MQL4/Files --win-rate-threshold 0.4 --drawdown-threshold 0.2
+ExecStart=/usr/bin/python /path/to/BotCopier/scripts/auto_retrain.py --log-dir /path/to/observer_logs --out-dir /path/to/BotCopier/models --files-dir /path/to/MT4/MQL4/Files --win-rate-threshold 0.4 --drawdown-threshold 0.2 --uncertain-file /path/to/observer_logs/uncertain_decisions_labeled.csv --uncertain-weight 3.0
 ```
 
 ```ini

--- a/docs/README.md
+++ b/docs/README.md
@@ -103,6 +103,10 @@ script multiplies the weight of these rows (configurable with
 ``--uncertain-weight``) so the newly labeled examples influence the next model
 more heavily.
 
+To continuously fold this feedback into the live model,
+``scripts/auto_retrain.py`` accepts matching ``--uncertain-file`` and
+``--uncertain-weight`` options and can be scheduled via cron or systemd.
+
 This loop—log uncertain decisions, label them and retrain—provides a lightweight
 form of active learning that incrementally improves the strategy where it
 previously hesitated.

--- a/experts/StrategyTemplate.mq4
+++ b/experts/StrategyTemplate.mq4
@@ -1318,7 +1318,7 @@ void LogDecision(double &feats[], double prob, string action, int modelIdx, int 
       FileFlush(DecisionLogHandle);
    }
    double thr = GetTradeThreshold();
-   bool uncertain = MathAbs(prob - thr) <= UncertaintyMargin;
+   bool uncertain = MathAbs(prob - thr) < UncertaintyMargin;
    if(uncertain && UncertainLogHandle != INVALID_HANDLE)
    {
       // capture feature snapshot for active learning


### PR DESCRIPTION
## Summary
- Only flag decisions as uncertain when probability is strictly within the `UncertaintyMargin`
- Allow auto-retrain to ingest labeled uncertain decisions with `--uncertain-file` and weighted via `--uncertain-weight`
- Document scheduling these options via cron or systemd

## Testing
- `pytest tests/test_auto_retrain.py`
- `pytest` *(fails: No module named 'pydantic', google.protobuf runtime version mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68b629508904832f8d6a2903045a3cdb