### PR TITLE
Instrument metrics with OpenTelemetry and expose error counters

### DIFF
--- a/docs/metrics_dashboard.json
+++ b/docs/metrics_dashboard.json
@@ -94,6 +94,14 @@
       "targets": [
         {"expr": "bot_cvar"}
       ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Queue Backlog",
+      "id": 12,
+      "targets": [
+        {"expr": "bot_queue_backlog"}
+      ]
     }
   ]
 }

--- a/tests/test_metrics_collector_writer.py
+++ b/tests/test_metrics_collector_writer.py
@@ -1,0 +1,55 @@
+import asyncio
+import sqlite3
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from scripts import metrics_collector as mc
+
+
+def test_writer_persists_trace_and_errors(tmp_path):
+    async def _run():
+        db = tmp_path / "m.db"
+        q = asyncio.Queue()
+        row = {
+        "time": "t",
+        "magic": "0",
+        "win_rate": "0.1",
+        "avg_profit": "0.2",
+        "trade_count": "1",
+        "drawdown": "0.0",
+        "sharpe": "0.0",
+        "sortino": "0.0",
+        "expectancy": "0.0",
+        "cvar": "0.0",
+        "file_write_errors": 1,
+        "socket_errors": 2,
+        "cpu_load": "0",
+        "flush_latency_ms": "0",
+        "network_latency_ms": "0",
+        "book_refresh_seconds": "0",
+        "var_breach_count": "0",
+        "trade_queue_depth": "0",
+        "metric_queue_depth": "0",
+        "trade_retry_count": "0",
+        "metric_retry_count": "0",
+        "fallback_events": 0,
+        "risk_weight": "0",
+        "trace_id": "trace123",
+        "span_id": "span456",
+        "queue_backlog": 5,
+        }
+        await q.put(row)
+        await q.put(None)
+        await mc._writer_task(db, q, lambda _r: None)
+        conn = sqlite3.connect(db)
+        try:
+            cur = conn.execute(
+                "SELECT file_write_errors, socket_errors, queue_backlog, trace_id, span_id FROM metrics"
+            )
+            data = cur.fetchone()
+        finally:
+            conn.close()
+        assert data == ("1", "2", "5", "trace123", "span456")
+
+    asyncio.run(_run())

--- a/tests/test_stream_listener_metrics_trace.py
+++ b/tests/test_stream_listener_metrics_trace.py
@@ -1,0 +1,39 @@
+from types import SimpleNamespace
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from scripts import stream_listener as sl
+
+
+def test_metric_record_has_errors_and_trace(monkeypatch):
+    records = []
+
+    def fake_append(path, record):
+        records.append(record)
+
+    monkeypatch.setattr(sl, "append_csv", fake_append)
+
+    msg = SimpleNamespace(
+        time="t",
+        magic=0,
+        winRate=0.1,
+        avgProfit=0.2,
+        tradeCount=1,
+        drawdown=0.0,
+        sharpe=0.0,
+        fileWriteErrors=1,
+        socketErrors=2,
+        queueBacklog=3,
+        bookRefreshSeconds=0,
+    )
+
+    sl.process_metric(msg)
+
+    assert records
+    rec = records[0]
+    assert rec["file_write_errors"] == 1
+    assert rec["socket_errors"] == 2
+    assert rec["queue_backlog"] == 3
+    assert rec["trace_id"]
+    assert rec["span_id"]


### PR DESCRIPTION
## Summary
- Track file write, socket, and backlog counters in Observer_TBot and emit via WriteMetrics
- Propagate OpenTelemetry trace/span IDs through stream and metrics collectors, adding queue backlog support and Prometheus export
- Provide Grafana dashboard panel and tests verifying trace IDs and error counters in metrics

## Testing
- `pytest tests/test_stream_listener_metrics_trace.py tests/test_metrics_collector_writer.py tests/test_system_telemetry.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bcf7d80c90832fb55006fbcd972dc0