### PR TITLE
Add lagged and diff features for trade metrics

### DIFF
--- a/scripts/train_target_clone.py
+++ b/scripts/train_target_clone.py
@@ -330,6 +330,20 @@ def _extract_features(
             "bollinger_lower",
             "atr",
         ]
+    base_cols: dict[str, str] = {}
+    if price_col is not None:
+        base_cols["price"] = price_col
+    for col in ["volume", "spread"]:
+        if col in df.columns:
+            base_cols[col] = col
+    for name, src in base_cols.items():
+        series = pd.to_numeric(df[src], errors="coerce")
+        df[f"{name}_lag_1"] = series.shift(1).fillna(0.0)
+        df[f"{name}_lag_5"] = series.shift(5).fillna(0.0)
+        df[f"{name}_diff"] = series.diff().fillna(0.0)
+        feature_names.extend(
+            [f"{name}_lag_1", f"{name}_lag_5", f"{name}_diff"]
+        )
     return df, feature_names, embeddings
 
 

--- a/tests/test_train_target_clone_features.py
+++ b/tests/test_train_target_clone_features.py
@@ -1,18 +1,18 @@
 import json
 from pathlib import Path
 
-from scripts.train_target_clone import train
+from scripts.train_target_clone import _extract_features, _load_logs, train
 
 
 def test_price_indicators_persisted(tmp_path: Path) -> None:
     data = tmp_path / "trades_raw.csv"
     rows = [
-        "label,price,hour,symbol\n",
-        "0,1.0,0,EURUSD\n",
-        "1,1.1,1,EURUSD\n",
-        "0,1.2,2,EURUSD\n",
-        "1,1.3,3,EURUSD\n",
-        "0,1.4,4,EURUSD\n",
+        "label,price,volume,spread,hour,symbol\n",
+        "0,1.0,100,1.5,0,EURUSD\n",
+        "1,1.1,110,1.6,1,EURUSD\n",
+        "0,1.2,120,1.7,2,EURUSD\n",
+        "1,1.3,130,1.8,3,EURUSD\n",
+        "0,1.4,140,1.9,4,EURUSD\n",
     ]
     data.write_text("".join(rows))
     out_dir = tmp_path / "out"
@@ -29,4 +29,12 @@ def test_price_indicators_persisted(tmp_path: Path) -> None:
         "atr",
     ]:
         assert name in model["feature_names"]
+    for col in ["price", "volume", "spread"]:
+        for feat in [f"{col}_lag_1", f"{col}_lag_5", f"{col}_diff"]:
+            assert feat in model["feature_names"]
+    df, feature_cols, _ = _load_logs(data)
+    df, _, _ = _extract_features(df, feature_cols)
+    for col in ["price", "volume", "spread"]:
+        for feat in [f"{col}_lag_1", f"{col}_lag_5", f"{col}_diff"]:
+            assert df[feat].notna().all()
 


### PR DESCRIPTION
## Summary
- compute 1/5-step lags and first differences for price, volume, and spread
- persist new lagged feature names in the trained model
- test that lagged fields exist and contain no NaNs

## Testing
- `pytest tests/test_train_target_clone_features.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bdee9a43c8832fa24bf340c169d53c