### PR TITLE
Use Arrow Flight with schema validation and WAL fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,14 +162,14 @@ A small web dashboard can display trades, metrics and training progress in real 
 
 ### Arrow Flight Logging
 
-`Observer_TBot` streams trade and metric events over [Apache Arrow Flight](https://arrow.apache.org/).
-Start the in-memory server and point clients to it:
+`Observer_TBot` streams trade and metric events over [Apache Arrow Flight](https://arrow.apache.org/) using schemas defined in `schemas/trades.py` and `schemas/metrics.py`. The EA falls back to a write‑ahead log when the Flight server is unavailable. Start the in-memory server and point clients to it:
 
 ```bash
 python scripts/flight_server.py
+python scripts/stream_listener.py --flight-host 127.0.0.1 --flight-port 8815
 ```
 
-`train_target_clone.py` accepts `--flight-uri` (defaulting to `$FLIGHT_URI`) and the dashboard pre-loads data when `FLIGHT_URI` is set.
+`stream_listener.py` validates each incoming record batch against the schema and appends it to a local Parquet dataset under `$FLIGHT_DATA_DIR` (default `data/`). `train_target_clone.py` accepts `--flight-uri` (defaulting to `$FLIGHT_URI`) and the dashboard pre-loads data when `FLIGHT_URI` is set.
 
 #### Latency Benchmark
 

--- a/schemas/metrics.py
+++ b/schemas/metrics.py
@@ -39,3 +39,5 @@ METRIC_SCHEMA = pa.schema([
     ("socket_errors", pa.int32()),
     ("book_refresh_seconds", pa.int32()),
 ])
+
+__all__ = ["MetricEvent", "METRIC_SCHEMA"]

--- a/schemas/trades.py
+++ b/schemas/trades.py
@@ -72,3 +72,5 @@ TRADE_SCHEMA = pa.schema([
     ("exit_reason", pa.string()),
     ("duration_sec", pa.int32()),
 ])
+
+__all__ = ["TradeEvent", "TRADE_SCHEMA"]

--- a/tests/test_flight_server.py
+++ b/tests/test_flight_server.py
@@ -72,6 +72,9 @@ def test_flight_server_roundtrip():
         pa.array([0.0]),
         pa.array([0.0]),
         pa.array([0]),
+        pa.array([0]),  # decision_id
+        pa.array([""]),  # exit_reason
+        pa.array([0]),  # duration_sec
     ], schema=TRADE_SCHEMA)
     t_writer, t_reader = client.do_put(t_desc, TRADE_SCHEMA)
 

--- a/tests/test_stream_listener_schema_persist.py
+++ b/tests/test_stream_listener_schema_persist.py
@@ -1,0 +1,46 @@
+import logging
+from pathlib import Path
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+from scripts import stream_listener as sl
+
+
+def _metric_table():
+    return pa.table(
+        [
+            pa.array([1], type=pa.int32()),
+            pa.array(["2024-01-01T00:00:00"]),
+            pa.array([1], type=pa.int32()),
+            pa.array([0.5], type=pa.float64()),
+            pa.array([0.1], type=pa.float64()),
+            pa.array([10], type=pa.int32()),
+            pa.array([0.2], type=pa.float64()),
+            pa.array([1.0], type=pa.float64()),
+            pa.array([0], type=pa.int32()),
+            pa.array([0], type=pa.int32()),
+            pa.array([5], type=pa.int32()),
+        ],
+        schema=sl.METRIC_SCHEMA,
+    )
+
+
+def test_validate_and_persist_roundtrip(tmp_path):
+    table = _metric_table()
+    dest = tmp_path / "metrics"
+    assert sl.validate_and_persist(table, sl.METRIC_SCHEMA, dest)
+    files = list(dest.glob("*.parquet"))
+    assert files
+    loaded = pq.read_table(dest)
+    assert loaded.schema.equals(sl.METRIC_SCHEMA)
+    assert loaded.to_pylist()[0]["trade_count"] == 10
+
+
+def test_validate_and_persist_schema_mismatch(tmp_path, caplog):
+    table = pa.table({"x": pa.array([1])})
+    dest = tmp_path / "bad"
+    with caplog.at_level(logging.WARNING):
+        assert not sl.validate_and_persist(table, sl.METRIC_SCHEMA, dest)
+    assert not dest.exists()
+    assert "schema mismatch" in caplog.text


### PR DESCRIPTION
## Summary
- expose Arrow schemas for trade and metric events
- send observer events via Arrow Flight with WAL fallback when the server is down
- validate Flight batches in `stream_listener.py` and persist them to Parquet
- document Flight setup and add tests for schema compliance

## Testing
- `pytest tests/test_stream_listener_schema_persist.py tests/test_stream_listener_validation.py tests/test_flight_server.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6716fa308832fb2c4fd6d08fff633