### PR TITLE
Add transformer training and MQL4 generation

### DIFF
--- a/tests/test_train_transformer.py
+++ b/tests/test_train_transformer.py
@@ -1,0 +1,36 @@
+import json
+from pathlib import Path
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+import scripts.generate_mql4_from_model as gen
+from scripts.train_target_clone import train
+
+
+def test_transformer_weights_and_generation(tmp_path):
+    data = tmp_path / "trades_raw.csv"
+    data.write_text(
+        "label,spread,hour\n"
+        "0,1.0,1\n"
+        "1,1.1,2\n"
+        "0,1.2,3\n"
+        "1,1.3,4\n"
+        "0,1.4,5\n"
+        "1,1.5,6\n"
+    )
+    out_dir = tmp_path / "out"
+    train(data, out_dir, model_type="transformer", window=2, epochs=1)
+    model = json.loads((out_dir / "model.json").read_text())
+    assert model["model_type"] == "transformer"
+    weights = model["weights"]
+    for key in ["q_weight", "k_weight", "v_weight", "out_weight"]:
+        assert key in weights and weights[key]
+
+    template = tmp_path / "Strategy.mq4"
+    template.write_text(Path("StrategyTemplate.mq4").read_text())
+    gen.insert_get_feature(out_dir / "model.json", template)
+    content = template.read_text()
+    assert "g_q_weight" in content
+    assert "seq_len=" in content


### PR DESCRIPTION
## Summary
- add transformer model that attends over recent feature windows and exports weights
- generate MQL4 expert to run transformer with sliding feature buffer and log sequence length
- regression test ensures transformer weights are exported and inserted into generated code

## Testing
- `pytest tests/test_train_transformer.py -q` *(skipped: torch not installed)*


------
https://chatgpt.com/codex/tasks/task_e_68bd05f78740832f9cc691250795a887