### PR TITLE
Log and label uncertain decisions

### DIFF
--- a/scripts/generate_mql4_from_model.py
+++ b/scripts/generate_mql4_from_model.py
@@ -43,6 +43,7 @@ FEATURE_MAP: dict[str, str] = {
     "spread*spread_lag_1": "MarketInfo(Symbol(), MODE_SPREAD) * MarketInfo(Symbol(), MODE_SPREAD)",
     "spread*spread_lag_5": "MarketInfo(Symbol(), MODE_SPREAD) * MarketInfo(Symbol(), MODE_SPREAD)",
     "spread*spread_diff": "MarketInfo(Symbol(), MODE_SPREAD) * MarketInfo(Symbol(), MODE_SPREAD)",
+    "hour_sin*hour_cos": "MathSin(TimeHour(TimeCurrent())*2*MathPi()/24) * MathCos(TimeHour(TimeCurrent())*2*MathPi()/24)",
 }
 
 GET_FEATURE_TEMPLATE = """double GetFeature(int idx)\n{{\n    switch(idx)\n    {{\n{cases}\n    }}\n    return 0.0;\n}}\n"""

--- a/scripts/uncertain_scheduler.py
+++ b/scripts/uncertain_scheduler.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Periodically run ``label_uncertain.py`` to label low-confidence decisions.
+
+This lightweight scheduler calls :mod:`scripts.label_uncertain` at a fixed
+interval.  It can optionally start a tiny web UI that allows labeling via a
+browser.  The web UI simply forwards submitted labels to ``label_uncertain.py``
+so the implementation stays minimal and dependency free.
+"""
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+from urllib.parse import parse_qs
+
+SCRIPT = Path(__file__).resolve().parent / "label_uncertain.py"
+
+
+def _run_labeler(input_file: Path, output_file: Path, label: int | None) -> None:
+    cmd = [sys.executable, str(SCRIPT), str(input_file), str(output_file)]
+    if label is not None:
+        cmd += ["--label", str(label)]
+    subprocess.run(cmd, check=True)
+
+
+class _Handler(BaseHTTPRequestHandler):  # pragma: no cover - simple utility
+    def do_GET(self) -> None:  # noqa: N802 - required by BaseHTTPRequestHandler
+        body = (
+            "<html><body><form method='post'>Label (0/1):"
+            "<input name='label'/><input type='submit'/></form></body></html>"
+        ).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "text/html")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_POST(self) -> None:  # noqa: N802 - required by BaseHTTPRequestHandler
+        length = int(self.headers.get("Content-Length", "0"))
+        data = self.rfile.read(length).decode()
+        label = parse_qs(data).get("label", ["0"])[0]
+        try:
+            lbl = int(label)
+        except ValueError:
+            lbl = 0
+        _run_labeler(self.server.input_file, self.server.output_file, lbl)
+        self.send_response(303)
+        self.send_header("Location", "/")
+        self.end_headers()
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description="Schedule label_uncertain runs")
+    p.add_argument("--interval", type=float, default=3600.0, help="seconds between runs")
+    p.add_argument("--input", type=Path, default=Path("uncertain_decisions.csv"))
+    p.add_argument(
+        "--output",
+        type=Path,
+        default=Path("uncertain_decisions_labeled.csv"),
+        help="output CSV with labels",
+    )
+    p.add_argument("--label", type=int, choices=[0, 1], help="constant label to apply")
+    p.add_argument("--once", action="store_true", help="run once then exit")
+    p.add_argument("--host", default=None, help="optional host for web UI")
+    p.add_argument("--port", type=int, default=8000, help="port for web UI")
+    args = p.parse_args()
+
+    if args.host:
+        server = HTTPServer((args.host, args.port), _Handler)
+        server.input_file = args.input  # type: ignore[attr-defined]
+        server.output_file = args.output  # type: ignore[attr-defined]
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+
+    while True:
+        _run_labeler(args.input, args.output, args.label)
+        if args.once:
+            break
+        time.sleep(args.interval)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    main()

--- a/tests/test_generate_mql4_from_model.py
+++ b/tests/test_generate_mql4_from_model.py
@@ -236,6 +236,7 @@ def test_on_tick_logs_uncertain_reason(tmp_path):
     assert "prob >= g_conformal_lower && prob <= g_conformal_upper" in content
     assert 'decision = "skip"' in content
     assert ",reason=" in content
+    assert "LogUncertainDecision" in content
 
 def test_generation_fails_on_unmapped_feature(tmp_path):
     model = tmp_path / "model.json"

--- a/tests/test_train_uncertain.py
+++ b/tests/test_train_uncertain.py
@@ -1,0 +1,24 @@
+import csv
+import json
+from pathlib import Path
+
+from scripts.train_target_clone import train
+
+
+def test_train_with_uncertain_file(tmp_path, caplog):
+    data = tmp_path / "trades_raw.csv"
+    data.write_text(
+        "label,profit,hour,spread\n" "1,1.0,1,1.0\n" "0,-0.5,2,1.1\n"
+    )
+    uncertain = tmp_path / "uncertain_decisions_labeled.csv"
+    with uncertain.open("w", newline="") as f:
+        writer = csv.writer(f, delimiter=";")
+        writer.writerow(["action", "probability", "threshold", "features", "label"])
+        writer.writerow(["buy", "0.55", "0.5", "1.0:0.0:1.0", "1"])
+    out_dir = tmp_path / "out"
+    with caplog.at_level("INFO"):
+        train(data, out_dir, uncertain_file=uncertain, uncertain_weight=3.0)
+    model = json.loads((out_dir / "model.json").read_text())
+    metrics = model["session_models"]["0"]["metrics"]
+    assert "uncertain_accuracy" in metrics
+    assert any("uncertain sample metrics" in r.message for r in caplog.records)

--- a/tests/test_uncertain_scheduler.py
+++ b/tests/test_uncertain_scheduler.py
@@ -1,0 +1,29 @@
+import csv
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_scheduler_runs_labeler(tmp_path):
+    input_file = tmp_path / "uncertain_decisions.csv"
+    with input_file.open("w", newline="") as f:
+        writer = csv.writer(f, delimiter=";")
+        writer.writerow(["action", "probability", "threshold", "features", "label"])
+        writer.writerow(["buy", "0.4", "0.5", "0.1:0.2", ""])
+    out_file = tmp_path / "labeled.csv"
+    subprocess.run(
+        [
+            sys.executable,
+            "scripts/uncertain_scheduler.py",
+            "--once",
+            "--label",
+            "1",
+            "--input",
+            str(input_file),
+            "--output",
+            str(out_file),
+        ],
+        check=True,
+    )
+    rows = list(csv.reader(out_file.open(), delimiter=";"))
+    assert rows[1][-1] == "1"


### PR DESCRIPTION
## Summary
- Log low-confidence trading decisions to `uncertain_decisions.csv`
- Add a scheduler to periodically label uncertain decisions via `label_uncertain.py`
- Train pipeline supports labeled uncertain samples with configurable weighting and metric logging

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68be42b38ec8832fbe704845ffbb633b