### PR TITLE
Train gating network and route models based on volatility/time

### DIFF
--- a/StrategyTemplate.mq4
+++ b/StrategyTemplate.mq4
@@ -51,16 +51,21 @@ double SymbolThreshold()
 
 int RouteModel()
 {
-    double vol = iStdDev(Symbol(), PERIOD_CURRENT, 14, 0, MODE_SMA, PRICE_CLOSE, 0);
-    double hour = TimeHour(TimeCurrent());
+    double features[2];
+    features[0] = iStdDev(Symbol(), PERIOD_CURRENT, 14, 0, MODE_SMA, PRICE_CLOSE, 0);
+    features[1] = TimeHour(TimeCurrent());
     int count = ArraySize(g_router_intercept);
+    int fcount = ArraySize(g_router_feature_mean);
     double best = -1e10;
     int best_idx = 0;
     for(int i = 0; i < count; i++)
     {
         double z = g_router_intercept[i];
-        z += (vol - g_router_feature_mean[0]) / g_router_feature_std[0] * g_router_coeffs[i*2];
-        z += (hour - g_router_feature_mean[1]) / g_router_feature_std[1] * g_router_coeffs[i*2 + 1];
+        for(int f = 0; f < fcount; f++)
+        {
+            double val = features[f];
+            z += (val - g_router_feature_mean[f]) / g_router_feature_std[f] * g_router_coeffs[i*fcount + f];
+        }
         if(z > best)
         {
             best = z;

--- a/scripts/generate_mql4_from_model.py
+++ b/scripts/generate_mql4_from_model.py
@@ -131,6 +131,13 @@ def _build_session_models(data: dict) -> str:
         lines.append(f"double g_router_coeffs[] = {{{coeffs}}};")
         lines.append(f"double g_router_feature_mean[] = {{{mean}}};")
         lines.append(f"double g_router_feature_std[] = {{{std}}};")
+    else:
+        # Provide default zeroed router arrays so the template compiles even
+        # without trained gating weights.
+        lines.append("double g_router_intercept[1] = {0.0};")
+        lines.append("double g_router_coeffs[2] = {0.0, 0.0};")
+        lines.append("double g_router_feature_mean[2] = {0.0, 0.0};")
+        lines.append("double g_router_feature_std[2] = {1.0, 1.0};")
 
     return "\n".join(lines)
 


### PR DESCRIPTION
## Summary
- Train three logistic base models for different volatility regimes and learn a router that picks the best model from volatility and hour features
- Ensure generated MQL4 strategies embed router weights and default to safe zeros when missing
- Evaluate router dynamically in StrategyTemplate so coefficients for the chosen model are loaded at runtime
- Add unit test verifying training outputs router weights and multiple model blocks in generated EA

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd0c9768a8832f9458140c42fb6605