### PR TITLE
Add CVaR metric and expose in dashboards

### DIFF
--- a/dashboard/static/index.html
+++ b/dashboard/static/index.html
@@ -24,13 +24,15 @@
                 datasets: [
                     { label: 'Win Rate', data: [], yAxisID: 'y' },
                     { label: 'Flush Latency (ms)', data: [], yAxisID: 'y1' },
-                    { label: 'Network Latency (ms)', data: [], yAxisID: 'y1' }
+                    { label: 'Network Latency (ms)', data: [], yAxisID: 'y1' },
+                    { label: 'CVaR', data: [], yAxisID: 'y2' }
                 ]
             },
             options: {
                 scales: {
                     y: { type: 'linear', position: 'left' },
-                    y1: { type: 'linear', position: 'right', grid: { drawOnChartArea: false } }
+                    y1: { type: 'linear', position: 'right', grid: { drawOnChartArea: false } },
+                    y2: { type: 'linear', position: 'right', grid: { drawOnChartArea: false } }
                 }
             }
         });
@@ -40,6 +42,7 @@
             metricsChart.data.datasets[0].data.push(metric.win_rate);
             metricsChart.data.datasets[1].data.push(metric.flush_latency_ms);
             metricsChart.data.datasets[2].data.push(metric.network_latency_ms);
+            metricsChart.data.datasets[3].data.push(metric.cvar);
             metricsChart.update();
         }
 

--- a/docs/metrics_dashboard.json
+++ b/docs/metrics_dashboard.json
@@ -89,7 +89,7 @@
     },
     {
       "type": "timeseries",
-      "title": "CVaR",
+      "title": "CVaR (worst 5%)",
       "id": 11,
       "targets": [
         {"expr": "bot_cvar"}

--- a/scripts/evaluation.py
+++ b/scripts/evaluation.py
@@ -188,6 +188,12 @@ def evaluate(pred_file: Path, actual_log: Path, window: int, model_json: Optiona
     downside = [p for p in profits if p < 0]
     downside_risk = -sum(downside) / len(downside) if downside else 0.0
     risk_reward = expected_return - downside_risk
+    cvar = 0.0
+    if profits:
+        sorted_profits = sorted(profits)
+        n_tail = max(1, int(math.ceil(len(sorted_profits) * 0.05)))
+        tail = sorted_profits[:n_tail]
+        cvar = sum(tail) / len(tail)
     sharpe = 0.0
     sortino = 0.0
     if len(profits) > 1:
@@ -215,6 +221,7 @@ def evaluate(pred_file: Path, actual_log: Path, window: int, model_json: Optiona
         "expectancy": expectancy,
         "expected_return": expected_return,
         "downside_risk": downside_risk,
+        "cvar": cvar,
         "sharpe_ratio": sharpe,
         "sortino_ratio": sortino,
         "risk_reward": risk_reward,

--- a/scripts/metrics_collector.py
+++ b/scripts/metrics_collector.py
@@ -368,7 +368,9 @@ def serve(
             await prom_site.start()
             win_rate_g = Gauge("bot_win_rate", "Win rate")
             drawdown_g = Gauge("bot_drawdown", "Drawdown")
-            cvar_g = Gauge("bot_cvar", "Conditional Value at Risk")
+            cvar_g = Gauge(
+                "bot_cvar", "Conditional Value at Risk (worst 5%)"
+            )
             socket_err_c = Counter(
                 "bot_socket_errors_total", "Socket error count"
             )

--- a/scripts/plot_metrics.py
+++ b/scripts/plot_metrics.py
@@ -37,6 +37,7 @@ def _load_metrics(path: Path):
                     "sharpe": float(r.get("sharpe", 0) or 0),
                     "sortino": float(r.get("sortino", 0) or 0),
                     "expectancy": float(r.get("expectancy", 0) or 0),
+                    "cvar": float(r.get("cvar", 0) or 0),
                     "file_write_errors": int(
                         float(r.get("file_write_errors") or r.get("write_errors") or 0)
                     ),
@@ -65,6 +66,7 @@ def _plot(rows, magic=None):
     socket_err = [r["socket_errors"] for r in rows]
     var_breach = [r.get("var_breach_count", 0) for r in rows]
     risk_w = [r.get("risk_weight", 0) for r in rows]
+    cvar = [r.get("cvar", 0) for r in rows]
 
     fig, (ax1, ax3, ax4) = plt.subplots(3, 1, sharex=True)
     ax1.plot(times, win_rate, label="Win Rate")
@@ -92,6 +94,11 @@ def _plot(rows, magic=None):
 
     ax4.plot(times, risk_w, label="Risk Weight", color="black")
     ax4.set_ylabel("Risk Weight")
+    if any(cvar):
+        ax4b = ax4.twinx()
+        ax4b.plot(times, cvar, label="CVaR", color="red")
+        ax4b.set_ylabel("CVaR")
+        ax4b.legend(loc="upper right")
     ax4.legend(loc="upper left")
     ax4.set_xlabel("Time")
     plt.tight_layout()


### PR DESCRIPTION
## Summary
- compute CVaR (worst 5% profits) during evaluation and report in stats
- expose CVaR through metrics collector and dashboards/plots

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bcc26f9228832f8545094f72073993