### PR TITLE
Add distributional RL evaluation stats and configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,6 +407,9 @@ available. Multi-step returns and prioritized replay can be enabled with
 ``--n-step`` and ``--replay-*`` options, and live metrics may be POSTed to a
 feedback service via ``--metrics-url`` for continual fine-tuning.
 
+Sample configurations using prioritized replay buffers are provided in
+``configs/prioritized_c51.json`` and ``configs/prioritized_qr_dqn.json``.
+
 ```bash
 pip install stable-baselines3 pandas
 python scripts/train_rl_agent.py --data-dir logs --out-dir models --start-model models/model.json --algo ppo --training-steps 1000

--- a/configs/prioritized_c51.json
+++ b/configs/prioritized_c51.json
@@ -1,0 +1,10 @@
+{
+  "data_dir": "logs",
+  "out_dir": "models",
+  "algo": "c51",
+  "training_steps": 10000,
+  "buffer_size": 5000,
+  "replay_alpha": 0.6,
+  "replay_beta": 0.4,
+  "n_step": 3
+}

--- a/configs/prioritized_qr_dqn.json
+++ b/configs/prioritized_qr_dqn.json
@@ -1,0 +1,10 @@
+{
+  "data_dir": "logs",
+  "out_dir": "models",
+  "algo": "qr_dqn",
+  "training_steps": 10000,
+  "buffer_size": 5000,
+  "replay_alpha": 0.6,
+  "replay_beta": 0.4,
+  "n_step": 3
+}

--- a/scripts/evaluate_predictions.py
+++ b/scripts/evaluate_predictions.py
@@ -53,6 +53,11 @@ def main() -> None:
         print(
             f"Probability coverage : {stats['conformal_coverage']*100:.1f}%"
         )
+        if "model_value_mean" in stats and "model_value_std" in stats:
+            print(
+                f"Model value mean : {stats['model_value_mean']:.2f}"
+                f" (std: {stats['model_value_std']:.2f})"
+            )
 
 
 if __name__ == "__main__":

--- a/scripts/train_rl_agent.py
+++ b/scripts/train_rl_agent.py
@@ -972,6 +972,17 @@ def main() -> None:
         p.add_argument(
             "--algo",
             default="dqn",
+            choices=[
+                "dqn",
+                "ppo",
+                "a2c",
+                "ddpg",
+                "c51",
+                "qr_dqn",
+                "qlearn",
+                "cql",
+                "decision_transformer",
+            ],
             help=(
                 "RL algorithm: dqn (default), ppo, a2c, ddpg, c51, qr_dqn, qlearn, cql, or "
                 "decision_transformer (requires transformers)."

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -1,4 +1,5 @@
 import csv
+import json
 from pathlib import Path
 import sys
 
@@ -39,7 +40,17 @@ def test_evaluate(tmp_path: Path):
     _write_prediction(pred_file, "2024.01.01 00:00:00")
     _write_actual(log_file, "2024.01.01 00:00:05", "2024.01.01 00:01:00")
 
-    stats = evaluate(pred_file, log_file, window=60)
+    model_file = tmp_path / "model.json"
+    model_info = {
+        "value_mean": 1.0,
+        "value_std": 0.5,
+        "value_atoms": [-1, 1],
+        "value_distribution": [0.4, 0.6],
+    }
+    with open(model_file, "w") as f:
+        json.dump(model_info, f)
+
+    stats = evaluate(pred_file, log_file, window=60, model_json=model_file)
 
     assert stats["matched_events"] == 1
     assert stats["predicted_events"] == 1
@@ -53,6 +64,10 @@ def test_evaluate(tmp_path: Path):
     assert stats["expected_return"] == 10
     assert stats["downside_risk"] == 0
     assert stats["risk_reward"] == 10
+    assert stats["model_value_mean"] == model_info["value_mean"]
+    assert stats["model_value_std"] == model_info["value_std"]
+    assert stats["model_value_atoms"] == model_info["value_atoms"]
+    assert stats["model_value_distribution"] == model_info["value_distribution"]
 
 
 def test_direction_mapping(tmp_path: Path):


### PR DESCRIPTION
## Summary
- Allow `train_rl_agent.py` to accept distributional algorithms `c51` and `qr_dqn` via argparse choices
- Record and expose value distribution statistics in evaluation reports and CLI output
- Add sample prioritized replay buffer configurations and document their usage

## Testing
- `pytest tests/test_evaluate.py::test_evaluate -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'ruptures', pydantic, grpc, uvicorn, opentelemetry.exporter, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b6403bc9e0832fa7fb5c4582cd3876