### PR TITLE
Expose scaler stats and normalize features in MQL4 output

### DIFF
--- a/StrategyTemplate.mq4
+++ b/StrategyTemplate.mq4
@@ -7,6 +7,8 @@ extern int ReloadModelInterval = 60;
 
 double g_coeffs[];
 double g_threshold;
+double g_feature_mean[];
+double g_feature_std[];
 
 // __SESSION_MODELS__
 
@@ -17,16 +19,22 @@ void SelectSessionModel()
     {
         ArrayCopy(g_coeffs, g_coeffs_asian);
         g_threshold = g_threshold_asian;
+        ArrayCopy(g_feature_mean, g_feature_mean_asian);
+        ArrayCopy(g_feature_std, g_feature_std_asian);
     }
     else if(h < 16)
     {
         ArrayCopy(g_coeffs, g_coeffs_london);
         g_threshold = g_threshold_london;
+        ArrayCopy(g_feature_mean, g_feature_mean_london);
+        ArrayCopy(g_feature_std, g_feature_std_london);
     }
     else
     {
         ArrayCopy(g_coeffs, g_coeffs_newyork);
         g_threshold = g_threshold_newyork;
+        ArrayCopy(g_feature_mean, g_feature_mean_newyork);
+        ArrayCopy(g_feature_std, g_feature_std_newyork);
     }
 }
 
@@ -166,4 +174,16 @@ double GetFeature(int idx)
     case 1: return TimeHour(TimeCurrent()); // hour
     }
     return 0.0;
+}
+
+double ScoreModel()
+{
+    double z = g_coeffs[0];
+    for(int i = 1; i < ArraySize(g_coeffs); i++)
+    {
+        double val = GetFeature(i - 1);
+        double norm = (val - g_feature_mean[i - 1]) / g_feature_std[i - 1];
+        z += g_coeffs[i] * norm;
+    }
+    return 1.0 / (1.0 + MathExp(-z));
 }

--- a/scripts/generate_mql4_from_model.py
+++ b/scripts/generate_mql4_from_model.py
@@ -45,6 +45,12 @@ def _build_session_models(data: dict) -> str:
         lines.append(
             f"double g_threshold_{name} = {params.get('threshold', 0.5)};"
         )
+        mean = params.get("feature_mean", [])
+        std = params.get("feature_std", [])
+        mean_str = ", ".join(f"{m}" for m in mean)
+        std_str = ", ".join(f"{s}" for s in std)
+        lines.append(f"double g_feature_mean_{name}[] = {{{mean_str}}};")
+        lines.append(f"double g_feature_std_{name}[] = {{{std_str}}};")
     return "\n".join(lines)
 
 

--- a/scripts/train_target_clone.py
+++ b/scripts/train_target_clone.py
@@ -175,10 +175,13 @@ def _train_lite_mode(
         if params["first"]:
             continue
         clf = params["clf"]
+        scaler = params["scaler"]
         session_models[name] = {
             "coefficients": clf.coef_[0].astype(float).tolist(),
             "intercept": float(clf.intercept_[0]),
             "threshold": 0.5,
+            "feature_mean": scaler.mean_.astype(float).tolist(),
+            "feature_std": scaler.scale_.astype(float).tolist(),
         }
 
     if not session_models:

--- a/tests/test_generate_mql4_from_model.py
+++ b/tests/test_generate_mql4_from_model.py
@@ -35,6 +35,8 @@ def test_session_models_inserted(tmp_path):
                         "coefficients": [1.0],
                         "intercept": 0.1,
                         "threshold": 0.5,
+                        "feature_mean": [0.0],
+                        "feature_std": [1.0],
                     }
                 },
             }
@@ -59,3 +61,9 @@ def test_session_models_inserted(tmp_path):
     content = template.read_text()
     assert "g_coeffs_asian" in content
     assert "g_threshold_asian" in content
+    assert "g_feature_mean_asian" in content
+    assert "g_feature_std_asian" in content
+
+    data = json.loads(model.read_text())
+    assert "feature_mean" in data["session_models"]["asian"]
+    assert "feature_std" in data["session_models"]["asian"]

--- a/tests/test_train_target_clone_scaler.py
+++ b/tests/test_train_target_clone_scaler.py
@@ -1,0 +1,24 @@
+import json
+from pathlib import Path
+
+from scripts.train_target_clone import train
+
+
+def test_scaler_stats_present(tmp_path):
+    data = tmp_path / "trades_raw.csv"
+    data.write_text(
+        "label,spread,hour\n"
+        "0,1.0,1\n"
+        "1,1.2,2\n"
+        "0,1.3,9\n"
+        "1,1.5,10\n"
+        "0,1.4,17\n"
+        "1,1.6,18\n"
+    )
+    out_dir = tmp_path / "out"
+    train(data, out_dir)
+    model = json.loads((out_dir / "model.json").read_text())
+    for sess in ["asian", "london", "newyork"]:
+        params = model["session_models"][sess]
+        assert "feature_mean" in params
+        assert "feature_std" in params


### PR DESCRIPTION
## Summary
- persist StandardScaler mean and std for each session in `model.json`
- emit scaler statistics in generated MQL4 code and normalize features before scoring
- test that scaler stats appear in trained models and generated strategies

## Testing
- `pytest tests/test_generate_mql4_from_model.py::test_generated_features tests/test_generate_mql4_from_model.py::test_session_models_inserted tests/test_train_target_clone_scaler.py::test_scaler_stats_present -q`

------
https://chatgpt.com/codex/tasks/task_e_68ba5efc0994832fa49ce6105232f2af