### PR TITLE
Refactor NATS and gRPC scripts to async

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ pydantic
 pydantic-settings
 pyyaml
 pytest
+pytest-asyncio
 aiohttp
 prometheus_client
 opentelemetry-sdk

--- a/scripts/nats_consumer.py
+++ b/scripts/nats_consumer.py
@@ -55,7 +55,7 @@ async def _consume(js, subject, proto_cls, schema_version, csv_writer=None, db=N
         await m.ack()
 
 
-async def _run(args):
+async def async_main(args):
     nc = await nats.connect(args.servers)
     js = nc.jetstream()
     tasks = []
@@ -115,7 +115,7 @@ def main() -> int:
         logging.basicConfig(handlers=[JournalHandler()], level=level)
     except Exception:  # pragma: no cover - fallback to file logging
         logging.basicConfig(filename="nats_consumer.log", level=level)
-    asyncio.run(_run(args))
+    asyncio.run(async_main(args))
     return 0
 
 

--- a/scripts/nats_publisher.py
+++ b/scripts/nats_publisher.py
@@ -6,7 +6,7 @@ import json
 import nats
 from proto import trade_event_pb2, metric_event_pb2
 
-async def _publish(args) -> None:
+async def async_main(args) -> None:
     nc = await nats.connect(args.servers)
     js = nc.jetstream()
     with open(args.file) as f:
@@ -29,7 +29,7 @@ def main() -> int:
     p.add_argument("--servers", default="nats://127.0.0.1:4222", help="NATS server URLs")
     p.add_argument("--schema-version", type=int, default=1, help="schema version byte")
     args = p.parse_args()
-    asyncio.run(_publish(args))
+    asyncio.run(async_main(args))
     return 0
 
 

--- a/tests/test_grpc_log_service.py
+++ b/tests/test_grpc_log_service.py
@@ -1,9 +1,9 @@
 import socket
-from pathlib import Path
-
-import grpc
 import sys
 from pathlib import Path
+
+import grpc.aio as grpc
+import pytest
 
 sys.path.append(str(Path(__file__).resolve().parents[1] / "proto"))
 import log_service_pb2_grpc  # type: ignore
@@ -12,7 +12,8 @@ import trade_event_pb2  # type: ignore
 from scripts import grpc_log_service
 
 
-def test_grpc_log_service(tmp_path: Path):
+@pytest.mark.asyncio
+async def test_grpc_log_service(tmp_path: Path):
     host = "127.0.0.1"
     srv_sock = socket.socket()
     srv_sock.bind((host, 0))
@@ -21,44 +22,43 @@ def test_grpc_log_service(tmp_path: Path):
 
     trade_out = tmp_path / "trades.csv"
     metrics_out = tmp_path / "metrics.csv"
-    server = grpc_log_service.create_server(host, port, trade_out, metrics_out)
-    server.start()
+    server = await grpc_log_service.create_server(host, port, trade_out, metrics_out)
     try:
-        channel = grpc.insecure_channel(f"{host}:{port}")
-        stub = log_service_pb2_grpc.LogServiceStub(channel)
+        async with grpc.insecure_channel(f"{host}:{port}") as channel:
+            stub = log_service_pb2_grpc.LogServiceStub(channel)
 
-        trade = trade_event_pb2.TradeEvent(
-            event_id=1,
-            event_time="t",
-            broker_time="b",
-            local_time="l",
-            action="OPEN",
-            ticket=1,
-            magic=2,
-            source="mt4",
-            symbol="EURUSD",
-            order_type=0,
-            lots=0.1,
-            price=1.2345,
-        )
-        stub.LogTrade(trade)
+            trade = trade_event_pb2.TradeEvent(
+                event_id=1,
+                event_time="t",
+                broker_time="b",
+                local_time="l",
+                action="OPEN",
+                ticket=1,
+                magic=2,
+                source="mt4",
+                symbol="EURUSD",
+                order_type=0,
+                lots=0.1,
+                price=1.2345,
+            )
+            await stub.LogTrade(trade)
 
-        metrics = metric_event_pb2.MetricEvent(
-            time="t",
-            magic=2,
-            win_rate=0.5,
-            avg_profit=1.0,
-            trade_count=1,
-            drawdown=0.1,
-            sharpe=1.2,
-            file_write_errors=0,
-            socket_errors=0,
-            book_refresh_seconds=5,
-            var_breach_count=0,
-        )
-        stub.LogMetrics(metrics)
+            metrics = metric_event_pb2.MetricEvent(
+                time="t",
+                magic=2,
+                win_rate=0.5,
+                avg_profit=1.0,
+                trade_count=1,
+                drawdown=0.1,
+                sharpe=1.2,
+                file_write_errors=0,
+                socket_errors=0,
+                book_refresh_seconds=5,
+                var_breach_count=0,
+            )
+            await stub.LogMetrics(metrics)
     finally:
-        server.stop(0)
+        await server.stop(0)
 
     assert trade_out.exists()
     assert metrics_out.exists()


### PR DESCRIPTION
## Summary
- migrate `grpc_log_service` to `grpc.aio` with async handlers and entrypoint
- standardize NATS scripts on `async_main` pattern and asyncio.run
- update gRPC log service test to use `pytest-asyncio`
- add `pytest-asyncio` dependency

## Testing
- `python -m py_compile scripts/grpc_log_service.py scripts/nats_consumer.py scripts/nats_publisher.py scripts/nats_stream.py tests/test_grpc_log_service.py`
- `pytest tests/test_grpc_log_service.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'psutil')*


------
https://chatgpt.com/codex/tasks/task_e_68c1abb0a6b4832f8346a2aea68d1e30