### PR TITLE
Add quantile regression models and VaR/ES metrics

### DIFF
--- a/scripts/evaluation.py
+++ b/scripts/evaluation.py
@@ -211,11 +211,15 @@ def evaluate(pred_file: Path, actual_log: Path, window: int, model_json: Optiona
     downside_risk = -sum(downside) / len(downside) if downside else 0.0
     risk_reward = expected_return - downside_risk
     cvar = 0.0
+    var_95 = 0.0
+    es_95 = 0.0
     if profits:
         sorted_profits = sorted(profits)
         n_tail = max(1, int(math.ceil(len(sorted_profits) * 0.05)))
         tail = sorted_profits[:n_tail]
         cvar = sum(tail) / len(tail)
+        var_95 = float(np.quantile(profits, 0.05))
+        es_95 = float(np.mean([p for p in profits if p <= var_95]))
     sharpe = 0.0
     sortino = 0.0
     if len(profits) > 1:
@@ -261,6 +265,8 @@ def evaluate(pred_file: Path, actual_log: Path, window: int, model_json: Optiona
         "expected_return": expected_return,
         "downside_risk": downside_risk,
         "cvar": cvar,
+        "var_95": var_95,
+        "es_95": es_95,
         "sharpe_ratio": sharpe,
         "sortino_ratio": sortino,
         "risk_reward": risk_reward,

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -71,6 +71,8 @@ def test_evaluate(tmp_path: Path):
     assert stats["expected_return"] == 10
     assert stats["downside_risk"] == 0
     assert stats["risk_reward"] == 10
+    assert stats["var_95"] == 10
+    assert stats["es_95"] == 10
     assert stats["model_value_mean"] == model_info["value_mean"]
     assert stats["model_value_std"] == model_info["value_std"]
     assert stats["model_value_atoms"] == model_info["value_atoms"]

--- a/tests/test_train_target_clone_quantile_model.py
+++ b/tests/test_train_target_clone_quantile_model.py
@@ -1,0 +1,26 @@
+import json
+from pathlib import Path
+
+from scripts.train_target_clone import train
+
+
+def test_quantile_model_outputs_quantiles(tmp_path: Path) -> None:
+    data = tmp_path / "trades_raw.csv"
+    rows = [
+        "label,profit,hour,spread\n",
+        "1,2,1,1.0\n",
+        "0,1,2,0.0\n",
+        "1,2,3,1.1\n",
+        "0,1,4,0.1\n",
+        "1,2,5,1.2\n",
+        "0,1,6,0.2\n",
+    ]
+    data.write_text("".join(rows))
+    out_dir = tmp_path / "out"
+    train(data, out_dir, quantile_model=True)
+    model = json.loads((out_dir / "model.json").read_text())
+    preds = model.get("quantile_predictions")
+    assert preds is not None
+    assert set(preds.keys()) >= {"0.05", "0.5", "0.95"}
+    assert len(preds["0.5"]) == 6
+


### PR DESCRIPTION
## Summary
- implement `fit_quantile_model` to train GradientBoostingRegressor or QuantileRegressor for multiple quantiles
- integrate optional `--quantile-model` flag in target clone training and persist quantile predictions
- report VaR/ES metrics during evaluation and add regression tests for quantile outputs

## Testing
- `pytest tests/test_model_fitting.py::test_fit_quantile_model_produces_monotonic_quantiles tests/test_train_target_clone_quantile_model.py tests/test_evaluate.py::test_evaluate -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf92abf244832fba2d5f8f77ac14a2