### PR TITLE
feat: track flush and network latencies in metrics

### DIFF
--- a/dashboard/static/index.html
+++ b/dashboard/static/index.html
@@ -19,12 +19,27 @@
         const ctx = document.getElementById('metricsChart').getContext('2d');
         const metricsChart = new Chart(ctx, {
             type: 'line',
-            data: { labels: [], datasets: [{ label: 'Win Rate', data: [] }] },
+            data: {
+                labels: [],
+                datasets: [
+                    { label: 'Win Rate', data: [], yAxisID: 'y' },
+                    { label: 'Flush Latency (ms)', data: [], yAxisID: 'y1' },
+                    { label: 'Network Latency (ms)', data: [], yAxisID: 'y1' }
+                ]
+            },
+            options: {
+                scales: {
+                    y: { type: 'linear', position: 'left' },
+                    y1: { type: 'linear', position: 'right', grid: { drawOnChartArea: false } }
+                }
+            }
         });
 
         function updateChart(metric) {
             metricsChart.data.labels.push(metric.time);
             metricsChart.data.datasets[0].data.push(metric.win_rate);
+            metricsChart.data.datasets[1].data.push(metric.flush_latency_ms);
+            metricsChart.data.datasets[2].data.push(metric.network_latency_ms);
             metricsChart.update();
         }
 

--- a/scripts/metrics_collector.py
+++ b/scripts/metrics_collector.py
@@ -77,6 +77,8 @@ FIELDS = [
     "file_write_errors",
     "socket_errors",
     "cpu_load",
+    "flush_latency_ms",
+    "network_latency_ms",
     "book_refresh_seconds",
     "var_breach_count",
     "trade_queue_depth",
@@ -286,6 +288,10 @@ def serve(
                 "Fallback logging event count",
             )
             cpu_load_g = Gauge("bot_cpu_load", "CPU load")
+            flush_latency_g = Gauge("bot_flush_latency_ms", "Log flush latency in ms")
+            network_latency_g = Gauge(
+                "bot_network_latency_ms", "Network send latency in ms"
+            )
             book_refresh_g = Gauge(
                 "bot_book_refresh_seconds",
                 "Cached book refresh interval",
@@ -375,6 +381,16 @@ def serve(
                 if (v := row.get("cpu_load")) is not None:
                     try:
                         cpu_load_g.set(float(v))
+                    except (TypeError, ValueError):
+                        pass
+                if (v := row.get("flush_latency_ms")) is not None:
+                    try:
+                        flush_latency_g.set(float(v))
+                    except (TypeError, ValueError):
+                        pass
+                if (v := row.get("network_latency_ms")) is not None:
+                    try:
+                        network_latency_g.set(float(v))
                     except (TypeError, ValueError):
                         pass
                 if (v := row.get("book_refresh_seconds")) is not None:


### PR DESCRIPTION
## Summary
- track log flushing and network send times in Observer_TBot and serialize as `flush_latency_ms` and `network_latency_ms`
- collect and expose new latency metrics via metrics_collector and Prometheus
- plot flush and network latencies in dashboard

## Testing
- `python -m py_compile scripts/metrics_collector.py`
- `pytest tests/test_metric_wal_replay.py`

------
https://chatgpt.com/codex/tasks/task_e_68b679e8c83c832f9ec4e46b5ebc2af8