### PR TITLE
Normalize order book volumes

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -27,7 +27,7 @@ Downstream components read these flags to stay in sync:
 When order‑book logging is active the trainer derives additional features:
 ``book_spread`` (ask minus bid volume), ``bid_ask_ratio`` and a rolling
 ``book_imbalance_roll`` averaged over the last five updates. These complement
-the raw ``book_bid_vol``, ``book_ask_vol`` and ``book_imbalance`` inputs
+the normalised ``book_bid_vol``, ``book_ask_vol`` and ``book_imbalance`` inputs
 extracted from the Observer EA.
 
 This metadata is persisted in ``model.json`` so that models trained on one

--- a/experts/StrategyTemplate.mq4
+++ b/experts/StrategyTemplate.mq4
@@ -755,11 +755,21 @@ void RefreshBookCache()
                ask += book[i].volume;
          }
       }
-      CachedBookBidVol = bid;
-      CachedBookAskVol = ask;
-      CachedBookImbalance = (bid+ask>0) ? (bid-ask)/(bid+ask) : 0.0;
-      CachedBookSpread = ask - bid;
-      CachedBidAskRatio = (ask>0) ? bid/ask : 0.0;
+      double total = bid + ask;
+      if(total > 0)
+      {
+         CachedBookBidVol = bid / total;
+         CachedBookAskVol = ask / total;
+         CachedBookImbalance = (bid - ask) / total;
+      }
+      else
+      {
+         CachedBookBidVol = 0.0;
+         CachedBookAskVol = 0.0;
+         CachedBookImbalance = 0.0;
+      }
+      CachedBookSpread = CachedBookAskVol - CachedBookBidVol;
+      CachedBidAskRatio = (CachedBookAskVol>0) ? CachedBookBidVol/CachedBookAskVol : 0.0;
       BookImbalanceHist[BookImbPos] = CachedBookImbalance;
       BookImbPos = (BookImbPos + 1) % 5;
       if(BookImbCount < 5) BookImbCount++;

--- a/scripts/features.py
+++ b/scripts/features.py
@@ -435,9 +435,17 @@ def _extract_features(
             feat["dom_sin"] = dom_sin
             feat["dom_cos"] = dom_cos
 
-        bid_vol = float(r.get("book_bid_vol", 0) or 0)
-        ask_vol = float(r.get("book_ask_vol", 0) or 0)
-        imbalance = float(r.get("book_imbalance", 0) or 0)
+        bid_vol_raw = float(r.get("book_bid_vol", 0) or 0)
+        ask_vol_raw = float(r.get("book_ask_vol", 0) or 0)
+        total_vol = bid_vol_raw + ask_vol_raw
+        if total_vol > 0:
+            bid_vol = bid_vol_raw / total_vol
+            ask_vol = ask_vol_raw / total_vol
+            imbalance = (bid_vol - ask_vol)
+        else:
+            bid_vol = 0.0
+            ask_vol = 0.0
+            imbalance = 0.0
         feat.update(
             {
                 "book_bid_vol": bid_vol,

--- a/tests/test_train_target_clone_features.py
+++ b/tests/test_train_target_clone_features.py
@@ -289,7 +289,7 @@ def test_orderbook_feature_extraction():
 
     feats, *_ = _extract_features(rows, use_orderbook=True)
     first, second = feats
-    assert first["book_spread"] == pytest.approx(1.0)
+    assert first["book_spread"] == pytest.approx(0.2)
     assert first["bid_ask_ratio"] == pytest.approx(2.0 / 3.0)
     assert first["book_imbalance_roll"] == pytest.approx(first["book_imbalance"])
     expected_roll = (first["book_imbalance"] + second["book_imbalance"]) / 2.0


### PR DESCRIPTION
## Summary
- Normalize order book bid/ask volumes when extracting features
- Apply the same normalization in StrategyTemplate.mq4 so EA inputs match training
- Document normalized order-book fields and adjust unit test expectations

## Testing
- `pytest tests/test_features_module.py`
- `pytest tests/test_train_target_clone_features.py -k orderbook_feature_extraction`
- `python - <<'PY'
import json
with open('sample_model.json') as f:
    data = json.load(f)
fi = sorted(data['feature_importance'].items(), key=lambda x: x[1], reverse=True)
print(fi)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68b665768fc0832f8f22ec35bb41f2e5