### PR TITLE
Verify feature mappings during MQL4 generation

### DIFF
--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -250,6 +250,11 @@ def test_unknown_feature_raises(tmp_path: Path):
     out_dir = tmp_path / "out"
     with pytest.raises(ValueError, match="mystery_feature"):
         generate(model_file, out_dir)
+    generated = list(out_dir.glob("Generated_unknown_*.mq4"))
+    assert generated
+    content = generated[0].read_text()
+    assert "#error" in content
+    assert "mystery_feature" in content
 
 
 def test_news_sentiment_feature(tmp_path: Path):


### PR DESCRIPTION
## Summary
- ensure `generate_mql4_from_model.py` flags unknown features and raises after writing the generated MQ4
- add compile-time `#error` directives for unmapped features
- extend `lite_mode` to disable remaining order book features and test for unmapped feature failures

## Testing
- `pytest tests/test_generate.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b63936d508832f91d8e5324be7a7af