### PR TITLE
Fail on unmapped model features

### DIFF
--- a/scripts/generate_mql4_from_model.py
+++ b/scripts/generate_mql4_from_model.py
@@ -58,7 +58,10 @@ def build_switch(names: Sequence[str]) -> str:
                 raise KeyError(f"Invalid corr feature name '{name}'") from None
             expr = f'RollingCorrelation("{a}", "{b}", 5)'
         else:
-            expr = "0.0"
+            raise KeyError(
+                "No runtime expression for feature "
+                f"'{name}'. Update StrategyTemplate.mq4 or FEATURE_MAP to add it."
+            )
         cases.append(CASE_TEMPLATE.format(idx=i, expr=expr, name=name))
     return GET_FEATURE_TEMPLATE.format(cases="\n".join(cases))
 

--- a/tests/test_generate_mql4_from_model.py
+++ b/tests/test_generate_mql4_from_model.py
@@ -111,24 +111,25 @@ def test_session_models_inserted(tmp_path):
     assert "feature_std" in data["session_models"]["asian"]
 
 
-def test_generation_handles_unmapped_feature(tmp_path):
+def test_generation_fails_on_unmapped_feature(tmp_path):
     model = tmp_path / "model.json"
     model.write_text(json.dumps({"feature_names": ["unknown"]}))
 
     template = tmp_path / "StrategyTemplate.mq4"
     template.write_text("#property strict\n\n// __GET_FEATURE__\n")
 
-    subprocess.run(
-        [
-            sys.executable,
-            "scripts/generate_mql4_from_model.py",
-            "--model",
-            model,
-            "--template",
-            template,
-        ],
-        check=True,
-    )
-
-    content = template.read_text()
-    assert "case 0: return 0.0; // unknown" in content
+    with pytest.raises(subprocess.CalledProcessError) as exc:
+        subprocess.run(
+            [
+                sys.executable,
+                "scripts/generate_mql4_from_model.py",
+                "--model",
+                model,
+                "--template",
+                template,
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    assert "Update StrategyTemplate.mq4" in exc.value.stderr


### PR DESCRIPTION
## Summary
- raise a KeyError when feature_names contain an unmapped feature
- hint to update StrategyTemplate.mq4 or FEATURE_MAP
- add tests verifying generation errors on unmapped features

## Testing
- `pytest tests/test_generate_mql4_from_model.py::test_generation_fails_on_unmapped_feature tests/test_generate.py::test_generation_fails_on_unmapped_feature -q`

------
https://chatgpt.com/codex/tasks/task_e_68bbc3649400832f9325d7632b30623c