### PR TITLE
Add time-decay sample weighting

### DIFF
--- a/tests/test_train_target_clone_half_life.py
+++ b/tests/test_train_target_clone_half_life.py
@@ -14,3 +14,26 @@ def test_half_life_recorded(tmp_path):
     train(data, out_dir, half_life_days=1.0)
     model = json.loads((out_dir / "model.json").read_text())
     assert model["half_life_days"] == 1.0
+
+
+def test_decay_weighting_changes_coefficients(tmp_path):
+    data = tmp_path / "trades_raw.csv"
+    rows = [
+        "label,event_time,price\n",
+        "0,2024-01-01,1.0\n",
+        "0,2024-01-02,2.0\n",
+        "0,2024-01-03,3.0\n",
+        "1,2024-01-04,4.0\n",
+    ]
+    data.write_text("".join(rows))
+    out1 = tmp_path / "out1"
+    train(data, out1)
+    coeffs1 = json.loads((out1 / "model.json").read_text())["session_models"][
+        "asian"
+    ]["coefficients"]
+    out2 = tmp_path / "out2"
+    train(data, out2, half_life_days=0.5)
+    coeffs2 = json.loads((out2 / "model.json").read_text())["session_models"][
+        "asian"
+    ]["coefficients"]
+    assert any(abs(a - b) > 1e-6 for a, b in zip(coeffs1, coeffs2))


### PR DESCRIPTION
## Summary
- compute exponential decay weights from `event_time` via `_compute_decay_weights`
- normalise and pass weights to model fitters
- test that time-decay weighting alters fitted coefficients

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68be0397da28832f8ba82d25601876ad