### PR TITLE
Add optional MLflow tracking to training pipeline

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -37,6 +37,7 @@ transformers
 pytorch-forecasting; extra == "tft"
 torch
 torch_geometric
+mlflow
 
 # Optional extras
 uvloop; extra == "uvloop"  # faster asyncio event loop (stream_listener.py, metrics_collector.py)

--- a/tests/test_mlflow_integration.py
+++ b/tests/test_mlflow_integration.py
@@ -1,0 +1,26 @@
+from botcopier.training.pipeline import train
+
+
+def test_mlflow_creates_artifacts(tmp_path):
+    data = tmp_path / "trades_raw.csv"
+    lines = ["label,spread,hour"]
+    for i in range(5):
+        lines.append(f"0,{1.0 + i * 0.1},{i % 24}")
+    for i in range(5):
+        lines.append(f"1,{2.0 + i * 0.1},{i % 24}")
+    data.write_text("\n".join(lines))
+
+    tracking_dir = tmp_path / "mlruns"
+    out_dir = tmp_path / "out"
+
+    train(
+        data,
+        out_dir,
+        tracking_uri=tracking_dir.as_uri(),
+        experiment_name="test-exp",
+    )
+
+    artifact = next(tracking_dir.glob("**/artifacts/model/model.json"))
+    run_dir = artifact.parents[2]
+    assert (run_dir / "params" / "model_type").exists()
+    assert (run_dir / "metrics" / "train_accuracy").exists()


### PR DESCRIPTION
## Summary
- integrate optional MLflow logging in the training pipeline with params, metrics and model artifact
- expose `--tracking-uri` and `--experiment-name` CLI flags
- test MLflow integration and add dependency

## Testing
- `pytest BotCopier/tests/test_mlflow_integration.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1b7663aac832f940a79af2fe7243e