### PR TITLE
feat: add basic price indicators

### DIFF
--- a/tests/test_train_target_clone_features.py
+++ b/tests/test_train_target_clone_features.py
@@ -1,2 +1,32 @@
-import pytest
-pytestmark = pytest.mark.skip(reason="legacy MQL4 functionality removed")
+import json
+from pathlib import Path
+
+from scripts.train_target_clone import train
+
+
+def test_price_indicators_persisted(tmp_path: Path) -> None:
+    data = tmp_path / "trades_raw.csv"
+    rows = [
+        "label,price,hour,symbol\n",
+        "0,1.0,0,EURUSD\n",
+        "1,1.1,1,EURUSD\n",
+        "0,1.2,2,EURUSD\n",
+        "1,1.3,3,EURUSD\n",
+        "0,1.4,4,EURUSD\n",
+    ]
+    data.write_text("".join(rows))
+    out_dir = tmp_path / "out"
+    train(data, out_dir)
+    model = json.loads((out_dir / "model.json").read_text())
+    for name in [
+        "sma",
+        "rsi",
+        "macd",
+        "macd_signal",
+        "bollinger_upper",
+        "bollinger_middle",
+        "bollinger_lower",
+        "atr",
+    ]:
+        assert name in model["feature_names"]
+


### PR DESCRIPTION
## Summary
- compute SMA, RSI, MACD and Bollinger bands for price series during target clone training
- track these indicators in `feature_names` and write them to `model.json`
- test that model training persists the new indicator features

## Testing
- `pytest tests/test_train_target_clone_features.py::test_price_indicators_persisted -q`
- `pytest tests/test_extra_price_features.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bde76ff3c8832fbe2e4bf7bcb803a5