### PR TITLE
Add time-decay weighting to target clone training

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -136,6 +136,15 @@ Feed this back into training to emphasise corrections and scale them further::
     python scripts/train_target_clone.py --replay-file divergences.csv --replay-weight 3
 
 
+## Time-decay Weighting
+
+Older trades can be down‑weighted so that recent market behaviour has more
+influence.  ``scripts/train_target_clone.py`` accepts ``--half-life-days`` which
+applies an exponential decay of ``0.5 ** (age_days / half_life_days)`` to each
+sample where ``age_days`` is the number of days since the most recent trade.
+The selected ``half_life_days`` value is stored in ``model.json`` for reference.
+
+
 ## Symbol Graph Embeddings
 
 Correlation structure between symbols can be captured with

--- a/tests/test_time_series_split_and_weighting.py
+++ b/tests/test_time_series_split_and_weighting.py
@@ -40,3 +40,11 @@ def test_shorter_half_life_emphasizes_recent_trades():
     proba_long = clf_long.predict_proba([[3]])[0, 1]
     proba_short = clf_short.predict_proba([[3]])[0, 1]
     assert proba_short > proba_long
+
+
+def test_weights_decrease_with_age():
+    times = np.array(
+        ["2024-01-01", "2024-01-02", "2024-01-03"], dtype="datetime64[s]"
+    )
+    weights = _compute_decay_weights(times, half_life_days=1.0)
+    assert weights[0] < weights[1] < weights[2]

--- a/tests/test_train_target_clone_half_life.py
+++ b/tests/test_train_target_clone_half_life.py
@@ -1,0 +1,16 @@
+import json
+
+from scripts.train_target_clone import train
+
+
+def test_half_life_recorded(tmp_path):
+    data = tmp_path / "trades_raw.csv"
+    data.write_text(
+        "label,event_time,price\n"
+        "0,2024-01-01,1.0\n"
+        "1,2024-01-03,1.1\n"
+    )
+    out_dir = tmp_path / "out"
+    train(data, out_dir, half_life_days=1.0)
+    model = json.loads((out_dir / "model.json").read_text())
+    assert model["half_life_days"] == 1.0


### PR DESCRIPTION
## Summary
- Add exponential time-decay sample weighting with configurable half-life
- Record `half_life_days` in trained model metadata
- Document decay mechanism and add regression tests for weight decay

## Testing
- `pytest tests/test_time_series_split_and_weighting.py tests/test_train_target_clone_half_life.py tests/test_train_target_clone_scaler.py tests/test_target_clone_cross_validation.py tests/test_extra_price_features.py`

------
https://chatgpt.com/codex/tasks/task_e_68bced2e05c8832f877cab0a39bfe75c