### PR TITLE
Add voting ensemble option to target clone trainer

### DIFF
--- a/tests/test_train_target_clone_validation.py
+++ b/tests/test_train_target_clone_validation.py
@@ -1,2 +1,41 @@
-import pytest
-pytestmark = pytest.mark.skip(reason="legacy MQL4 functionality removed")
+import json
+from pathlib import Path
+
+import pandas as pd
+from sklearn.datasets import make_classification
+
+from scripts.train_target_clone import train
+
+
+def test_voting_ensemble_improves_accuracy(tmp_path):
+    X, y = make_classification(
+        n_samples=200,
+        n_features=11,
+        n_informative=5,
+        n_redundant=0,
+        random_state=0,
+        flip_y=0.4,
+    )
+    cols = [
+        "spread",
+        "slippage",
+        "equity",
+        "margin_level",
+        "volume",
+        "hour_sin",
+        "hour_cos",
+        "month_sin",
+        "month_cos",
+        "dom_sin",
+        "dom_cos",
+    ]
+    df = pd.DataFrame(X, columns=cols)
+    df["label"] = y
+    data_file = tmp_path / "trades_raw.csv"
+    df.to_csv(data_file, index=False)
+    out_dir = tmp_path / "out"
+    train(data_file, out_dir, ensemble="voting")
+    model = json.loads((out_dir / "model.json").read_text())
+    ensemble = model["ensemble"]
+    assert ensemble["estimators"] == ["logreg", "gboost"]
+    assert ensemble["accuracy"] >= max(ensemble["base_accuracies"].values())


### PR DESCRIPTION
## Summary
- add Voting/Stacking ensemble option to `train_target_clone`
- persist ensemble metadata including estimator names and weights to `model.json`
- update CLI to toggle ensemble mode
- test that voting ensemble improves accuracy on synthetic data

## Testing
- `pytest tests/test_train_target_clone_validation.py -q`
- `pytest tests/test_train_target_clone_scaler.py tests/test_train_target_clone_features.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bdea727ab0832f9b4b8bae9c7538a6