### PR TITLE
Track and log trade and metric retry counts separately

### DIFF
--- a/docs/grpc_pipeline.md
+++ b/docs/grpc_pipeline.md
@@ -20,8 +20,12 @@ appended to CSV files for downstream processing.
 (`pending_trades` and `pending_metrics`). `LogTrade` and `WriteMetrics`
 push messages into these buffers and the `OnTimer` handler periodically
 drains them via `GrpcSendTrade` and `GrpcSendMetrics`. Failed sends are
-retried with exponential backoff and the retry counters `trade_retry_count`
-and `metric_retry_count` are exported through `SerializeMetrics`.
+retried with exponential backoff. Separate counters
+`trade_retry_count` and `metric_retry_count` track consecutive failures
+for each stream, and an alert is printed when either exceeds
+`FallbackRetryThreshold`. Both counters are exported through
+`SerializeMetrics`, allowing monitoring to distinguish which stream is
+failing.
 
 The Python `scripts/metrics_collector.py` tool exposes these counters as
 Prometheus gauges and emits warnings when they grow, allowing operators to


### PR DESCRIPTION
## Summary
- maintain distinct retry counters for trade and metric streams
- log alerts when retry counters exceed `FallbackRetryThreshold`
- document monitoring of separate retry counters and alerts

## Testing
- `pytest tests/test_metric_wal_replay.py::test_metric_wal_replay tests/test_logging_basic.py::test_logging_roundtrip -q` *(fails: ModuleNotFoundError: No module named 'scripts.socket_log_service')*
- `pytest tests/test_metric_wal_replay.py::test_metric_wal_replay -q`


------
https://chatgpt.com/codex/tasks/task_e_68b63dbb4030832f9659e55a0641fb67