### PR TITLE
Add model registry for training selection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,6 @@ ENV/
 # Local configuration
 *.env
 
-/models
 
 # Pretrained encoders
 encoder/

--- a/models/registry.py
+++ b/models/registry.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from typing import Callable, Dict
+
+_REGISTRY: Dict[str, Callable] = {}
+
+
+def register_model(name: str, builder: Callable) -> None:
+    """Register a model builder under ``name``.
+
+    Parameters
+    ----------
+    name:
+        Identifier for the model.
+    builder:
+        Callable that returns a fitted model when invoked.
+    """
+    _REGISTRY[name] = builder
+
+
+def get_model(name: str) -> Callable:
+    """Retrieve a registered model builder by ``name``.
+
+    Raises
+    ------
+    KeyError
+        If ``name`` is not present in the registry.
+    """
+    try:
+        return _REGISTRY[name]
+    except KeyError as e:  # pragma: no cover - defensive
+        raise KeyError(f"Model '{name}' is not registered") from e


### PR DESCRIPTION
## Summary
- add lightweight model registry with register_model/get_model helpers
- register existing fit_* trainers in the registry
- refactor training selection to use registry lookups instead of large conditional blocks

## Testing
- `pytest tests/test_extra_price_features.py tests/test_generate.py` *(fails: AssertionError & KeyError)*

------
https://chatgpt.com/codex/tasks/task_e_68c19cbb6e28832f9ae70b86090301ae