### PR TITLE
Add neighbor correlation features to target clone training

### DIFF
--- a/tests/test_train_target_clone_features.py
+++ b/tests/test_train_target_clone_features.py
@@ -39,6 +39,37 @@ def test_price_indicators_persisted(tmp_path: Path) -> None:
             assert df[feat].notna().all()
 
 
+def test_neighbor_correlation_features(tmp_path: Path) -> None:
+    data = tmp_path / "trades_raw.csv"
+    rows = [
+        "label,price,hour,symbol,event_time\n",
+        "0,1.0,0,EURUSD,2020-01-01T00:00:00\n",
+        "0,0.9,0,USDCHF,2020-01-01T00:00:00\n",
+        "1,1.1,1,EURUSD,2020-01-01T00:01:00\n",
+        "1,0.95,1,USDCHF,2020-01-01T00:01:00\n",
+        "0,1.2,2,EURUSD,2020-01-01T00:02:00\n",
+        "0,1.0,2,USDCHF,2020-01-01T00:02:00\n",
+        "1,1.3,3,EURUSD,2020-01-01T00:03:00\n",
+        "1,1.05,3,USDCHF,2020-01-01T00:03:00\n",
+        "0,1.4,4,EURUSD,2020-01-01T00:04:00\n",
+        "0,1.1,4,USDCHF,2020-01-01T00:04:00\n",
+    ]
+    data.write_text("".join(rows))
+    out_dir = tmp_path / "out"
+    sg_path = Path(__file__).resolve().parent.parent / "symbol_graph.json"
+    train(data, out_dir, symbol_graph=sg_path, neighbor_corr_windows=[3])
+    model = json.loads((out_dir / "model.json").read_text())
+    corr_cols = ["corr_EURUSD_USDCHF_w3", "corr_USDCHF_EURUSD_w3"]
+    for col in corr_cols:
+        assert col in model["feature_names"]
+    df, feature_cols, _ = _load_logs(data)
+    df, _, _ = _extract_features(
+        df, feature_cols, symbol_graph=sg_path, neighbor_corr_windows=[3]
+    )
+    for col in corr_cols:
+        assert df[col].notna().all()
+
+
 def test_mutual_info_feature_filter(tmp_path: Path) -> None:
     data = tmp_path / "trades_raw.csv"
     rows = [


### PR DESCRIPTION
## Summary
- compute rolling correlations with graph neighbors in `_extract_features`
- add CLI flag for configurable neighbor correlation windows
- test persistence and non-null values of correlation features

## Testing
- `pytest tests/test_train_target_clone_features.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bdfaaf6fec832f8a8ea6f4b166e724