### PR TITLE
Add calendar impact feature and log order-book volumes

### DIFF
--- a/experts/Observer_TBot.mq4
+++ b/experts/Observer_TBot.mq4
@@ -1184,26 +1184,22 @@ void OnTradeTransaction(const MqlTradeTransaction &trans,
 
    if(entry==DEAL_ENTRY_IN || entry==DEAL_ENTRY_INOUT)
    {
-      double bid_vol, ask_vol, book_imb;
-      GetBookVolumes(symbol, bid_vol, ask_vol, book_imb);
       int event_id = NextEventId++;
       LogTrade(event_id, "OPEN", ticket, magic, "mt4", symbol, order_type,
                lots, price, req.price, sl, tp, 0.0, profit_after,
                remaining, now, comment, iVolume(symbol, 0, 0), 0,
-               bid_vol, ask_vol, book_imb, slippage, equity, margin, risk_weight);
+               slippage, equity, margin, risk_weight);
       SetTicketState(ticket, STATE_OPEN);
       if(entry==DEAL_ENTRY_INOUT && remaining>0.0 && OrderSelect(ticket, SELECT_BY_TICKET, MODE_TRADES))
       {
          double cur_price = OrderOpenPrice();
          double cur_sl    = OrderStopLoss();
          double cur_tp    = OrderTakeProfit();
-         double bid_vol2, ask_vol2, book_imb2;
-         GetBookVolumes(symbol, bid_vol2, ask_vol2, book_imb2);
          event_id = NextEventId++;
          LogTrade(event_id, "MODIFY", ticket, magic, "mt4", symbol, order_type,
                   0.0, cur_price, cur_price, cur_sl, cur_tp, 0.0, profit_after,
                   remaining, now, comment, iVolume(symbol, 0, 0), 0,
-                  bid_vol2, ask_vol2, book_imb2, slippage, equity, margin, risk_weight);
+                  slippage, equity, margin, risk_weight);
          SetTicketState(ticket, STATE_MODIFY);
       }
    }
@@ -1214,13 +1210,11 @@ void OnTradeTransaction(const MqlTradeTransaction &trans,
          open_time = OrderOpenTime();
       else if(OrderSelect(ticket, SELECT_BY_TICKET, MODE_TRADES))
          open_time = OrderOpenTime();
-      double bid_vol3, ask_vol3, book_imb3;
-      GetBookVolumes(symbol, bid_vol3, ask_vol3, book_imb3);
       int event_id = NextEventId++;
       LogTrade(event_id, "CLOSE", ticket, magic, "mt4", symbol, order_type,
                lots, price, req.price, sl, tp, profit, profit_after,
                remaining, now, comment, iVolume(symbol, 0, 0), open_time,
-               bid_vol3, ask_vol3, book_imb3, slippage, equity, margin, risk_weight);
+               slippage, equity, margin, risk_weight);
       SetTicketState(ticket, STATE_CLOSE);
       if(remaining==0.0)
          RemoveTicket(ticket);
@@ -1229,13 +1223,11 @@ void OnTradeTransaction(const MqlTradeTransaction &trans,
          double cur_price = OrderOpenPrice();
          double cur_sl    = OrderStopLoss();
          double cur_tp    = OrderTakeProfit();
-         double bid_vol4, ask_vol4, book_imb4;
-         GetBookVolumes(symbol, bid_vol4, ask_vol4, book_imb4);
          event_id = NextEventId++;
          LogTrade(event_id, "MODIFY", ticket, magic, "mt4", symbol, order_type,
                   0.0, cur_price, cur_price, cur_sl, cur_tp, 0.0, profit_after,
                   remaining, now, comment, iVolume(symbol, 0, 0), 0,
-                  bid_vol4, ask_vol4, book_imb4, slippage, equity, margin, risk_weight);
+                  slippage, equity, margin, risk_weight);
          SetTicketState(ticket, STATE_MODIFY);
       }
    }
@@ -1422,10 +1414,11 @@ void LogTrade(int event_id, string action, int ticket, int magic, string source,
               double req_price, double sl, double tp, double profit,
               double profit_after, double remaining, datetime time_event,
               string comment, double volume, datetime open_time,
-              double book_bid_vol, double book_ask_vol, double book_imbalance,
               double slippage, double equity, double margin_level,
               double risk_weight)
   {
+   double book_bid_vol, book_ask_vol, book_imbalance;
+   GetBookVolumes(symbol, book_bid_vol, book_ask_vol, book_imbalance);
    PendingTrade t;
    t.id = event_id;
    string trace_id = "";

--- a/scripts/generate_mql4_from_model.py
+++ b/scripts/generate_mql4_from_model.py
@@ -135,6 +135,7 @@ def _build_feature_cases(
         'volume': 'iVolume(SymbolToTrade, 0, 0)',
         'event_flag': 'CalendarFlag()',
         'event_impact': 'CalendarImpact()',
+        'calendar_impact': 'CalendarImpact()',
         'calendar_event_id': 'CalendarEventIdAt(TimeCurrent())',
         'book_bid_vol': 'BookBidVol()',
         'book_ask_vol': 'BookAskVol()',
@@ -168,6 +169,7 @@ def _build_feature_cases(
         'dom_sin': 'time',
         'dom_cos': 'time',
         'duration_sec': 'time',
+        'calendar_impact': 'time',
         # order-book features
         'book_bid_vol': 'order-book',
         'book_ask_vol': 'order-book',

--- a/scripts/train_target_clone.py
+++ b/scripts/train_target_clone.py
@@ -114,6 +114,7 @@ MANDATORY_FEATURES = {
     "book_bid_vol",
     "book_ask_vol",
     "book_imbalance",
+    "calendar_impact",
     "equity",
     "margin_level",
 }
@@ -779,6 +780,7 @@ def _train_lite_mode(
         if not f_chunk:
             continue
         for f in f_chunk:
+            f["calendar_impact"] = f.get("event_flag", 0.0) * f.get("event_impact", 0.0)
             feature_names_set.update(f.keys())
         if vec_reg is not None and f_chunk:
             Xr = vec_reg.transform(f_chunk)
@@ -1168,6 +1170,8 @@ def train(
                 symbol_graph=graph_params,
                 poly_degree=poly_degree,
             )
+            for f in f_chunk:
+                f["calendar_impact"] = f.get("event_flag", 0.0) * f.get("event_impact", 0.0)
             features.extend(f_chunk)
             labels_list.append(l_chunk)
             sl_list.append(sl_chunk)

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -891,3 +891,24 @@ def test_hashed_feature_alignment(tmp_path: Path):
     idx_spread = int(np.flatnonzero(vec_spread)[0])
     assert f"case {idx_hour}:" in content
     assert f"case {idx_spread}:" in content
+
+
+def test_calendar_and_book_features(tmp_path: Path):
+    model = {
+        "model_id": "calbook",
+        "magic": 321,
+        "coefficients": [0.1, 0.2],
+        "intercept": 0.0,
+        "threshold": 0.5,
+        "feature_names": ["calendar_impact", "book_imbalance"],
+    }
+    model_file = tmp_path / "model.json"
+    with open(model_file, "w") as f:
+        json.dump(model, f)
+    out_dir = tmp_path / "out"
+    generate(model_file, out_dir)
+    generated = list(out_dir.glob("Generated_calbook_*.mq4"))
+    assert len(generated) == 1
+    content = generated[0].read_text()
+    assert "CalendarImpact()" in content
+    assert "BookImbalance()" in content

--- a/tests/test_train_target_clone_features.py
+++ b/tests/test_train_target_clone_features.py
@@ -4,6 +4,7 @@ import sys
 from pathlib import Path
 from datetime import datetime
 import logging
+import shutil
 
 import pytest
 
@@ -233,6 +234,7 @@ def test_model_serialization(tmp_path: Path):
     out_dir = tmp_path / "out"
     data_dir.mkdir()
     _write_sample_log(data_dir / "trades_sample.csv")
+    shutil.copy(Path(__file__).parent / "sample_calendar.csv", data_dir / "calendar.csv")
 
     train(data_dir, out_dir, use_orderbook=True)
 
@@ -250,6 +252,8 @@ def test_model_serialization(tmp_path: Path):
     assert "book_spread" in data.get("feature_names", [])
     assert "bid_ask_ratio" in data.get("feature_names", [])
     assert "book_imbalance_roll" in data.get("feature_names", [])
+    assert "book_imbalance" in data.get("feature_names", [])
+    assert "calendar_impact" in data.get("feature_names", [])
     assert data.get("weighted_by_net_profit") is True
 
 


### PR DESCRIPTION
## Summary
- parse calendar.csv and append `calendar_impact` feature to trade vectors
- log book bid/ask volumes directly in `LogTrade` and map new feature in EA generator
- extend unit tests for calendar and order-book feature emission

## Testing
- `pytest tests/test_train_target_clone_features.py::test_model_serialization tests/test_generate.py::test_calendar_and_book_features -q`

------
https://chatgpt.com/codex/tasks/task_e_68b66a7b6270832fa3c1e36aa1dd9533