### PR TITLE
feat: add caching for feature engineering

### DIFF
--- a/botcopier/training/pipeline.py
+++ b/botcopier/training/pipeline.py
@@ -16,7 +16,7 @@ import psutil
 from sklearn.linear_model import LogisticRegression
 
 from botcopier.data.loading import _load_logs
-from botcopier.features.engineering import _extract_features
+from botcopier.features.engineering import _extract_features, configure_cache
 
 try:  # optional torch dependency flag
     import torch  # type: ignore
@@ -32,9 +32,12 @@ def train(
     out_dir: Path,
     *,
     model_type: str = "logreg",
+    cache_dir: Path | None = None,
     **_: object,
 ) -> None:
     """Train a simple logistic regression model from trade logs."""
+    if cache_dir is not None:
+        configure_cache(cache_dir)
     df, feature_names, _ = _load_logs(data_dir)
     df, feature_names, _, _ = _extract_features(df, feature_names)
     label_col = next((c for c in df.columns if c.startswith("label")), None)

--- a/config/settings.py
+++ b/config/settings.py
@@ -42,6 +42,7 @@ class TrainingConfig(BaseSettings):
     flight_port: int = 8815
     flight_path: str = "trades"
     drift_interval: float = 300.0
+    cache_dir: Optional[Path] = None
     model: Path = Path("model.json")
     features: List[str] = []
     label: str = "best_model"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ numpy
 pandas
 great_expectations
 scikit-learn
+joblib
 river
 psutil
 pydantic

--- a/tests/test_regime_assignment.py
+++ b/tests/test_regime_assignment.py
@@ -1,8 +1,13 @@
 import json
+import logging
 from pathlib import Path
 
 from botcopier.data.loading import _load_logs
-from botcopier.features.engineering import _extract_features
+from botcopier.features.engineering import (
+    _extract_features,
+    configure_cache,
+    clear_cache,
+)
 from botcopier.training.pipeline import train
 
 
@@ -16,7 +21,7 @@ def _write_regime_model(path: Path) -> None:
     path.write_text(json.dumps(model))
 
 
-def test_regime_labels_assigned(tmp_path: Path) -> None:
+def test_regime_labels_assigned(tmp_path: Path, caplog) -> None:
     data = tmp_path / "trades_raw.csv"
     rows = [
         "label,price,volume,spread,hour,symbol\n",
@@ -26,17 +31,23 @@ def test_regime_labels_assigned(tmp_path: Path) -> None:
     data.write_text("".join(rows))
     regime_path = tmp_path / "regime_model.json"
     _write_regime_model(regime_path)
+    cache_dir = tmp_path / "cache"
+    configure_cache(cache_dir)
+    clear_cache()
     df, feature_cols, _ = _load_logs(data)
-    df, feature_cols, _, _ = _extract_features(
-        df, feature_cols, regime_model=regime_path
-    )
+    with caplog.at_level(logging.INFO):
+        df, feature_cols, _, _ = _extract_features(
+            df, feature_cols, regime_model=regime_path
+        )
+        _extract_features(df, feature_cols, regime_model=regime_path)
+    assert "cache hit for _extract_features" in caplog.text
     assert df["regime"].tolist() == [0, 1]
     assert df["regime_0"].tolist() == [1.0, 0.0]
     assert df["regime_1"].tolist() == [0.0, 1.0]
     assert "regime_0" in feature_cols and "regime_1" in feature_cols
 
 
-def test_per_regime_training(tmp_path: Path) -> None:
+def test_per_regime_training(tmp_path: Path, caplog) -> None:
     data = tmp_path / "trades_raw.csv"
     rows = [
         "label,price,volume,spread,hour,symbol\n",
@@ -49,7 +60,15 @@ def test_per_regime_training(tmp_path: Path) -> None:
     regime_path = tmp_path / "regime_model.json"
     _write_regime_model(regime_path)
     out_dir = tmp_path / "out"
-    train(data, out_dir, regime_model=regime_path, per_regime=True)
+    cache_dir = tmp_path / "cache"
+    configure_cache(cache_dir)
+    clear_cache()
+    with caplog.at_level(logging.INFO):
+        df, feature_cols, _ = _load_logs(data)
+        _extract_features(df, feature_cols, regime_model=regime_path)
+        _extract_features(df, feature_cols, regime_model=regime_path)
+    assert "cache hit for _extract_features" in caplog.text
+    train(data, out_dir, regime_model=regime_path, per_regime=True, cache_dir=cache_dir)
     model = json.loads((out_dir / "model.json").read_text())
     sess = model["session_models"]
     assert set(sess.keys()) == {"regime_0", "regime_1"}

--- a/tests/test_train_target_clone_multi.py
+++ b/tests/test_train_target_clone_multi.py
@@ -1,27 +1,38 @@
 import json
+import logging
 from pathlib import Path
 
 import numpy as np
 
 from botcopier.data.loading import _load_logs
-from botcopier.features.engineering import _extract_features
+from botcopier.features.engineering import (
+    _extract_features,
+    configure_cache,
+    clear_cache,
+)
 from botcopier.training.pipeline import train
 
 
-def test_multi_horizon_training(tmp_path: Path) -> None:
+def test_multi_horizon_training(tmp_path: Path, caplog) -> None:
     data = tmp_path / "trades_raw.csv"
     rows = ["label,price,volume,spread,hour,symbol\n"]
     for i in range(30):
         rows.append(f"{i%2},{1.0 + i*0.01},{100+i},{1.5 + 0.01*i},{i%24},EURUSD\n")
     data.write_text("".join(rows))
 
+    cache_dir = tmp_path / "cache"
+    configure_cache(cache_dir)
+    clear_cache()
     df, feature_cols, _ = _load_logs(data)
-    df, feature_cols, _, _ = _extract_features(df, feature_cols)
+    with caplog.at_level(logging.INFO):
+        df, feature_cols, _, _ = _extract_features(df, feature_cols)
+        _extract_features(df, feature_cols)
+    assert "cache hit for _extract_features" in caplog.text
     assert df["label_h5"].notna().all()
     assert df["label_h20"].notna().all()
 
     out_dir = tmp_path / "out"
-    train(data, out_dir)
+    train(data, out_dir, cache_dir=cache_dir)
 
     model = json.loads((out_dir / "model.json").read_text())
     assert set(model["label_columns"]) >= {"label", "label_h5", "label_h20"}


### PR DESCRIPTION
## Summary
- cache expensive feature engineering steps with joblib
- expose configurable cache_dir on TrainingConfig and training pipeline
- clear and verify caches in tests

## Testing
- `pytest` *(fails: tests/test_extra_price_features.py::test_extra_price_features, tests/test_generate.py::test_router_and_models_from_training, tests/test_generate.py::test_scaler_stats_present, tests/test_generate.py::test_threshold_and_metrics_present)*

------
https://chatgpt.com/codex/tasks/task_e_68c1a26346d4832f8dff1f90ddbd3de9