### PR TITLE
feat: monitor drift and trigger retrain

### DIFF
--- a/model.json
+++ b/model.json
@@ -19,6 +19,10 @@
   "training_mode": "lite",
   "mode": "lite",
   "drift_metric": 0.0,
+  "drift_metrics": {
+    "psi": 0.0,
+    "ks": 0.0
+  },
   "drift_history": [],
   "retrain_history": [],
   "labeled_uncertainties": 0,


### PR DESCRIPTION
## Summary
- compute PSI and KS drift metrics across recent vs baseline feature logs
- trigger auto_retrain when drift exceeds threshold and update model.json with metrics and retrain history

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68b797497688832fa95160f972a4ba8a