### PR TITLE
Enable chunked log loading for non-lite mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,13 @@ Run the unit tests:
 pytest
 ```
 
+## Memory usage
+
+The log loading helpers in `scripts/train_target_clone.py` and
+`scripts/model_fitting.py` accept a `chunk_size` argument. Providing a positive
+value streams DataFrame chunks instead of materialising the entire log in
+memory, enabling training on machines with limited RAM.
+
 ## License
 
 This project is licensed under the [MIT License](LICENSE).

--- a/tests/test_chunked_loading.py
+++ b/tests/test_chunked_loading.py
@@ -1,0 +1,35 @@
+import json
+from pathlib import Path
+
+import pandas as pd
+
+from scripts.train_target_clone import _load_logs, train
+
+
+def _write_log(path: Path, rows: int) -> None:
+    df = pd.DataFrame(
+        {
+            "label": [0, 1] * (rows // 2),
+            "spread": [1.0] * rows,
+            "hour": [i % 24 for i in range(rows)],
+        }
+    )
+    df.to_csv(path, index=False)
+
+
+def test_load_logs_chunks_when_not_lite(tmp_path):
+    csv = tmp_path / "trades_raw.csv"
+    _write_log(csv, 120_000)
+    chunks, _, _ = _load_logs(tmp_path, lite_mode=False, chunk_size=50_000)
+    assert not isinstance(chunks, pd.DataFrame)
+    sizes = [len(c) for c in chunks]
+    assert sizes == [50_000, 50_000, 20_000]
+
+
+def test_train_iterates_chunks(tmp_path):
+    csv = tmp_path / "trades_raw.csv"
+    _write_log(csv, 100_000)
+    out_dir = tmp_path / "out"
+    train(csv, out_dir, chunk_size=50_000, mode="standard")
+    model = json.loads((out_dir / "model.json").read_text())
+    assert model["mode"] == "standard"


### PR DESCRIPTION
## Summary
- Stream DataFrame chunks when `chunk_size` is set even if not in lite mode
- Iterate over returned chunks in training loop regardless of mode
- Document memory benefits and add tests for large synthetic logs

## Testing
- `pytest tests/test_model_fitting.py::test_load_logs_basic tests/test_train_target_clone_scaler.py tests/test_chunked_loading.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb7b359dd8832f9071b44de3ae2666