### PR TITLE
Add polynomial interaction features

### DIFF
--- a/tests/test_train_target_clone_features.py
+++ b/tests/test_train_target_clone_features.py
@@ -37,6 +37,8 @@ def test_price_indicators_persisted(tmp_path: Path) -> None:
     for col in ["price", "volume", "spread"]:
         for feat in [f"{col}_lag_1", f"{col}_lag_5", f"{col}_diff"]:
             assert df[feat].notna().all()
+    assert "sma*rsi" in model["feature_names"]
+    assert df["sma*rsi"].notna().all()
 
 
 def test_neighbor_correlation_features(tmp_path: Path) -> None:
@@ -68,6 +70,8 @@ def test_neighbor_correlation_features(tmp_path: Path) -> None:
     )
     for col in corr_cols:
         assert df[col].notna().all()
+    assert "sma*rsi" in model["feature_names"]
+    assert df["sma*rsi"].notna().all()
 
 
 def test_mutual_info_feature_filter(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Expand numeric features with pairwise interaction-only terms using `PolynomialFeatures`
- Persist interaction names in `feature_names` and model metadata
- Test that representative interaction fields exist and are non-NaN

## Testing
- `pytest tests/test_train_target_clone_features.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68be102c9be4832fbade223eefb361e0