### PR TITLE
Add background drift monitor and drift-aware promotion

### DIFF
--- a/docs/drift_monitor.md
+++ b/docs/drift_monitor.md
@@ -1,8 +1,17 @@
 # Automated Drift Checks
 
-`scripts/auto_retrain.py` can watch feature logs for population drift. When
-PSI or KS statistics exceed a threshold the script retrains the model using
-`train_target_clone.py` and publishes the result.
+`scripts/drift_monitor.py` computes Population Stability Index (PSI) and
+Kolmogorov–Smirnov (KS) statistics between a baseline feature log and a recent
+sample.  When either metric exceeds a threshold the monitor can trigger
+`auto_retrain.py` and touch a flag file so other services know drift occurred.
+The computed drift metrics are written to both `model.json` and
+`evaluation.json` (using `drift_` prefixes) so subsequent tooling can inspect
+them.
+
+`scripts/drift_service.py` runs the monitor in a simple loop and is suitable for
+`systemd` or container based deployments.  `promote_best_models.py` will skip any
+model whose `drift_psi` or `drift_ks` in `evaluation.json` exceed the
+`--max-drift` threshold when publishing models.
 
 ## Cron
 
@@ -56,4 +65,4 @@ sudo systemctl enable --now auto-retrain.timer
 
 The service computes drift between `baseline.csv` and `recent.csv`, retrains the
 model when the metric exceeds the threshold and writes the computed
-`drift_metric` into `model.json` for traceability.
+`drift_metric` into both `model.json` and `evaluation.json` for traceability.

--- a/scripts/drift_service.py
+++ b/scripts/drift_service.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Background service to periodically run ``drift_monitor.py``."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+
+def _run_monitor(args: argparse.Namespace) -> None:
+    cmd = [
+        sys.executable,
+        str(Path(__file__).with_name("drift_monitor.py")),
+        "--baseline-file",
+        str(args.baseline_file),
+        "--recent-file",
+        str(args.recent_file),
+        "--drift-threshold",
+        str(args.drift_threshold),
+        "--model-json",
+        str(args.model_json),
+        "--log-dir",
+        str(args.log_dir),
+        "--out-dir",
+        str(args.out_dir),
+        "--files-dir",
+        str(args.files_dir),
+    ]
+    if args.flag_file is not None:
+        cmd += ["--flag-file", str(args.flag_file)]
+    subprocess.run(cmd, check=False)
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description="Run drift monitor in a loop")
+    p.add_argument("--baseline-file", type=Path, required=True)
+    p.add_argument("--recent-file", type=Path, required=True)
+    p.add_argument("--drift-threshold", type=float, default=0.2)
+    p.add_argument("--model-json", type=Path, default=Path("model.json"))
+    p.add_argument("--log-dir", type=Path, required=True)
+    p.add_argument("--out-dir", type=Path, required=True)
+    p.add_argument("--files-dir", type=Path, required=True)
+    p.add_argument("--flag-file", type=Path)
+    p.add_argument("--interval", type=int, default=3600, help="seconds between checks")
+    args = p.parse_args()
+
+    while True:
+        _run_monitor(args)
+        time.sleep(args.interval)
+
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- log drift metrics to evaluation.json and optional flag file
- background drift_service to run drift monitor on a schedule
- skip high-drift models during promotion

## Testing
- `pytest tests/test_promote_best_models.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'sklearn')*

------
https://chatgpt.com/codex/tasks/task_e_68bca35b87e8832fb54329f528c43162