### PR TITLE
Add device support and mixed precision to transformer training

### DIFF
--- a/tests/test_train_transformer.py
+++ b/tests/test_train_transformer.py
@@ -21,7 +21,19 @@ def test_transformer_weights_and_generation(tmp_path):
         "1,1.5,6\n"
     )
     out_dir = tmp_path / "out"
-    train(data, out_dir, model_type="transformer", window=2, epochs=1)
+    model_obj = train(data, out_dir, model_type="transformer", window=2, epochs=1)
+    assert next(model_obj.parameters()).device.type == "cpu"
+    if torch.cuda.is_available():
+        cuda_dir = tmp_path / "out_cuda"
+        cuda_model = train(
+            data,
+            cuda_dir,
+            model_type="transformer",
+            window=2,
+            epochs=1,
+            device="cuda",
+        )
+        assert next(cuda_model.parameters()).device.type == "cuda"
     model = json.loads((out_dir / "model.json").read_text())
     assert model["model_type"] == "transformer"
     weights = model["weights"]

--- a/tests/test_train_transformer_synthetic.py
+++ b/tests/test_train_transformer_synthetic.py
@@ -38,7 +38,7 @@ def test_transformer_with_synthetic_sequences(tmp_path):
         "1,1.5,6\n"
     )
     out_dir = tmp_path / "out"
-    train(
+    model_obj = train(
         data,
         out_dir,
         model_type="transformer",
@@ -48,6 +48,21 @@ def test_transformer_with_synthetic_sequences(tmp_path):
         synthetic_frac=1.0,
         synthetic_weight=0.5,
     )
+    assert next(model_obj.parameters()).device.type == "cpu"
+    if torch.cuda.is_available():
+        cuda_dir = tmp_path / "out_cuda"
+        cuda_model = train(
+            data,
+            cuda_dir,
+            model_type="transformer",
+            window=2,
+            epochs=1,
+            synthetic_model=gan_path,
+            synthetic_frac=1.0,
+            synthetic_weight=0.5,
+            device="cuda",
+        )
+        assert next(cuda_model.parameters()).device.type == "cuda"
 
     model = json.loads((out_dir / "model.json").read_text())
     assert "synthetic_metrics" in model


### PR DESCRIPTION
## Summary
- Add `device` parameter and CLI flag to `_train_transformer`
- Move data/model to selected device and use AMP `autocast` with `GradScaler` on CUDA
- Return trained model for verification and update tests to check CPU/GPU placement

## Testing
- `python -m pytest tests/test_train_transformer.py tests/test_train_transformer_synthetic.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68be002176d0832f88c2e4f49c44fe5c