### PR TITLE
feat: stream decisions via arrow flight

### DIFF
--- a/schemas/__init__.py
+++ b/schemas/__init__.py
@@ -1,20 +1,25 @@
-"""Arrow and Avro schemas for trade and metric records."""
+"""Arrow and Avro schemas for trade, metric and decision records."""
 
 from pathlib import Path
 import json
 
 from .trades import TRADE_SCHEMA
 from .metrics import METRIC_SCHEMA
+from .decisions import DECISION_SCHEMA
 
 SCHEMA_DIR = Path(__file__).resolve().parent
 with (SCHEMA_DIR / "trade.avsc").open() as f:
     TRADE_AVRO_SCHEMA = json.load(f)
 with (SCHEMA_DIR / "metric.avsc").open() as f:
     METRIC_AVRO_SCHEMA = json.load(f)
+with (SCHEMA_DIR / "decision.avsc").open() as f:
+    DECISION_AVRO_SCHEMA = json.load(f)
 
 __all__ = [
     "TRADE_SCHEMA",
     "METRIC_SCHEMA",
+    "DECISION_SCHEMA",
     "TRADE_AVRO_SCHEMA",
     "METRIC_AVRO_SCHEMA",
+    "DECISION_AVRO_SCHEMA",
 ]

--- a/schemas/decision.avsc
+++ b/schemas/decision.avsc
@@ -1,0 +1,25 @@
+{
+  "type": "record",
+  "name": "DecisionEvent",
+  "namespace": "bot",
+  "fields": [
+    {"name": "schema_version", "type": "int"},
+    {"name": "event_id", "type": "int"},
+    {"name": "timestamp", "type": "string"},
+    {"name": "model_version", "type": "string"},
+    {"name": "action", "type": "string"},
+    {"name": "probability", "type": "double"},
+    {"name": "sl_dist", "type": "double"},
+    {"name": "tp_dist", "type": "double"},
+    {"name": "model_idx", "type": "int"},
+    {"name": "regime", "type": "int"},
+    {"name": "chosen", "type": "int"},
+    {"name": "risk_weight", "type": "double"},
+    {"name": "variance", "type": "double"},
+    {"name": "lots_predicted", "type": "double"},
+    {"name": "executed_model_idx", "type": "int"},
+    {"name": "features", "type": "string"},
+    {"name": "trace_id", "type": "string", "default": ""},
+    {"name": "span_id", "type": "string", "default": ""}
+  ]
+}

--- a/schemas/decisions.py
+++ b/schemas/decisions.py
@@ -1,0 +1,57 @@
+"""Arrow and Pydantic schemas for decision events."""
+
+from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel
+import pyarrow as pa
+
+
+class DecisionEvent(BaseModel):
+    """Pydantic model describing a trading decision."""
+
+    schema_version: int
+    event_id: int
+    timestamp: datetime
+    model_version: str
+    action: str
+    probability: float
+    sl_dist: float
+    tp_dist: float
+    model_idx: int
+    regime: int
+    chosen: int
+    risk_weight: float
+    variance: float
+    lots_predicted: float
+    executed_model_idx: int
+    features: str
+    trace_id: Optional[str] = ""
+    span_id: Optional[str] = ""
+
+    class Config:
+        extra = "ignore"
+
+
+DECISION_SCHEMA = pa.schema([
+    ("schema_version", pa.int32()),
+    ("event_id", pa.int32()),
+    ("timestamp", pa.string()),
+    ("model_version", pa.string()),
+    ("action", pa.string()),
+    ("probability", pa.float64()),
+    ("sl_dist", pa.float64()),
+    ("tp_dist", pa.float64()),
+    ("model_idx", pa.int32()),
+    ("regime", pa.int32()),
+    ("chosen", pa.int32()),
+    ("risk_weight", pa.float64()),
+    ("variance", pa.float64()),
+    ("lots_predicted", pa.float64()),
+    ("executed_model_idx", pa.int32()),
+    ("features", pa.string()),
+    ("trace_id", pa.string()),
+    ("span_id", pa.string()),
+])
+
+__all__ = ["DecisionEvent", "DECISION_SCHEMA"]

--- a/scripts/flight_server.py
+++ b/scripts/flight_server.py
@@ -1,13 +1,14 @@
 #!/usr/bin/env python3
-"""Arrow Flight server exposing trade and metric streams.
+"""Arrow Flight server exposing trade, metric and decision streams.
 
 Incoming record batches are retained in memory for clients and mirrored
 to both SQLite databases and Parquet datasets.  A short summary of each
 batch is emitted via the standard :mod:`logging` framework which routes
-to journald when available. Two logical paths are served:
+to journald when available. Three logical paths are served:
 
 * ``trades``
 * ``metrics``
+* ``decisions``
 """
 
 from __future__ import annotations
@@ -22,7 +23,7 @@ import pyarrow as pa
 import pyarrow.flight as flight
 import pyarrow.parquet as pq
 
-from schemas import TRADE_SCHEMA, METRIC_SCHEMA
+from schemas import TRADE_SCHEMA, METRIC_SCHEMA, DECISION_SCHEMA
 
 try:  # prefer systemd journal if available
     from systemd.journal import JournalHandler
@@ -50,12 +51,17 @@ class FlightServer(flight.FlightServerBase):
         self._batches: Dict[str, List[pa.RecordBatch]] = {
             "trades": [],
             "metrics": [],
+            "decisions": [],
         }
         self._dir = Path(data_dir)
         self._dir.mkdir(parents=True, exist_ok=True)
         self._sqlite: Dict[str, sqlite3.Connection] = {}
         self._sqlite_sql: Dict[str, str] = {}
-        for name, schema in (("trades", TRADE_SCHEMA), ("metrics", METRIC_SCHEMA)):
+        for name, schema in (
+            ("trades", TRADE_SCHEMA),
+            ("metrics", METRIC_SCHEMA),
+            ("decisions", DECISION_SCHEMA),
+        ):
             conn = sqlite3.connect(self._dir / f"{name}.db", check_same_thread=False)
             cols = [f.name for f in schema]
             col_defs = ",".join(f"{c} TEXT" for c in cols)
@@ -69,9 +75,14 @@ class FlightServer(flight.FlightServerBase):
         self, context: flight.ServerCallContext, descriptor: flight.FlightDescriptor
     ) -> flight.FlightInfo:
         path = descriptor.path[0].decode()
-        if path not in ("trades", "metrics"):
+        if path not in ("trades", "metrics", "decisions"):
             raise KeyError(f"unknown path: {path}")
-        schema = TRADE_SCHEMA if path == "trades" else METRIC_SCHEMA
+        if path == "trades":
+            schema = TRADE_SCHEMA
+        elif path == "metrics":
+            schema = METRIC_SCHEMA
+        else:
+            schema = DECISION_SCHEMA
         ticket = flight.Ticket(path.encode())
         endpoint = flight.FlightEndpoint(ticket, [flight.Location.for_grpc_tcp(self._host, self.port)])
         return flight.FlightInfo(schema, descriptor, [endpoint], -1, -1)
@@ -85,10 +96,15 @@ class FlightServer(flight.FlightServerBase):
         writer: flight.ServerStreamWriter,
     ) -> None:
         path = descriptor.path[0].decode()
-        if path not in ("trades", "metrics"):
+        if path not in ("trades", "metrics", "decisions"):
             raise KeyError(f"unknown path: {path}")
         batches = self._batches.setdefault(path, [])
-        schema = TRADE_SCHEMA if path == "trades" else METRIC_SCHEMA
+        if path == "trades":
+            schema = TRADE_SCHEMA
+        elif path == "metrics":
+            schema = METRIC_SCHEMA
+        else:
+            schema = DECISION_SCHEMA
         for chunk in reader:
             batch = chunk.data
             batches.append(batch)
@@ -105,8 +121,10 @@ class FlightServer(flight.FlightServerBase):
             logger.info("stored %d %s rows", batch.num_rows, path)
             if path == "trades":
                 ack_id = batch.column("event_id")[batch.num_rows - 1].as_py()
-            else:
+            elif path == "metrics":
                 ack_id = batch.column("time")[batch.num_rows - 1].as_py()
+            else:
+                ack_id = batch.column("event_id")[batch.num_rows - 1].as_py()
             writer.write(pa.py_buffer(str(ack_id).encode()))
 
     # ------------------------------------------------------------------
@@ -114,9 +132,14 @@ class FlightServer(flight.FlightServerBase):
         self, context: flight.ServerCallContext, ticket: flight.Ticket
     ) -> flight.RecordBatchStream:
         path = ticket.ticket.decode()
-        if path not in ("trades", "metrics"):
+        if path not in ("trades", "metrics", "decisions"):
             raise KeyError(f"unknown path: {path}")
-        schema = TRADE_SCHEMA if path == "trades" else METRIC_SCHEMA
+        if path == "trades":
+            schema = TRADE_SCHEMA
+        elif path == "metrics":
+            schema = METRIC_SCHEMA
+        else:
+            schema = DECISION_SCHEMA
         table = pa.Table.from_batches(self._batches.get(path, []), schema=schema)
         return flight.RecordBatchStream(table)
 


### PR DESCRIPTION
## Summary
- send strategy decision logs to an Arrow Flight `decisions` stream
- expose and persist `decisions` batches in the Flight server
- ingest decision data in analytics tools and dashboard

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68b7c78caf50832f857cfc35cd22e1c2