### PR TITLE
Refresh indicator cache in OnTick

### DIFF
--- a/experts/StrategyTemplate.mq4
+++ b/experts/StrategyTemplate.mq4
@@ -981,7 +981,6 @@ __FEATURE_CASES__      default:
 
 double GetFeature(int index)
 {
-   RefreshIndicatorCache();
    if(index >= 0 && index < ArraySize(CachedFeatures))
       return(CachedFeatures[index]);
    return(0.0);
@@ -1544,6 +1543,7 @@ void OnTick()
 {
    if(Time[0] != LastFeatureTime)
       NeedsFeatureRefresh = true;
+   RefreshIndicatorCache();
    UpdateTickReturns();
    PollRegimeRing();
    UpdateKalman(iClose(SymbolToTrade, 0, 0));

--- a/tests/test_indicator_cache_refresh.py
+++ b/tests/test_indicator_cache_refresh.py
@@ -8,6 +8,9 @@ def test_strategy_template_has_refresh_flag():
     on_tick_idx = next(i for i, line in enumerate(content) if "void OnTick()" in line)
     assert any("if(Time[0] != LastFeatureTime)" in line for line in content[on_tick_idx:on_tick_idx + 5])
     assert any("NeedsFeatureRefresh = true;" in line for line in content[on_tick_idx:on_tick_idx + 10])
+    assert any("RefreshIndicatorCache();" in line for line in content[on_tick_idx:on_tick_idx + 10])
+    get_idx = next(i for i, line in enumerate(content) if "double GetFeature" in line)
+    assert not any("RefreshIndicatorCache" in line for line in content[get_idx:get_idx + 5])
     refresh_idx = next(i for i, line in enumerate(content) if "void RefreshIndicatorCache()" in line)
     assert any("if(!NeedsFeatureRefresh)" in line for line in content[refresh_idx:refresh_idx + 5])
 
@@ -19,6 +22,7 @@ def test_refresh_indicator_cache_once_per_bar():
             self.last_time = 0
             self.current_time = 0
             self.refresh_count = 0
+            self.cached = 0
 
         def RefreshIndicatorCache(self):
             if not self.needs_refresh:
@@ -26,15 +30,16 @@ def test_refresh_indicator_cache_once_per_bar():
             self.needs_refresh = False
             self.last_time = self.current_time
             self.refresh_count += 1
+            self.cached = self.refresh_count
 
         def GetFeature(self):
-            self.RefreshIndicatorCache()
-            return self.refresh_count
+            return self.cached
 
         def OnTick(self, t):
             self.current_time = t
             if t != self.last_time:
                 self.needs_refresh = True
+            self.RefreshIndicatorCache()
 
     s = Dummy()
     s.OnTick(1)


### PR DESCRIPTION
## Summary
- Refresh indicators at the beginning of each `OnTick` call
- Simplify `GetFeature` to return cached features without triggering refresh
- Adjust unit tests for new cache refresh behavior

## Testing
- `pytest tests/test_indicator_cache_refresh.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b678524e7c832f9e1ade016871dc3c