### PR TITLE
Add volume feature mapping and strategy support

### DIFF
--- a/StrategyTemplate.mq4
+++ b/StrategyTemplate.mq4
@@ -10,7 +10,18 @@ double g_threshold;
 double g_feature_mean[];
 double g_feature_std[];
 
-// __SESSION_MODELS__
+double g_coeffs_asian[] = {0.0, 0.0};
+double g_threshold_asian = 0.5;
+double g_feature_mean_asian[] = {};
+double g_feature_std_asian[] = {};
+double g_coeffs_london[] = {0.0, 0.0};
+double g_threshold_london = 0.5;
+double g_feature_mean_london[] = {};
+double g_feature_std_london[] = {};
+double g_coeffs_newyork[] = {0.0, 0.0};
+double g_threshold_newyork = 0.5;
+double g_feature_mean_newyork[] = {};
+double g_feature_std_newyork[] = {};
 
 void SelectSessionModel()
 {
@@ -202,9 +213,11 @@ double GetFeature(int idx)
     {
     case 0: return MarketInfo(Symbol(), MODE_SPREAD); // spread
     case 1: return TimeHour(TimeCurrent()); // hour
+    case 2: return iVolume(Symbol(), PERIOD_CURRENT, 0); // volume
     }
     return 0.0;
 }
+
 
 double ScoreModel()
 {

--- a/model.json
+++ b/model.json
@@ -20,7 +20,8 @@
   "mode": "lite",
   "feature_names": [
     "spread",
-    "hour"
+    "hour",
+    "volume"
   ],
   "session_models": {
     "asian": {

--- a/scripts/generate_mql4_from_model.py
+++ b/scripts/generate_mql4_from_model.py
@@ -21,7 +21,7 @@ FEATURE_MAP: dict[str, str] = {
     "ask": "MarketInfo(Symbol(), MODE_ASK)",
     "bid": "MarketInfo(Symbol(), MODE_BID)",
     "hour": "TimeHour(TimeCurrent())",
-    # "volume": "iVolume(Symbol(), PERIOD_CURRENT, 0)",  # Example placeholder
+    "volume": "iVolume(Symbol(), PERIOD_CURRENT, 0)",
 }
 
 GET_FEATURE_TEMPLATE = """double GetFeature(int idx)\n{{\n    switch(idx)\n    {{\n{cases}\n    }}\n    return 0.0;\n}}\n"""

--- a/scripts/train_target_clone.py
+++ b/scripts/train_target_clone.py
@@ -70,7 +70,7 @@ def _load_logs(
             continue
         df[col] = pd.to_numeric(df[col], errors="ignore")
 
-    optional_cols = ["spread", "slippage", "equity", "margin_level"]
+    optional_cols = ["spread", "slippage", "equity", "margin_level", "volume"]
     feature_cols = [c for c in optional_cols if c in df.columns]
 
     # When ``chunk_size`` is provided (or lite_mode explicitly enabled), yield

--- a/tests/test_chunked_loading.py
+++ b/tests/test_chunked_loading.py
@@ -12,6 +12,7 @@ def _write_log(path: Path, rows: int) -> None:
             "label": [0, 1] * (rows // 2),
             "spread": [1.0] * rows,
             "hour": [i % 24 for i in range(rows)],
+            "volume": [100] * rows,
         }
     )
     df.to_csv(path, index=False)
@@ -20,8 +21,9 @@ def _write_log(path: Path, rows: int) -> None:
 def test_load_logs_chunks_when_not_lite(tmp_path):
     csv = tmp_path / "trades_raw.csv"
     _write_log(csv, 120_000)
-    chunks, _, _ = _load_logs(tmp_path, lite_mode=False, chunk_size=50_000)
+    chunks, feature_cols, _ = _load_logs(tmp_path, lite_mode=False, chunk_size=50_000)
     assert not isinstance(chunks, pd.DataFrame)
+    assert "volume" in feature_cols
     sizes = [len(c) for c in chunks]
     assert sizes == [50_000, 50_000, 20_000]
 


### PR DESCRIPTION
## Summary
- include tick `volume` among optional features when loading logs
- map `volume` to `iVolume(Symbol(), PERIOD_CURRENT, 0)` for MQL4 generation
- regenerate strategy template so `GetFeature` returns current tick volume
- cover chunked log loading with volume in tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb844c679c832f937015ffdcd0f69d