### PR TITLE
Prune features via SHAP and update MQL4 generator

### DIFF
--- a/scripts/generate_mql4_from_model.py
+++ b/scripts/generate_mql4_from_model.py
@@ -271,7 +271,7 @@ def _build_transformer_params(data: dict) -> str:
 def insert_get_feature(model: Path, template: Path) -> None:
     """Insert generated GetFeature and session models into ``template``."""
     data = json.loads(model.read_text())
-    feature_names = data.get("feature_names", [])
+    feature_names = data.get("retained_features") or data.get("feature_names", [])
     get_feature = build_switch(feature_names)
     session_models = _build_session_models(data)
     symbol_emb = _build_symbol_embeddings(data.get("symbol_embeddings", {}))

--- a/tests/test_generate_mql4_from_model.py
+++ b/tests/test_generate_mql4_from_model.py
@@ -91,6 +91,37 @@ def test_generated_features(tmp_path):
     ]
 
 
+def test_pruned_features_not_emitted(tmp_path):
+    model = tmp_path / "model.json"
+    model.write_text(
+        json.dumps(
+            {
+                "feature_names": ["spread", "slippage"],
+                "retained_features": ["slippage"],
+            }
+        )
+    )
+
+    template = tmp_path / "StrategyTemplate.mq4"
+    template.write_text("#property strict\n\n// __GET_FEATURE__\n")
+
+    subprocess.run(
+        [
+            sys.executable,
+            "scripts/generate_mql4_from_model.py",
+            "--model",
+            model,
+            "--template",
+            template,
+        ],
+        check=True,
+    )
+
+    content = template.read_text()
+    assert "OrderSlippage()" in content
+    assert "MODE_SPREAD" not in content
+
+
 def test_models_and_router_inserted(tmp_path):
     model = tmp_path / "model.json"
     model.write_text(


### PR DESCRIPTION
## Summary
- add SHAP-based feature pruning with configurable `--prune-threshold`
- export retained features and importance data to `model.json`
- generate MQL4 switch cases only for kept features and test pruning

## Testing
- `pytest tests/test_generate_mql4_from_model.py -q`
- `pytest tests/test_train_target_clone_scaler.py::test_scaler_stats_present -q`


------
https://chatgpt.com/codex/tasks/task_e_68bdb5b306ec832fba6c3ce9b44ad663