### PR TITLE
Calibrate classifier and add symbol thresholds

### DIFF
--- a/StrategyTemplate.mq4
+++ b/StrategyTemplate.mq4
@@ -42,6 +42,13 @@ double GraphEmbedding(int idx)
 }
 // __SYMBOL_EMBEDDINGS_END__
 
+// __SYMBOL_THRESHOLDS_START__
+double SymbolThreshold()
+{
+    return g_threshold;
+}
+// __SYMBOL_THRESHOLDS_END__
+
 int RouteModel()
 {
     double vol = iStdDev(Symbol(), PERIOD_CURRENT, 14, 0, MODE_SMA, PRICE_CLOSE, 0);
@@ -530,7 +537,7 @@ void OnTick()
         decision = "skip";
         reason = "uncertain_prob";
     }
-    else if(prob > g_threshold)
+    else if(prob > SymbolThreshold())
     {
         double sl_price = Ask - sl * Point;
         double tp_price = Ask + tp * Point;
@@ -540,7 +547,7 @@ void OnTick()
             decision = "buy";
         }
     }
-    else if((1.0 - prob) > g_threshold)
+    else if((1.0 - prob) > SymbolThreshold())
     {
         double sl_price = Bid + sl * Point;
         double tp_price = Bid - tp * Point;

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -1,0 +1,88 @@
+import json
+import subprocess
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+from sklearn.calibration import CalibratedClassifierCV
+from sklearn.linear_model import SGDClassifier
+from sklearn.preprocessing import StandardScaler
+
+from scripts.train_target_clone import train
+
+
+def _make_dataset(tmp_path: Path) -> Path:
+    df = pd.DataFrame(
+        {
+            "symbol": ["EURUSD"] * 20 + ["GBPUSD"] * 20,
+            "feature": list(range(40)),
+            "label": [0] * 10 + [1] * 10 + [0] * 10 + [1] * 10,
+        }
+    )
+    file = tmp_path / "trades_raw.csv"
+    df.to_csv(file, index=False)
+    return file
+
+
+def test_calibrated_probabilities_and_symbol_thresholds(tmp_path):
+    data_file = _make_dataset(tmp_path)
+    out = tmp_path / "out"
+    train(data_file, out)
+    model = json.loads((out / "model.json").read_text())
+    assert "symbol_thresholds" in model
+    assert set(model["symbol_thresholds"].keys()) == {"EURUSD", "GBPUSD"}
+    # verify calibration alters probabilities
+    df = pd.read_csv(data_file)
+    X = df[["feature"]].to_numpy()
+    y = df["label"].to_numpy()
+    scaler = StandardScaler().fit(X)
+    clf = SGDClassifier(loss="log_loss").fit(scaler.transform(X), y)
+    calib = CalibratedClassifierCV(clf, method="isotonic", cv="prefit").fit(
+        scaler.transform(X), y
+    )
+    probs_raw = clf.predict_proba(scaler.transform(X))[:, 1]
+    probs_cal = calib.predict_proba(scaler.transform(X))[:, 1]
+    assert not np.allclose(probs_raw, probs_cal)
+
+
+def test_threshold_lookup_in_mql4(tmp_path):
+    model = tmp_path / "model.json"
+    model.write_text(
+        json.dumps(
+            {
+                "feature_names": [],
+                "models": {
+                    "logreg": {
+                        "coefficients": [1.0],
+                        "intercept": 0.0,
+                        "threshold": 0.5,
+                        "feature_mean": [0.0],
+                        "feature_std": [1.0],
+                        "conformal_lower": 0.0,
+                        "conformal_upper": 1.0,
+                    }
+                },
+                "symbol_thresholds": {"EURUSD": 0.7},
+            }
+        )
+    )
+    template_src = Path(__file__).resolve().parents[1] / "StrategyTemplate.mq4"
+    template = tmp_path / "StrategyTemplate.mq4"
+    template.write_text(template_src.read_text())
+    subprocess.run(
+        [
+            sys.executable,
+            "scripts/generate_mql4_from_model.py",
+            "--model",
+            model,
+            "--template",
+            template,
+        ],
+        check=True,
+    )
+    content = template.read_text()
+    assert 'if(s == "EURUSD") return 0.7;' in content
+    assert "prob > SymbolThreshold()" in content


### PR DESCRIPTION
## Summary
- calibrate per-symbol classifiers with `CalibratedClassifierCV` and persist computed thresholds
- generate MQL4 code that looks up thresholds by symbol
- use symbol-specific thresholds in strategy template
- add tests ensuring calibration and threshold lookup work

## Testing
- `pytest tests/test_calibration.py tests/test_generate_mql4_from_model.py`

------
https://chatgpt.com/codex/tasks/task_e_68bd0aa8ee88832fb96a3f2b767f0ef5