### PR TITLE
Distil transformer teacher into logistic student

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,16 @@ Run the unit tests:
 pytest
 ```
 
+## Model distillation
+
+The training pipeline can fit a high-capacity transformer model and then
+distil it into a simple logistic regression.  After the transformer is trained
+on rolling feature windows, its probabilities for each training sample are used
+as soft targets for a linear student.  The distilled coefficients and teacher
+evaluation metrics are saved in ``model.json`` and are embedded into
+``StrategyTemplate.mq4`` by ``scripts/generate_mql4_from_model.py`` for use in
+MetaTrader.
+
 ## Memory usage
 
 The log loading helpers in `scripts/train_target_clone.py` and

--- a/tests/test_train_transformer.py
+++ b/tests/test_train_transformer.py
@@ -27,6 +27,8 @@ def test_transformer_weights_and_generation(tmp_path):
     weights = model["weights"]
     for key in ["q_weight", "k_weight", "v_weight", "out_weight"]:
         assert key in weights and weights[key]
+    assert "teacher_metrics" in model
+    assert "distilled" in model and model["distilled"]["coefficients"]
 
     template = tmp_path / "Strategy.mq4"
     template.write_text(Path("StrategyTemplate.mq4").read_text())
@@ -34,3 +36,4 @@ def test_transformer_weights_and_generation(tmp_path):
     content = template.read_text()
     assert "g_q_weight" in content
     assert "seq_len=" in content
+    assert "g_coeffs_logreg" in content


### PR DESCRIPTION
## Summary
- Train transformer and distil its soft outputs into a logistic regression student
- Export distilled coefficients and teacher metrics to model.json and generate MQL4 code
- Document the distillation process in the README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bdbe70fd64832fb5240f3d2ae658b5