### PR TITLE
feat: use persistent gRPC client for trade and metric streaming

### DIFF
--- a/grpc_client.cpp
+++ b/grpc_client.cpp
@@ -1,0 +1,114 @@
+#include <grpcpp/grpcpp.h>
+#include <google/protobuf/empty.pb.h>
+#include "proto/log_service.grpc.pb.h"
+#include "proto/trade_event.pb.h"
+#include "proto/metric_event.pb.h"
+
+#include <queue>
+#include <mutex>
+#include <string>
+#include <chrono>
+#include <thread>
+
+namespace {
+class GrpcClient {
+ public:
+  void Init(const std::string& trade_host, int trade_port,
+            const std::string& metric_host, int metric_port) {
+    trade_stub_ = tbot::LogService::NewStub(
+        grpc::CreateChannel(trade_host + ":" + std::to_string(trade_port),
+                             grpc::InsecureChannelCredentials()));
+    metric_stub_ = tbot::LogService::NewStub(
+        grpc::CreateChannel(metric_host + ":" + std::to_string(metric_port),
+                             grpc::InsecureChannelCredentials()));
+  }
+
+  void EnqueueTrade(const std::string& payload) {
+    std::lock_guard<std::mutex> lock(mu_);
+    trade_queue_.push(payload);
+  }
+
+  void EnqueueMetric(const std::string& payload) {
+    std::lock_guard<std::mutex> lock(mu_);
+    metric_queue_.push(payload);
+  }
+
+  void Flush() {
+    FlushTrades();
+    FlushMetrics();
+  }
+
+ private:
+  void FlushTrades() {
+    std::lock_guard<std::mutex> lock(mu_);
+    int backoff_ms = 10;
+    while (!trade_queue_.empty()) {
+      const std::string payload = trade_queue_.front();
+      tbot::TradeEvent req;
+      req.set_payload(payload);
+      google::protobuf::Empty resp;
+      grpc::ClientContext ctx;
+      grpc::Status status = trade_stub_->LogTrade(&ctx, req, &resp);
+      if (!status.ok()) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(backoff_ms));
+        backoff_ms = std::min(backoff_ms * 2, 1000);
+        continue;
+      }
+      trade_queue_.pop();
+      backoff_ms = 10;
+    }
+  }
+
+  void FlushMetrics() {
+    std::lock_guard<std::mutex> lock(mu_);
+    int backoff_ms = 10;
+    while (!metric_queue_.empty()) {
+      const std::string payload = metric_queue_.front();
+      tbot::MetricEvent req;
+      req.set_payload(payload);
+      google::protobuf::Empty resp;
+      grpc::ClientContext ctx;
+      grpc::Status status = metric_stub_->LogMetrics(&ctx, req, &resp);
+      if (!status.ok()) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(backoff_ms));
+        backoff_ms = std::min(backoff_ms * 2, 1000);
+        continue;
+      }
+      metric_queue_.pop();
+      backoff_ms = 10;
+    }
+  }
+
+  std::unique_ptr<tbot::LogService::Stub> trade_stub_;
+  std::unique_ptr<tbot::LogService::Stub> metric_stub_;
+  std::queue<std::string> trade_queue_;
+  std::queue<std::string> metric_queue_;
+  std::mutex mu_;
+};
+
+GrpcClient g_client;
+}  // namespace
+
+extern "C" {
+
+__attribute__((visibility("default"))) void grpc_client_init(const char* trade_host, int trade_port,
+                                         const char* metric_host, int metric_port) {
+  g_client.Init(trade_host ? trade_host : "", trade_port,
+                metric_host ? metric_host : "", metric_port);
+}
+
+__attribute__((visibility("default"))) void grpc_enqueue_trade(const char* payload) {
+  if (payload)
+    g_client.EnqueueTrade(payload);
+}
+
+__attribute__((visibility("default"))) void grpc_enqueue_metric(const char* payload) {
+  if (payload)
+    g_client.EnqueueMetric(payload);
+}
+
+__attribute__((visibility("default"))) void grpc_flush() {
+  g_client.Flush();
+}
+
+}


### PR DESCRIPTION
## Summary
- add lightweight C++ gRPC client DLL with persistent channels and retry backoff
- route `SendTrade` and `SendMetric` through gRPC client and remove raw sockets
- flush queues via client with connection reuse

## Testing
- `pytest tests/test_grpc_log_service.py::test_grpc_log_service -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc84d877e8832fb11eec2f36fb0f98