### PR TITLE
Add DTW mixup augmentation to log loader

### DIFF
--- a/tests/test_train_target_clone_features.py
+++ b/tests/test_train_target_clone_features.py
@@ -244,6 +244,29 @@ def test_augmentation_adds_rows_and_limits_ranges(tmp_path: Path) -> None:
         assert aug_df[col].between(lo - 0.1 * rng, hi + 0.1 * rng).all()
 
 
+def test_dtw_augmentation_adds_rows_and_limits_ranges(tmp_path: Path) -> None:
+    data = tmp_path / "trades_raw.csv"
+    rows = [
+        "label,price,volume,spread,event_time,symbol\n",
+        "0,1.0,100,1.5,2020-01-01T00:00:00,EURUSD\n",
+        "1,1.1,110,1.6,2020-01-01T00:01:00,EURUSD\n",
+        "0,1.2,120,1.7,2020-01-01T00:02:00,EURUSD\n",
+        "1,1.3,130,1.8,2020-01-01T00:03:00,EURUSD\n",
+        "0,1.4,140,1.9,2020-01-01T00:04:00,EURUSD\n",
+    ]
+    data.write_text("".join(rows))
+    base_df, _, _ = _load_logs(data)
+    aug_df, _, _ = _load_logs(data, dtw_augment_ratio=0.5)
+    assert len(aug_df) > len(base_df)
+    min_time = base_df["event_time"].min()
+    max_time = base_df["event_time"].max()
+    assert pd.to_datetime(aug_df["event_time"]).between(min_time, max_time).all()
+    for col in ["price", "volume", "spread"]:
+        lo, hi = base_df[col].min(), base_df[col].max()
+        assert aug_df[col].between(lo, hi).all()
+    assert aug_df["dtw_aug_ratio"].dropna().between(0.0, 1.0).all()
+
+
 def test_market_index_neutralization(tmp_path: Path) -> None:
     data = tmp_path / "trades_raw.csv"
     rows = [


### PR DESCRIPTION
## Summary
- add `_dtw_augment_dataframe` helper that pairs similar sequences via DTW and interpolates them, recording mix ratios
- support `--dtw-augment` CLI flag and propagate augmentation through training
- ensure DTW-augmented rows keep feature ranges and expand dataset size

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0c3bb2ba8832f8de53550d740e974