### PR TITLE
Add CVaR metric and dashboard support

### DIFF
--- a/docs/metrics_dashboard.json
+++ b/docs/metrics_dashboard.json
@@ -86,6 +86,14 @@
       "targets": [
         {"expr": "bot_fallback_events_total"}
       ]
+    },
+    {
+      "type": "timeseries",
+      "title": "CVaR",
+      "id": 11,
+      "targets": [
+        {"expr": "bot_cvar"}
+      ]
     }
   ]
 }

--- a/scripts/metrics_collector.py
+++ b/scripts/metrics_collector.py
@@ -74,6 +74,7 @@ FIELDS = [
     "sharpe",
     "sortino",
     "expectancy",
+    "cvar",
     "file_write_errors",
     "socket_errors",
     "cpu_load",
@@ -276,11 +277,12 @@ def serve(
             await prom_runner.setup()
             prom_site = web.TCPSite(prom_runner, http_host, prom_port)
             await prom_site.start()
-            win_rate_g = Gauge("bot_win_rate", "Win rate")
-            drawdown_g = Gauge("bot_drawdown", "Drawdown")
-            socket_err_c = Counter(
-                "bot_socket_errors_total", "Socket error count"
-            )
+              win_rate_g = Gauge("bot_win_rate", "Win rate")
+              drawdown_g = Gauge("bot_drawdown", "Drawdown")
+              cvar_g = Gauge("bot_cvar", "Conditional Value at Risk")
+              socket_err_c = Counter(
+                  "bot_socket_errors_total", "Socket error count"
+              )
             file_err_c = Counter(
                 "bot_file_write_errors_total", "File write error count"
             )
@@ -367,6 +369,11 @@ def serve(
                 if (v := row.get("drawdown")) is not None:
                     try:
                         drawdown_g.set(float(v))
+                    except (TypeError, ValueError):
+                        pass
+                if (v := row.get("cvar")) is not None:
+                    try:
+                        cvar_g.set(float(v))
                     except (TypeError, ValueError):
                         pass
                 if (v := row.get("socket_errors")) is not None:


### PR DESCRIPTION
## Summary
- Compute per-magic CVaR from trade profits and include it in metrics payloads
- Expose `cvar` via metrics collector and Prometheus for dashboarding
- Add Grafana panel to visualise CVaR tail risk

## Testing
- `pytest tests/test_metric_wal_replay.py tests/test_flight_server.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b90e3dfde0832fb6e7990572e955df