### PR TITLE
Add half-life decay weighting CLI and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,8 @@ The EA records trade openings, closings and order modifications through the `OnT
    with the `feature_names` and `last_event_id`. When these match the existing
    model, subsequent runs reuse the cache and skip feature generation for faster
    reproducible training. Use the `--half-life-days` flag to weight recent trades
-   more heavily via an exponential decay (set to `0` to disable). The script also
+   more heavily via an exponential decay where each sample weight is
+   `0.5 ** (age_days / half_life_days)` (set to `0` to disable). The script also
    checks for class imbalance and fits `LogisticRegression` with
    `class_weight='balanced'` when necessary. The selected decay half-life and
    class-weighting strategy are stored in `model.json` so future training runs and online

--- a/tests/test_model_fitting_module.py
+++ b/tests/test_model_fitting_module.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from scripts.model_fitting import fit_logistic_regression
+from scripts.model_fitting import fit_logistic_regression, train_model
 
 
 def test_fit_logistic_regression():
@@ -9,3 +9,29 @@ def test_fit_logistic_regression():
     clf = fit_logistic_regression(X, y)
     preds = clf.predict(X)
     assert (preds == y).mean() >= 0.75
+
+
+def test_train_model_half_life_weights(tmp_path):
+    X = np.array([[0.0], [1.0], [2.0], [3.0]])
+    y = np.array([0, 0, 1, 1])
+    times = np.array(
+        [
+            "2024-01-01",
+            "2024-01-02",
+            "2024-01-03",
+            "2024-01-04",
+        ],
+        dtype="datetime64[s]",
+    )
+    model_long = train_model(X, y, times, tmp_path / "long", half_life_days=1000)
+    model_short = train_model(X, y, times, tmp_path / "short", half_life_days=0.5)
+
+    def _predict(model, x):
+        z = model["coefficients"][0] * x + model["intercept"]
+        return 1 / (1 + np.exp(-z))
+
+    proba_long = _predict(model_long, 3.0)
+    proba_short = _predict(model_short, 3.0)
+    assert proba_short > proba_long
+    assert model_short["half_life_days"] == 0.5
+    assert model_long["half_life_days"] == 1000


### PR DESCRIPTION
## Summary
- expose `--half-life-days` flag in `model_fitting.py` and apply exponential decay weights when fitting
- record chosen half-life and validation metrics in `model.json`
- document sample-weight decay in README and add regression test

## Testing
- `pytest tests/test_model_fitting_module.py tests/test_time_series_split_and_weighting.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b8f9936244832fb643445691976b3b