### PR TITLE
Add configuration for Python tooling and CI checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,12 @@ jobs:
           python-version: '3.x'
       - name: Install dependencies
         run: |
-          pip install -r requirements.txt dvc
+          pip install -r requirements.txt dvc pre-commit mypy
       - name: Verify DVC data hashes
         run: dvc status
+      - name: Run pre-commit
+        run: pre-commit run --all-files
+      - name: Run mypy
+        run: mypy .
       - name: Run tests
         run: pytest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,22 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 23.12.1
+    hooks:
+      - id: black
+        files: ^botcopier/.*\.py$
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.13.2
+    hooks:
+      - id: isort
+        files: ^botcopier/.*\.py$
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.1.5
+    hooks:
+      - id: ruff
+        files: ^botcopier/.*\.py$
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.6.1
+    hooks:
+      - id: mypy
+        pass_filenames: false
+        args: [botcopier/__init__.py]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,19 @@
+[tool.black]
+line-length = 88
+target-version = ['py310']
+
+[tool.isort]
+profile = 'black'
+line_length = 88
+
+[tool.ruff]
+line-length = 88
+target-version = "py310"
+ignore = ["E402", "F401", "F821", "F841", "E741"]
+exclude = ["scripts", "tests", "proto"]
+
+[tool.mypy]
+python_version = "3.10"
+ignore_missing_imports = true
+exclude = ["^scripts/"]
+


### PR DESCRIPTION
## Summary
- configure black, isort, ruff and mypy via `pyproject.toml`
- add pre-commit configuration for formatting, linting and type checking
- extend CI workflow to run pre-commit and mypy

## Testing
- `pre-commit run --all-files`
- `mypy botcopier` (fails: Library stubs not installed for "requests")
- `pytest` (fails: No module named 'sklearn')

------
https://chatgpt.com/codex/tasks/task_e_68c0f96805ec832f8edc9c5e9330baba