### PR TITLE
Add PCA-based factor features to target clone training

### DIFF
--- a/tests/test_regime_assignment.py
+++ b/tests/test_regime_assignment.py
@@ -25,7 +25,9 @@ def test_regime_labels_assigned(tmp_path: Path) -> None:
     regime_path = tmp_path / "regime_model.json"
     _write_regime_model(regime_path)
     df, feature_cols, _ = _load_logs(data)
-    df, feature_cols, _ = _extract_features(df, feature_cols, regime_model=regime_path)
+    df, feature_cols, _, _ = _extract_features(
+        df, feature_cols, regime_model=regime_path
+    )
     assert df["regime"].tolist() == [0, 1]
     assert df["regime_0"].tolist() == [1.0, 0.0]
     assert df["regime_1"].tolist() == [0.0, 1.0]

--- a/tests/test_train_target_clone_features.py
+++ b/tests/test_train_target_clone_features.py
@@ -76,12 +76,18 @@ def test_neighbor_correlation_features(tmp_path: Path) -> None:
     corr_cols = ["corr_EURUSD_USDCHF_w3", "corr_USDCHF_EURUSD_w3"]
     for col in corr_cols:
         assert col in model["feature_names"]
+    factor_cols = ["factor_0", "factor_1"]
+    for col in factor_cols:
+        assert col in model["feature_names"]
+    assert "pca_components" in model
     df, feature_cols, _ = _load_logs(data)
     df, _, _, _ = _extract_features(
         df, feature_cols, symbol_graph=sg_path, neighbor_corr_windows=[3]
     )
     for col in corr_cols:
         assert df[col].notna().all()
+    for col in factor_cols:
+        assert np.isfinite(df[col]).all()
 
 
 def test_calendar_fields_utc_and_ranges() -> None:

--- a/tests/test_train_target_clone_scaler.py
+++ b/tests/test_train_target_clone_scaler.py
@@ -26,7 +26,7 @@ def test_scaler_robust_with_outliers(tmp_path):
     params = model["session_models"]["asian"]
 
     df, features, _ = _load_logs(data)
-    df, features, _ = _extract_features(df, features)
+    df, features, _, _ = _extract_features(df, features)
     X = df[features].to_numpy(dtype=float)
     clip_min = np.quantile(X, 0.01, axis=0)
     clip_max = np.quantile(X, 0.99, axis=0)


### PR DESCRIPTION
## Summary
- derive cross-sectional PCA factor loadings for each symbol in `_extract_features`
- persist PCA components with models and expose `factor_0`, `factor_1`, ... as features
- update feature tests to validate new factor columns and adjust helper tests

## Testing
- `pytest tests/test_train_target_clone_features.py tests/test_train_target_clone_scaler.py tests/test_regime_assignment.py`

------
https://chatgpt.com/codex/tasks/task_e_68c06504fc60832f8cc770da49b39e91