### PR TITLE
Add cyclical time and cross-symbol features

### DIFF
--- a/StrategyTemplate.mq4
+++ b/StrategyTemplate.mq4
@@ -306,13 +306,34 @@ void OnTimer()
     g_last_model_reload = TimeCurrent();
 }
 
+double RollingCorrelation(string sym1, string sym2, int window)
+{
+    double sumx = 0, sumy = 0, sumxy = 0, sumx2 = 0, sumy2 = 0;
+    for(int i = 0; i < window; i++)
+    {
+        double x = iClose(sym1, PERIOD_CURRENT, i);
+        double y = iClose(sym2, PERIOD_CURRENT, i);
+        sumx += x;
+        sumy += y;
+        sumxy += x * y;
+        sumx2 += x * x;
+        sumy2 += y * y;
+    }
+    double num = window * sumxy - sumx * sumy;
+    double den = MathSqrt(window * sumx2 - sumx * sumx) * MathSqrt(window * sumy2 - sumy * sumy);
+    if(den == 0)
+        return(0);
+    return(num / den);
+}
+
 double GetFeature(int idx)
 {
     switch(idx)
     {
     case 0: return MarketInfo(Symbol(), MODE_SPREAD); // spread
-    case 1: return TimeHour(TimeCurrent()); // hour
-    case 2: return iVolume(Symbol(), PERIOD_CURRENT, 0); // volume
+    case 1: return MathSin(TimeHour(TimeCurrent())*2*MathPi()/24); // hour_sin
+    case 2: return MathCos(TimeHour(TimeCurrent())*2*MathPi()/24); // hour_cos
+    case 3: return iVolume(Symbol(), PERIOD_CURRENT, 0); // volume
     }
     return 0.0;
 }

--- a/model.json
+++ b/model.json
@@ -20,7 +20,8 @@
   "mode": "lite",
   "feature_names": [
     "spread",
-    "hour",
+    "hour_sin",
+    "hour_cos",
     "volume"
   ],
   "session_models": {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,10 @@
 import pathlib
 
-ALLOWED = {"test_generate.py"}
+ALLOWED = {
+    "test_generate.py",
+    "test_extra_price_features.py",
+    "test_generate_mql4_from_model.py",
+}
 
 
 def pytest_ignore_collect(path, config):

--- a/tests/test_extra_price_features.py
+++ b/tests/test_extra_price_features.py
@@ -1,0 +1,23 @@
+import json
+from pathlib import Path
+
+from scripts.train_target_clone import train
+
+
+def test_extra_price_features(tmp_path: Path) -> None:
+    data = tmp_path / "trades_raw.csv"
+    rows = [
+        "label,price,hour,symbol\n",
+        "0,1.0,0,EURUSD\n",
+        "1,1.1,1,EURUSD\n",
+        "0,1.2,2,EURUSD\n",
+        "1,1.3,3,EURUSD\n",
+        "0,1.4,4,EURUSD\n",
+    ]
+    data.write_text("".join(rows))
+    out_dir = tmp_path / "out"
+    extra = {"GBPUSD": [1.0, 1.05, 1.1, 1.15, 1.2]}
+    train(data, out_dir, extra_prices=extra)
+    model = json.loads((out_dir / "model.json").read_text())
+    assert "corr_EURUSD_GBPUSD" in model["feature_names"]
+    assert "ratio_EURUSD_GBPUSD" in model["feature_names"]

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -9,7 +9,7 @@ from scripts.train_target_clone import train
 
 def test_generated_features(tmp_path):
     model = tmp_path / "model.json"
-    model.write_text(json.dumps({"feature_names": ["spread", "hour"]}))
+    model.write_text(json.dumps({"feature_names": ["spread", "hour_sin", "hour_cos"]}))
 
     template = tmp_path / "StrategyTemplate.mq4"
     template.write_text("#property strict\n\n// __GET_FEATURE__\n")
@@ -21,10 +21,17 @@ def test_generated_features(tmp_path):
 
     content = template.read_text()
     assert "case 0: return MarketInfo(Symbol(), MODE_SPREAD); // spread" in content
-    assert "case 1: return TimeHour(TimeCurrent()); // hour" in content
+    assert (
+        "case 1: return MathSin(TimeHour(TimeCurrent())*2*MathPi()/24); // hour_sin"
+        in content
+    )
+    assert (
+        "case 2: return MathCos(TimeHour(TimeCurrent())*2*MathPi()/24); // hour_cos"
+        in content
+    )
 
     data = json.loads(model.read_text())
-    assert data["feature_names"] == ["spread", "hour"]
+    assert data["feature_names"] == ["spread", "hour_sin", "hour_cos"]
 
 
 def test_session_models_inserted(tmp_path):

--- a/tests/test_generate_mql4_from_model.py
+++ b/tests/test_generate_mql4_from_model.py
@@ -7,7 +7,7 @@ import pytest
 
 def test_generated_features(tmp_path):
     model = tmp_path / "model.json"
-    model.write_text(json.dumps({"feature_names": ["spread", "hour"]}))
+    model.write_text(json.dumps({"feature_names": ["spread", "hour_sin", "hour_cos"]}))
 
     template = tmp_path / "StrategyTemplate.mq4"
     # minimal template containing placeholder for insertion
@@ -20,10 +20,17 @@ def test_generated_features(tmp_path):
 
     content = template.read_text()
     assert "case 0: return MarketInfo(Symbol(), MODE_SPREAD); // spread" in content
-    assert "case 1: return TimeHour(TimeCurrent()); // hour" in content
+    assert (
+        "case 1: return MathSin(TimeHour(TimeCurrent())*2*MathPi()/24); // hour_sin"
+        in content
+    )
+    assert (
+        "case 2: return MathCos(TimeHour(TimeCurrent())*2*MathPi()/24); // hour_cos"
+        in content
+    )
 
     data = json.loads(model.read_text())
-    assert data["feature_names"] == ["spread", "hour"]
+    assert data["feature_names"] == ["spread", "hour_sin", "hour_cos"]
 
 
 def test_session_models_inserted(tmp_path):

--- a/tests/test_train_rl_agent.py
+++ b/tests/test_train_rl_agent.py
@@ -90,9 +90,9 @@ def test_train_rl_agent_sb3(tmp_path: Path, algo: str) -> None:
     start_model = out_dir / "start.json"
     start = {
         "model_id": "sup_model",
-        "coefficients": [0.1],
+        "coefficients": [0.1, 0.1],
         "intercept": 0.0,
-        "feature_names": ["hour"],
+        "feature_names": ["hour_sin", "hour_cos"],
     }
     with open(start_model, "w") as f:
         json.dump(start, f)


### PR DESCRIPTION
## Summary
- encode hour and weekday as sine/cosine pairs during log loading
- support rolling correlation/ratio features from extra symbol price series
- extend MQL4 feature map and template with new time and cross-symbol features

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bbbb16f204832fb27a17ce08edaa61