### PR TITLE
Add dynamic parameter loading for MQL4 strategy

### DIFF
--- a/StrategyTemplate.mq4
+++ b/StrategyTemplate.mq4
@@ -1,6 +1,82 @@
 #property strict
 
 // Strategy template for generated expert advisor.
+//
+// The expert loads model parameters from a comma separated file located in the
+// ``Files`` directory of the terminal.  The file ``model_params.csv`` is
+// expected to contain two lines: the first with coefficient values and the
+// second with decision thresholds.  A timer periodically checks for updates and
+// reloads the values without requiring recompilation.
+
+// Seconds between model reload checks.  A value of 0 disables the timer.
+extern int ReloadModelInterval = 60;
+
+double g_coeffs[];
+double g_thresholds[];
+datetime g_last_params_time = 0;
+
+// Read coefficients and thresholds from the Files\model_params.csv file.
+bool LoadParameters()
+{
+    int handle = FileOpen("model_params.csv", FILE_READ|FILE_ANSI);
+    if(handle == INVALID_HANDLE)
+    {
+        Print("Failed to open model_params.csv: ", GetLastError());
+        return false;
+    }
+
+    string line;
+    if(!FileIsEnding(handle))
+    {
+        line = FileReadString(handle);
+        string parts[];
+        int n = StringSplit(line, ",", parts);
+        ArrayResize(g_coeffs, n);
+        for(int i = 0; i < n; i++)
+            g_coeffs[i] = StrToDouble(parts[i]);
+    }
+
+    if(!FileIsEnding(handle))
+    {
+        line = FileReadString(handle);
+        string parts[];
+        int n = StringSplit(line, ",", parts);
+        ArrayResize(g_thresholds, n);
+        for(int i = 0; i < n; i++)
+            g_thresholds[i] = StrToDouble(parts[i]);
+    }
+
+    g_last_params_time = (datetime)FileGetInteger(handle, FILE_MODIFY_DATE);
+    FileClose(handle);
+    Print("Loaded ", ArraySize(g_coeffs), " coeffs and ", ArraySize(g_thresholds), " thresholds");
+    return true;
+}
+
+int OnInit()
+{
+    if(!LoadParameters())
+        return(INIT_FAILED);
+    if(ReloadModelInterval > 0)
+        EventSetTimer(ReloadModelInterval);
+    return(INIT_SUCCEEDED);
+}
+
+void OnDeinit(const int reason)
+{
+    if(ReloadModelInterval > 0)
+        EventKillTimer();
+}
+
+void OnTimer()
+{
+    int handle = FileOpen("model_params.csv", FILE_READ|FILE_ANSI);
+    if(handle == INVALID_HANDLE)
+        return;
+    datetime mod = (datetime)FileGetInteger(handle, FILE_MODIFY_DATE);
+    FileClose(handle);
+    if(mod > g_last_params_time)
+        LoadParameters();
+}
 
 double GetFeature(int idx)
 {
@@ -11,4 +87,3 @@ double GetFeature(int idx)
     }
     return 0.0;
 }
-

--- a/scripts/write_model_params.py
+++ b/scripts/write_model_params.py
@@ -1,0 +1,45 @@
+"""Write model coefficients and thresholds for the MQL4 strategy.
+
+This helper saves comma separated ``coeffs`` and ``thresholds`` values to a
+file inside the ``Files`` directory.  ``StrategyTemplate.mq4`` reloads the file
+on a timer and therefore can pick up new parameters after each training run
+without requiring recompilation.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Sequence
+
+
+def write_params(coeffs: Sequence[float], thresholds: Sequence[float], path: Path) -> None:
+    """Write ``coeffs`` and ``thresholds`` to ``path``."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w") as f:
+        f.write(",".join(map(str, coeffs)) + "\n")
+        f.write(",".join(map(str, thresholds)) + "\n")
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--coeffs", type=float, nargs="+", required=True, help="Model coefficients")
+    p.add_argument(
+        "--thresholds",
+        type=float,
+        nargs="+",
+        required=True,
+        help="Decision thresholds",
+    )
+    p.add_argument(
+        "--output",
+        type=Path,
+        default=Path("Files/model_params.csv"),
+        help="Destination parameters file",
+    )
+    args = p.parse_args()
+    write_params(args.coeffs, args.thresholds, args.output)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- load coefficients and thresholds from `Files/model_params.csv` during `OnInit`
- periodically reload parameters using a timer controlled by `ReloadModelInterval`
- provide `write_model_params.py` helper to save updated parameters after training runs

## Testing
- `pytest tests/test_generate_mql4_from_model.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba46838f58832fac01ceea459a03de