### PR TITLE
Ensure core book metrics always present and preserved through pruning

### DIFF
--- a/scripts/features.py
+++ b/scripts/features.py
@@ -435,10 +435,17 @@ def _extract_features(
             feat["dom_sin"] = dom_sin
             feat["dom_cos"] = dom_cos
 
+        bid_vol = float(r.get("book_bid_vol", 0) or 0)
+        ask_vol = float(r.get("book_ask_vol", 0) or 0)
+        imbalance = float(r.get("book_imbalance", 0) or 0)
+        feat.update(
+            {
+                "book_bid_vol": bid_vol,
+                "book_ask_vol": ask_vol,
+                "book_imbalance": imbalance,
+            }
+        )
         if use_orderbook:
-            bid_vol = float(r.get("book_bid_vol", 0) or 0)
-            ask_vol = float(r.get("book_ask_vol", 0) or 0)
-            imbalance = float(r.get("book_imbalance", 0) or 0)
             imbalance_history.append(imbalance)
             window = 5
             roll = sum(imbalance_history[-window:]) / min(len(imbalance_history), window)
@@ -446,9 +453,6 @@ def _extract_features(
             ratio = bid_vol / (ask_vol + 1e-9)
             feat.update(
                 {
-                    "book_bid_vol": bid_vol,
-                    "book_ask_vol": ask_vol,
-                    "book_imbalance": imbalance,
                     "book_spread": spread_vol,
                     "bid_ask_ratio": ratio,
                     "book_imbalance_roll": roll,

--- a/scripts/generate_mql4_from_model.py
+++ b/scripts/generate_mql4_from_model.py
@@ -22,6 +22,15 @@ from datetime import datetime
 from typing import Iterable, List, Union, Optional
 
 
+MANDATORY_FEATURES = {
+    "book_bid_vol",
+    "book_ask_vol",
+    "book_imbalance",
+    "equity",
+    "margin_level",
+}
+
+
 def _fmt(value: float) -> str:
     """Format floats for insertion into MQL4 code."""
     return f"{value:.6g}"
@@ -39,7 +48,7 @@ def _prune_model_features(model: dict) -> dict:
     fi = model.get("feature_importance")
     names = model.get("feature_names")
     if isinstance(fi, dict) and isinstance(names, list):
-        keep = [i for i, n in enumerate(names) if fi.get(n, 0.0) > 0.0]
+        keep = [i for i, n in enumerate(names) if fi.get(n, 0.0) > 0.0 or n in MANDATORY_FEATURES]
         if len(keep) != len(names):
             model["feature_names"] = [names[i] for i in keep]
             # Keep related arrays in sync when their lengths match the feature list
@@ -143,9 +152,6 @@ def _build_feature_cases(
     }
 
     if lite_mode:
-        feature_map['book_bid_vol'] = '0.0'
-        feature_map['book_ask_vol'] = '0.0'
-        feature_map['book_imbalance'] = '0.0'
         feature_map['book_spread'] = '0.0'
         feature_map['bid_ask_ratio'] = '0.0'
         feature_map['book_imbalance_roll'] = '0.0'

--- a/scripts/train_target_clone.py
+++ b/scripts/train_target_clone.py
@@ -108,6 +108,14 @@ from opentelemetry.trace import format_span_id, format_trace_id
 SCHEMA_VERSION = 3
 START_EVENT_ID = 0
 
+MANDATORY_FEATURES = {
+    "book_bid_vol",
+    "book_ask_vol",
+    "book_imbalance",
+    "equity",
+    "margin_level",
+}
+
 resource = Resource.create({"service.name": os.getenv("OTEL_SERVICE_NAME", "train_target_clone")})
 provider = TracerProvider(resource=resource)
 if endpoint := os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT"):
@@ -2954,7 +2962,11 @@ def train(
         feature_importance = {}
 
     if prune_threshold > 0.0 and feature_importance:
-        keep_idx = [i for i, name in enumerate(feature_names) if feature_importance.get(name, 0.0) >= prune_threshold]
+        keep_idx = [
+            i
+            for i, name in enumerate(feature_names)
+            if feature_importance.get(name, 0.0) >= prune_threshold or name in MANDATORY_FEATURES
+        ]
         removed_ratio = 1 - len(keep_idx) / len(feature_names)
         if removed_ratio > prune_warn:
             logging.warning("Pruning removed %.1f%% of features", removed_ratio * 100)

--- a/tests/test_features_module.py
+++ b/tests/test_features_module.py
@@ -33,3 +33,22 @@ def test_extract_features_basic():
     feats, labels, *_ = _extract_features(rows)
     assert len(feats) == 2
     assert labels.tolist() == [1, 0]
+
+
+def test_mandatory_features_present():
+    rows = [
+        {
+            "event_time": datetime(2024, 1, 1, 0, 0, 0),
+            "action": "OPEN",
+            "order_type": "0",
+            "symbol": "EURUSD",
+            "price": 1.1,
+            "sl": 1.0,
+            "tp": 1.2,
+            "lots": 0.1,
+            "profit": 1.0,
+        }
+    ]
+    feats, *_ = _extract_features(rows)
+    for key in ["book_bid_vol", "book_ask_vol", "book_imbalance", "equity", "margin_level"]:
+        assert key in feats[0]

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -818,6 +818,45 @@ def test_pruned_features_omitted(tmp_path: Path):
     assert "// spread" not in content
 
 
+def test_mandatory_features_not_pruned(tmp_path: Path):
+    model = {
+        "model_id": "mand",
+        "magic": 123,
+        "coefficients": [0.1, 0.2, 0.3, 0.4, 0.5, 0.6],
+        "intercept": 0.0,
+        "threshold": 0.5,
+        "feature_names": [
+            "hour",
+            "book_bid_vol",
+            "book_ask_vol",
+            "book_imbalance",
+            "equity",
+            "margin_level",
+        ],
+        "feature_importance": {
+            "hour": 0.3,
+            "book_bid_vol": 0.0,
+            "book_ask_vol": 0.0,
+            "book_imbalance": 0.0,
+            "equity": 0.0,
+            "margin_level": 0.0,
+        },
+    }
+    model_file = tmp_path / "model.json"
+    with open(model_file, "w") as f:
+        json.dump(model, f)
+    out_dir = tmp_path / "out"
+    generate(model_file, out_dir, lite_mode=True)
+    generated = list(out_dir.glob("Generated_mand_*.mq4"))
+    assert len(generated) == 1
+    content = generated[0].read_text()
+    assert "BookBidVol()" in content
+    assert "BookAskVol()" in content
+    assert "BookImbalance()" in content
+    assert "AccountEquity()" in content
+    assert "AccountMarginLevel()" in content
+
+
 def test_hashed_feature_alignment(tmp_path: Path):
     model = {
         "model_id": "hash",


### PR DESCRIPTION
## Summary
- Always populate book_bid_vol, book_ask_vol and book_imbalance along with equity and margin_level in feature dictionaries
- Preserve these core features during feature-importance pruning and map them to live runtime values even in lite mode
- Add regression tests for mandatory feature presence and pruning behaviour

## Testing
- `pytest tests/test_features_module.py tests/test_generate.py::test_pruned_features_omitted tests/test_generate.py::test_mandatory_features_not_pruned -q`

------
https://chatgpt.com/codex/tasks/task_e_68b62aaf97d8832f8b7825349952e5b1