### PR TITLE
Queue anomaly evaluations asynchronously

### DIFF
--- a/docs/grpc_pipeline.md
+++ b/docs/grpc_pipeline.md
@@ -27,6 +27,10 @@ for each stream, and an alert is printed when either exceeds
 `SerializeMetrics`, allowing monitoring to distinguish which stream is
 failing.
 
+`anomaly_timeout_count` and `anomaly_retry_count` expose delays in anomaly
+evaluation so operators can track missing or slow responses from the
+background worker.
+
 The Python `scripts/metrics_collector.py` tool exposes these counters as
 Prometheus gauges and emits warnings when they grow, allowing operators to
 alert on gRPC backpressure or outages.


### PR DESCRIPTION
## Summary
- Queue anomaly feature vectors to files and poll results instead of synchronous WebRequests
- Track anomaly timeout and retry counters and export them via WriteMetrics
- Document new anomaly monitoring metrics

## Testing
- `pytest tests/test_logging_basic.py tests/test_shm_ring.py -q` *(fails: No module named 'scripts.socket_log_service')*
- `pytest tests/test_shm_ring.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b67d33df98832f8997a18ca29b79b7