### PR TITLE
Add slippage and account metrics feature support

### DIFF
--- a/scripts/generate_mql4_from_model.py
+++ b/scripts/generate_mql4_from_model.py
@@ -22,6 +22,9 @@ FEATURE_MAP: dict[str, str] = {
     "bid": "MarketInfo(Symbol(), MODE_BID)",
     "hour": "TimeHour(TimeCurrent())",
     "volume": "iVolume(Symbol(), PERIOD_CURRENT, 0)",
+    "slippage": "OrderSlippage()",
+    "equity": "AccountEquity()",
+    "margin_level": "AccountMarginLevel()",
 }
 
 GET_FEATURE_TEMPLATE = """double GetFeature(int idx)\n{{\n    switch(idx)\n    {{\n{cases}\n    }}\n    return 0.0;\n}}\n"""

--- a/scripts/sqlite_log_service.py
+++ b/scripts/sqlite_log_service.py
@@ -38,6 +38,8 @@ FIELDS = [
     "sl_hit_dist",
     "tp_hit_dist",
     "decision_id",
+    "equity",
+    "margin_level",
 ]
 
 


### PR DESCRIPTION
## Summary
- map `slippage`, `equity`, and `margin_level` to corresponding MQL4 expressions in `generate_mql4_from_model.py`
- log `equity` and `margin_level` in SQLite log service so observers provide these fields
- regenerate StrategyTemplate.mq4 to ensure feature cases are up-to-date

## Testing
- `python scripts/generate_mql4_from_model.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bbb8788c78832f83fb5de51ec2ebe3