### PR TITLE
feat: ensemble weighting with rolling performance

### DIFF
--- a/tests/test_meta_strategy.py
+++ b/tests/test_meta_strategy.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pandas as pd
 
-from scripts.meta_strategy import select_model, train_meta_model
+from scripts.meta_strategy import RollingMetrics, select_model, train_meta_model
 
 
 def test_partial_fit_updates_coefficients_and_selection() -> None:
@@ -21,3 +21,24 @@ def test_partial_fit_updates_coefficients_and_selection() -> None:
     assert not np.allclose(coeff1, coeff2)
     # Updated model should now select model 1 for feature value 4
     assert select_model(params2, {"f1": 4}) == 1
+
+
+def test_weighted_ensemble_adapts_to_performance() -> None:
+    rm = RollingMetrics(n_models=2, alpha=0.5)
+    preds = [0.2, 0.8]
+
+    # Initially model 0 performs better
+    rm.update(0, profit=1.0, correct=True)
+    rm.update(1, profit=-1.0, correct=False)
+    weights1 = rm.weights()
+    out1 = rm.combine(preds)
+    assert weights1[0] > weights1[1]
+
+    # Model 1 starts to outperform
+    rm.update(0, profit=-1.0, correct=False)
+    rm.update(1, profit=2.0, correct=True)
+    weights2 = rm.weights()
+    out2 = rm.combine(preds)
+    assert weights2[1] > weights2[0]
+    # Ensemble output shifts toward model 1 prediction
+    assert out2 > out1


### PR DESCRIPTION
## Summary
- track rolling profit and accuracy for each base model
- derive exponential weights and blend model outputs via weighted average
- test adaptive weighting as model performance changes

## Testing
- `pytest tests/test_meta_strategy.py tests/test_meta_strategy_audit.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c09f706d08832f865e3ab6c79eb127