### PR TITLE
feat: refresh risk parity weights from model

### DIFF
--- a/scripts/train_target_clone.py
+++ b/scripts/train_target_clone.py
@@ -3020,6 +3020,9 @@ def train(
                         model["risk_parity_weights"] = [float(rp[s]) for s in syms]
                         model["risk_covariance_symbols"] = syms
                         model["risk_covariance_matrix"] = cov.astype(float).tolist()
+                        sidecar = out_dir / "risk_weights.json"
+                        with open(sidecar, "w") as f:
+                            json.dump({"symbols": syms, "weights": [float(rp[s]) for s in syms]}, f)
             except Exception as exc:  # pragma: no cover - optional
                 logging.warning("risk parity computation failed: %s", exc)
     except Exception as exc:


### PR DESCRIPTION
## Summary
- compute symbol return covariance each train run and write sidecar risk weights
- reload risk parity weights in StrategyTemplate.mq4 on a timer
- log applied risk weight with each trade

## Testing
- `pytest` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68b8dc7e9bc8832f91087d56fb8a6cdd