### PR TITLE
Add symbol embedding features and expose in MQL4

### DIFF
--- a/experts/StrategyTemplate.mq4
+++ b/experts/StrategyTemplate.mq4
@@ -1111,6 +1111,7 @@ double GraphEmbedding(int idx)
 
 double SymbolEmbedding(int idx)
 {
+   // Lookup Node2Vec embedding for the active symbol
    for(int i=0; i<SymbolEmbCount; i++)
       if(SymbolEmbSymbols[i] == SymbolToTrade)
          if(idx >= 0 && idx < SymbolEmbDim)

--- a/scripts/generate_mql4_from_model.py
+++ b/scripts/generate_mql4_from_model.py
@@ -775,6 +775,12 @@ def generate(
     output = output.replace('__FEATURE_STD__', ', '.join(std_vec))
 
     emb_data = base.get('symbol_embeddings', {})
+    if not emb_data and symbol_graph:
+        try:
+            with open(symbol_graph) as f:
+                emb_data = json.load(f).get('embeddings', {})
+        except Exception:
+            emb_data = {}
     if emb_data:
         emb_symbols = list(emb_data.keys())
         emb_dim = len(next(iter(emb_data.values()), []))


### PR DESCRIPTION
## Summary
- append symbol Node2Vec embeddings in training features
- load symbol embeddings when generating MQL4 code
- document Node2Vec embedding lookup in StrategyTemplate

## Testing
- `pytest tests/test_train_target_clone_features.py tests/test_generate.py tests/test_graph_features.py -q` *(fails: ValueError: Cannot have number of splits n_splits=3 greater than the number of samples: n_samples=2.; UnboundLocalError: cannot access local variable 'train_proba_raw' where it is not associated with a value)*

------
https://chatgpt.com/codex/tasks/task_e_68b8efc637fc832fafff9f5b3bb551b3