### PR TITLE
Add session-aware model training and integration

### DIFF
--- a/StrategyTemplate.mq4
+++ b/StrategyTemplate.mq4
@@ -1,19 +1,34 @@
 #property strict
 
 // Strategy template for generated expert advisor.
-//
-// The expert loads model parameters from a comma separated file located in the
-// ``Files`` directory of the terminal.  The file ``model_params.csv`` is
-// expected to contain two lines: the first with coefficient values and the
-// second with decision thresholds.  A timer periodically checks for updates and
-// reloads the values without requiring recompilation.
 
-// Seconds between model reload checks.  A value of 0 disables the timer.
+// Seconds between model reload checks for session switching.  A value of 0 disables the timer.
 extern int ReloadModelInterval = 60;
 
 double g_coeffs[];
-double g_thresholds[];
-datetime g_last_params_time = 0;
+double g_threshold;
+
+// __SESSION_MODELS__
+
+void SelectSessionModel()
+{
+    int h = TimeHour(TimeCurrent());
+    if(h < 8)
+    {
+        ArrayCopy(g_coeffs, g_coeffs_asian);
+        g_threshold = g_threshold_asian;
+    }
+    else if(h < 16)
+    {
+        ArrayCopy(g_coeffs, g_coeffs_london);
+        g_threshold = g_threshold_london;
+    }
+    else
+    {
+        ArrayCopy(g_coeffs, g_coeffs_newyork);
+        g_threshold = g_threshold_newyork;
+    }
+}
 
 string g_trade_queue[];
 string g_metric_queue[];
@@ -120,49 +135,11 @@ void FlushMetrics()
     }
 }
 
-// Read coefficients and thresholds from the Files\model_params.csv file.
-bool LoadParameters()
-{
-    int handle = FileOpen("model_params.csv", FILE_READ|FILE_ANSI);
-    if(handle == INVALID_HANDLE)
-    {
-        Print("Failed to open model_params.csv: ", GetLastError());
-        return false;
-    }
-
-    string line;
-    if(!FileIsEnding(handle))
-    {
-        line = FileReadString(handle);
-        string parts[];
-        int n = StringSplit(line, ",", parts);
-        ArrayResize(g_coeffs, n);
-        for(int i = 0; i < n; i++)
-            g_coeffs[i] = StrToDouble(parts[i]);
-    }
-
-    if(!FileIsEnding(handle))
-    {
-        line = FileReadString(handle);
-        string parts[];
-        int n = StringSplit(line, ",", parts);
-        ArrayResize(g_thresholds, n);
-        for(int i = 0; i < n; i++)
-            g_thresholds[i] = StrToDouble(parts[i]);
-    }
-
-    g_last_params_time = (datetime)FileGetInteger(handle, FILE_MODIFY_DATE);
-    FileClose(handle);
-    Print("Loaded ", ArraySize(g_coeffs), " coeffs and ", ArraySize(g_thresholds), " thresholds");
-    return true;
-}
-
 int OnInit()
 {
     LoadWal(TRADE_WAL, g_trade_queue);
     LoadWal(METRIC_WAL, g_metric_queue);
-    if(!LoadParameters())
-        return(INIT_FAILED);
+    SelectSessionModel();
     if(ReloadModelInterval > 0)
         EventSetTimer(ReloadModelInterval);
     return(INIT_SUCCEEDED);
@@ -178,13 +155,7 @@ void OnTimer()
 {
     FlushTrades();
     FlushMetrics();
-    int handle = FileOpen("model_params.csv", FILE_READ|FILE_ANSI);
-    if(handle == INVALID_HANDLE)
-        return;
-    datetime mod = (datetime)FileGetInteger(handle, FILE_MODIFY_DATE);
-    FileClose(handle);
-    if(mod > g_last_params_time)
-        LoadParameters();
+    SelectSessionModel();
 }
 
 double GetFeature(int idx)

--- a/model.json
+++ b/model.json
@@ -22,6 +22,28 @@
     "spread",
     "hour"
   ],
+  "session_models": {
+    "asian": {
+      "coefficients": [0.0],
+      "intercept": 0.0,
+      "threshold": 0.5
+    },
+    "london": {
+      "coefficients": [0.0],
+      "intercept": 0.0,
+      "threshold": 0.5
+    },
+    "newyork": {
+      "coefficients": [0.0],
+      "intercept": 0.0,
+      "threshold": 0.5
+    }
+  },
+  "session_hours": {
+    "asian": [0, 8],
+    "london": [8, 16],
+    "newyork": [16, 24]
+  },
   "drift_metric": 0.0,
   "drift_metrics": {
     "psi": 0.0,


### PR DESCRIPTION
## Summary
- Train separate logistic models for Asian, London, and New York sessions and store metadata
- Generate MQL4 code with session-specific arrays from model.json
- Strategy template selects session model based on current hour

## Testing
- `pytest -q` *(no tests collected, configuration ignores most tests)*

------
https://chatgpt.com/codex/tasks/task_e_68ba5b46af78832f8bf2dd89c727a3ad