### PR TITLE
Add ATR-based volatility and normalized risk distances

### DIFF
--- a/scripts/features.py
+++ b/scripts/features.py
@@ -251,7 +251,6 @@ def _extract_features(
     use_rsi=False,
     rsi_period=14,
     use_macd=False,
-    use_atr=False,
     atr_period=14,
     use_bollinger=False,
     boll_window=20,
@@ -397,7 +396,6 @@ def _extract_features(
         "use_adx",
         "use_stochastic",
         "use_bollinger",
-        "use_atr",
     ]
 
     for r in rows:
@@ -582,8 +580,14 @@ def _extract_features(
             feat["macd"] = macd
             feat["macd_signal"] = signal
 
-        if use_atr:
-            feat["atr"] = _atr(prices, atr_period)
+        atr_val = _atr(prices, atr_period)
+        feat["atr"] = atr_val
+        if atr_val > 0:
+            feat["sl_dist_atr"] = sl_dist / atr_val
+            feat["tp_dist_atr"] = tp_dist / atr_val
+        else:
+            feat["sl_dist_atr"] = 0.0
+            feat["tp_dist_atr"] = 0.0
 
         if use_bollinger:
             upper, mid, lower = _bollinger(prices, boll_window)
@@ -728,9 +732,7 @@ def _extract_features(
                 elapsed > perf_budget * row_idx or load > 90.0
             ):
                 feat_name = heavy_order.pop(0)
-                if feat_name == "use_atr":
-                    use_atr = False
-                elif feat_name == "use_bollinger":
+                if feat_name == "use_bollinger":
                     use_bollinger = False
                 elif feat_name == "use_stochastic":
                     use_stochastic = False
@@ -758,8 +760,7 @@ def _extract_features(
         enabled_feats.append("rsi")
     if use_macd:
         enabled_feats.append("macd")
-    if use_atr:
-        enabled_feats.append("atr")
+    enabled_feats.append("atr")
     if use_bollinger:
         enabled_feats.append("bollinger")
     if use_stochastic:

--- a/scripts/generate_mql4_from_model.py
+++ b/scripts/generate_mql4_from_model.py
@@ -33,6 +33,7 @@ FEATURE_MAP: dict[str, str] = {
     "slippage": "OrderSlippage()",
     "equity": "AccountEquity()",
     "margin_level": "AccountMarginLevel()",
+    "atr": "iATR(Symbol(), PERIOD_CURRENT, 14, 0)",
     "event_flag": "CalendarFlag()",
     "event_impact": "CalendarImpact()",
     "news_sentiment": "NewsSentiment()",

--- a/tests/test_features_module.py
+++ b/tests/test_features_module.py
@@ -33,6 +33,9 @@ def test_extract_features_basic():
     feats, labels, *_ = _extract_features(rows)
     assert len(feats) == 2
     assert labels.tolist() == [1, 0]
+    assert "atr" in feats[0]
+    assert "sl_dist_atr" in feats[0]
+    assert "tp_dist_atr" in feats[0]
 
 
 def test_mandatory_features_present():
@@ -50,5 +53,5 @@ def test_mandatory_features_present():
         }
     ]
     feats, *_ = _extract_features(rows)
-    for key in ["book_bid_vol", "book_ask_vol", "book_imbalance", "equity", "margin_level"]:
+    for key in ["book_bid_vol", "book_ask_vol", "book_imbalance", "equity", "margin_level", "atr"]:
         assert key in feats[0]

--- a/tests/test_generate_mql4_from_model.py
+++ b/tests/test_generate_mql4_from_model.py
@@ -23,6 +23,7 @@ def test_generated_features(tmp_path):
                     "month_cos",
                     "dom_sin",
                     "dom_cos",
+                    "atr",
                 ]
             }
         )
@@ -74,6 +75,9 @@ def test_generated_features(tmp_path):
         "case 10: return MathCos((TimeDay(TimeCurrent())-1)*2*MathPi()/31); // dom_cos"
         in content
     )
+    assert (
+        "case 11: return iATR(Symbol(), PERIOD_CURRENT, 14, 0); // atr" in content
+    )
 
     data = json.loads(model.read_text())
     assert data["feature_names"] == [
@@ -88,6 +92,7 @@ def test_generated_features(tmp_path):
         "month_cos",
         "dom_sin",
         "dom_cos",
+        "atr",
     ]
 
 


### PR DESCRIPTION
## Summary
- compute ATR volatility for each feature row and provide normalized SL/TP distances
- expose ATR in generated MQL4 strategies so runtime features align with training
- extend tests for feature extraction and MQL4 generation

## Testing
- `pytest tests/test_features_module.py tests/test_generate_mql4_from_model.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bdcb02e4d0832fb0b65d34be722fac