### PR TITLE
Generate MQL4 features from model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ models/best/
 
 # Legacy MQL4 sources
 *.mq4
+!StrategyTemplate.mq4
 
 # Virtual environments
 .venv/

--- a/StrategyTemplate.mq4
+++ b/StrategyTemplate.mq4
@@ -1,0 +1,14 @@
+#property strict
+
+// Strategy template for generated expert advisor.
+
+double GetFeature(int idx)
+{
+    switch(idx)
+    {
+    case 0: return MarketInfo(Symbol(), MODE_SPREAD); // spread
+    case 1: return TimeHour(TimeCurrent()); // hour
+    }
+    return 0.0;
+}
+

--- a/model.json
+++ b/model.json
@@ -18,6 +18,10 @@
   },
   "training_mode": "lite",
   "mode": "lite",
+  "feature_names": [
+    "spread",
+    "hour"
+  ],
   "drift_metric": 0.0,
   "drift_metrics": {
     "psi": 0.0,

--- a/scripts/generate_mql4_from_model.py
+++ b/scripts/generate_mql4_from_model.py
@@ -1,0 +1,58 @@
+"""Generate MQL4 expert advisor snippets from model.json.
+
+This script reads ``feature_names`` from a model JSON file and renders a
+``GetFeature`` function containing a ``switch`` statement mapping each feature
+index to a runtime MQL4 expression.  The generated function is inserted into a
+strategy template file in place, allowing the resulting ``.mq4`` file to be
+compiled directly.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Sequence
+
+# Mapping from feature name to MQL4 runtime expression.
+FEATURE_MAP: dict[str, str] = {
+    "spread": "MarketInfo(Symbol(), MODE_SPREAD)",
+    "ask": "MarketInfo(Symbol(), MODE_ASK)",
+    "bid": "MarketInfo(Symbol(), MODE_BID)",
+    "hour": "TimeHour(TimeCurrent())",
+}
+
+GET_FEATURE_TEMPLATE = """double GetFeature(int idx)\n{{\n    switch(idx)\n    {{\n{cases}\n    }}\n    return 0.0;\n}}\n"""
+CASE_TEMPLATE = "    case {idx}: return {expr}; // {name}"
+
+
+def build_switch(names: Sequence[str]) -> str:
+    """Render switch cases for each feature name."""
+    cases = []
+    for i, name in enumerate(names):
+        expr = FEATURE_MAP.get(name, "0.0")
+        cases.append(CASE_TEMPLATE.format(idx=i, expr=expr, name=name))
+    return GET_FEATURE_TEMPLATE.format(cases="\n".join(cases))
+
+
+def insert_get_feature(model: Path, template: Path) -> None:
+    """Insert generated GetFeature into ``template`` in place."""
+    feature_names = json.loads(model.read_text()).get("feature_names", [])
+    get_feature = build_switch(feature_names)
+    content = template.read_text()
+    output = content.replace("// __GET_FEATURE__", get_feature)
+    template.write_text(output)
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--model", type=Path, default=Path("model.json"), help="Path to model.json")
+    p.add_argument(
+        "--template", type=Path, default=Path("StrategyTemplate.mq4"), help="Template .mq4 file"
+    )
+    args = p.parse_args()
+    insert_get_feature(args.model, args.template)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_generate_mql4_from_model.py
+++ b/tests/test_generate_mql4_from_model.py
@@ -1,0 +1,24 @@
+import json
+import subprocess
+import sys
+
+
+def test_generated_features(tmp_path):
+    model = tmp_path / "model.json"
+    model.write_text(json.dumps({"feature_names": ["spread", "hour"]}))
+
+    template = tmp_path / "StrategyTemplate.mq4"
+    # minimal template containing placeholder for insertion
+    template.write_text("#property strict\n\n// __GET_FEATURE__\n")
+
+    subprocess.run(
+        [sys.executable, "scripts/generate_mql4_from_model.py", "--model", model, "--template", template],
+        check=True,
+    )
+
+    content = template.read_text()
+    assert "case 0: return MarketInfo(Symbol(), MODE_SPREAD); // spread" in content
+    assert "case 1: return TimeHour(TimeCurrent()); // hour" in content
+
+    data = json.loads(model.read_text())
+    assert data["feature_names"] == ["spread", "hour"]


### PR DESCRIPTION
## Summary
- add script to inject GetFeature switch into MQL4 template based on model feature names
- include generated StrategyTemplate.mq4 with feature cases for spread and hour
- test generation to ensure EA and model.json contain trained feature names

## Testing
- `pytest tests/test_generate_mql4_from_model.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9d02f3504832faf3607061d09a32d