### PR TITLE
Log skipped trades via conformal bounds

### DIFF
--- a/StrategyTemplate.mq4
+++ b/StrategyTemplate.mq4
@@ -491,10 +491,12 @@ void OnTick()
     g_decision_id++;
     int decision_id = g_decision_id;
     string decision = "hold";
+    string reason = "";
     bool uncertain = (prob >= g_conformal_lower && prob <= g_conformal_upper);
     if(uncertain)
     {
         decision = "skip";
+        reason = "uncertain_prob";
     }
     else if(prob > g_threshold)
     {
@@ -531,6 +533,7 @@ void OnTick()
         ",lot=" + DoubleToString(lot, 2) +
         ",sl=" + DoubleToString(sl, 2) +
         ",tp=" + DoubleToString(tp, 2) +
+        ",reason=" + reason +
         ",features=" + features
     );
 }

--- a/scripts/generate_mql4_from_model.py
+++ b/scripts/generate_mql4_from_model.py
@@ -82,7 +82,11 @@ def _build_session_models(data: dict) -> str:
 
     lines: list[str] = []
 
-    models = data.get("models") or {}
+    # ``model.json`` produced by training historically stored per-algorithm
+    # parameters under ``models``.  Newer pipelines may instead emit
+    # ``session_models`` keyed by trading session.  Accept either key so the
+    # generator remains backward compatible.
+    models = data.get("models") or data.get("session_models") or {}
     for name, params in models.items():
         coeffs = [params.get("intercept", 0.0)] + params.get("coefficients", [])
         coeff_str = ", ".join(f"{c}" for c in coeffs)

--- a/tests/test_target_clone_cross_validation.py
+++ b/tests/test_target_clone_cross_validation.py
@@ -21,8 +21,10 @@ def test_cross_validation_metrics_written(tmp_path: Path) -> None:
     train(data, out_dir)
     model = json.loads((out_dir / "model.json").read_text())
     assert "cv_accuracy" in model and "cv_profit" in model
+    assert "conformal_lower" in model and "conformal_upper" in model
     for params in model["session_models"].values():
         assert params["cv_metrics"]
+        assert "conformal_lower" in params and "conformal_upper" in params
         for fm in params["cv_metrics"]:
             assert "accuracy" in fm and "profit" in fm
 


### PR DESCRIPTION
## Summary
- embed conformal lower/upper bounds from training into generated EA code
- skip trades when probability falls inside conformal interval and log a reason code
- ensure training output and code generation handle session models with bounds

## Testing
- `pytest tests/test_target_clone_cross_validation.py::test_cross_validation_metrics_written tests/test_target_clone_cross_validation.py::test_training_fails_when_threshold_unmet -q`
- `pytest tests/test_generate_mql4_from_model.py::test_models_and_router_inserted tests/test_generate_mql4_from_model.py::test_on_tick_logs_uncertain_reason -q`


------
https://chatgpt.com/codex/tasks/task_e_68bcd8e04998832f913692ca38f613a4