### PR TITLE
Add configurable FocalLoss for PyTorch models

### DIFF
--- a/scripts/model_fitting.py
+++ b/scripts/model_fitting.py
@@ -45,6 +45,40 @@ except Exception:  # pragma: no cover - optional dependency
     pa = None  # type: ignore
     flight = None  # type: ignore
 
+try:  # pragma: no cover - optional dependency
+    import torch
+    import torch.nn.functional as F
+except Exception:  # pragma: no cover - optional dependency
+    torch = None  # type: ignore
+    F = None  # type: ignore
+
+if torch is not None:  # pragma: no cover - simple wrapper
+    class FocalLoss(torch.nn.Module):
+        """Binary Focal Loss for imbalanced classification."""
+
+        def __init__(self, gamma: float = 2.0, reduction: str = "mean") -> None:
+            super().__init__()
+            self.gamma = gamma
+            self.reduction = reduction
+
+        def forward(
+            self, input: "torch.Tensor", target: "torch.Tensor"
+        ) -> "torch.Tensor":
+            bce = F.binary_cross_entropy_with_logits(input, target, reduction="none")
+            pt = torch.exp(-bce)
+            loss = (1 - pt) ** self.gamma * bce
+            if self.reduction == "mean":
+                return loss.mean()
+            if self.reduction == "sum":
+                return loss.sum()
+            return loss
+
+else:  # pragma: no cover - torch optional
+
+    class FocalLoss:  # type: ignore[misc]
+        def __init__(self, *_, **__) -> None:
+            raise ImportError("PyTorch is required for FocalLoss")
+
 SCHEMA_VERSION = 3
 START_EVENT_ID = 0
 

--- a/tests/test_train_target_clone_sampling.py
+++ b/tests/test_train_target_clone_sampling.py
@@ -1,6 +1,13 @@
+import json
 import numpy as np
+import torch
 
-from scripts.train_target_clone import _load_logs, _extract_features, _maybe_smote
+from scripts.train_target_clone import (
+    _load_logs,
+    _extract_features,
+    _maybe_smote,
+    train,
+)
 
 
 def test_smote_balances_classes(tmp_path):
@@ -24,3 +31,33 @@ def test_smote_balances_classes(tmp_path):
     assert res_counts[0] == res_counts[1]
     assert res_counts[1] > orig_counts[1]
     assert len(w_res) == len(y_res)
+
+
+def test_focal_loss_changes_coefficients(tmp_path):
+    data = tmp_path / "trades_raw.csv"
+    lines = ["label,spread,hour"]
+    for i in range(30):
+        lines.append(f"0,{1.0 + i*0.01},{i%24}")
+    for i in range(3):
+        lines.append(f"1,{2.0 + i*0.01},{i%24}")
+    data.write_text("\n".join(lines))
+
+    torch.manual_seed(0)
+    np.random.seed(0)
+    out1 = tmp_path / "out1"
+    train(data, out1, model_type="transformer", epochs=1, window=4)
+    coeff1 = json.loads((out1 / "model.json").read_text())["distilled"]["coefficients"]
+
+    torch.manual_seed(0)
+    np.random.seed(0)
+    out2 = tmp_path / "out2"
+    train(
+        data,
+        out2,
+        model_type="transformer",
+        epochs=1,
+        window=4,
+        focal_gamma=2.0,
+    )
+    coeff2 = json.loads((out2 / "model.json").read_text())["distilled"]["coefficients"]
+    assert not np.allclose(coeff1, coeff2)


### PR DESCRIPTION
## Summary
- introduce FocalLoss implementation in `model_fitting`
- allow `--focal-gamma` flag to enable FocalLoss in transformer/TCN training
- test that FocalLoss changes distilled model coefficients

## Testing
- `pytest tests/test_train_target_clone_sampling.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c05c577098832fbbada7f186e05d7c