### PR TITLE
Introduce FeatureConfig and refactor cache handling

### DIFF
--- a/botcopier/training/pipeline.py
+++ b/botcopier/training/pipeline.py
@@ -23,7 +23,11 @@ except Exception:  # pragma: no cover - optional
     pl = None  # type: ignore
     _HAS_POLARS = False
 from botcopier.data.loading import _load_logs
-from botcopier.features.engineering import _extract_features, configure_cache
+from botcopier.features.engineering import (
+    _extract_features,
+    configure_cache,
+    FeatureConfig,
+)
 from botcopier.models.registry import MODEL_REGISTRY, get_model
 
 try:  # optional torch dependency flag
@@ -55,7 +59,7 @@ def train(
 ) -> None:
     """Train a model selected from the registry."""
     if cache_dir is not None:
-        configure_cache(cache_dir)
+        configure_cache(FeatureConfig(cache_dir=cache_dir))
     df, feature_names, _ = _load_logs(data_dir)
     df, feature_names, _, _ = _extract_features(df, feature_names)
     label_col = next((c for c in df.columns if c.startswith("label")), None)

--- a/tests/test_candlestick_patterns.py
+++ b/tests/test_candlestick_patterns.py
@@ -4,11 +4,8 @@ import logging
 import pandas as pd
 
 from scripts.features import _extract_features as extract_rows_features
-from botcopier.features.engineering import (
-    _extract_features as extract_df_features,
-    configure_cache,
-    clear_cache,
-)
+import botcopier.features.engineering as fe
+from botcopier.features.engineering import configure_cache, clear_cache, FeatureConfig
 
 
 def _synthetic_rows():
@@ -73,14 +70,14 @@ def test_pattern_detection_rows():
 
 def test_pattern_detection_dataframe(tmp_path, caplog):
     cache_dir = tmp_path / "cache"
-    configure_cache(cache_dir)
+    configure_cache(FeatureConfig(cache_dir=cache_dir))
     clear_cache()
     rows = _synthetic_rows()
     df = pd.DataFrame(rows)
     feature_cols = ["price"]
     with caplog.at_level(logging.INFO):
-        df, feature_cols, *_ = extract_df_features(df, feature_cols)
-        extract_df_features(df, feature_cols)
+        df, feature_cols, *_ = fe._extract_features(df, feature_cols)
+        fe._extract_features(df, feature_cols)
     assert "cache hit for _extract_features" in caplog.text
     assert "pattern_hammer" in feature_cols
     assert "pattern_doji" in feature_cols

--- a/tests/test_contrastive_encoder.py
+++ b/tests/test_contrastive_encoder.py
@@ -6,11 +6,12 @@ import pandas as pd
 import torch
 
 from scripts.pretrain_contrastive import train as pretrain_encoder
+import botcopier.features.engineering as fe
 from botcopier.features.engineering import (
-    _extract_features,
     train,
     configure_cache,
     clear_cache,
+    FeatureConfig,
 )
 from scripts.replay_decisions import _recompute
 
@@ -26,7 +27,7 @@ def _write_ticks(dir_path: Path, n: int = 50) -> None:
 
 def test_contrastive_encoder_flow(tmp_path: Path, caplog):
     cache_dir = tmp_path / "cache"
-    configure_cache(cache_dir)
+    configure_cache(FeatureConfig(cache_dir=cache_dir))
     clear_cache()
     tick_dir = tmp_path / "ticks"
     tick_dir.mkdir()
@@ -40,8 +41,8 @@ def test_contrastive_encoder_flow(tmp_path: Path, caplog):
     # verify feature extraction
     df = pd.DataFrame({f"tick_{i}": [float(i)] for i in range(window)})
     with caplog.at_level(logging.INFO):
-        df2, feats, _, _ = _extract_features(df.copy(), [], tick_encoder=enc_path)
-        _extract_features(df.copy(), [], tick_encoder=enc_path)
+        df2, feats, _, _ = fe._extract_features(df.copy(), [], tick_encoder=enc_path)
+        fe._extract_features(df.copy(), [], tick_encoder=enc_path)
     assert "cache hit for _extract_features" in caplog.text
     for i in range(dim):
         assert f"enc_{i}" in feats

--- a/tests/test_regime_assignment.py
+++ b/tests/test_regime_assignment.py
@@ -3,11 +3,8 @@ import logging
 from pathlib import Path
 
 from botcopier.data.loading import _load_logs
-from botcopier.features.engineering import (
-    _extract_features,
-    configure_cache,
-    clear_cache,
-)
+import botcopier.features.engineering as fe
+from botcopier.features.engineering import configure_cache, clear_cache, FeatureConfig
 from botcopier.training.pipeline import train
 
 
@@ -32,14 +29,14 @@ def test_regime_labels_assigned(tmp_path: Path, caplog) -> None:
     regime_path = tmp_path / "regime_model.json"
     _write_regime_model(regime_path)
     cache_dir = tmp_path / "cache"
-    configure_cache(cache_dir)
+    configure_cache(FeatureConfig(cache_dir=cache_dir))
     clear_cache()
     df, feature_cols, _ = _load_logs(data)
     with caplog.at_level(logging.INFO):
-        df, feature_cols, _, _ = _extract_features(
+        df, feature_cols, _, _ = fe._extract_features(
             df, feature_cols, regime_model=regime_path
         )
-        _extract_features(df, feature_cols, regime_model=regime_path)
+        fe._extract_features(df, feature_cols, regime_model=regime_path)
     assert "cache hit for _extract_features" in caplog.text
     assert df["regime"].tolist() == [0, 1]
     assert df["regime_0"].tolist() == [1.0, 0.0]
@@ -61,12 +58,12 @@ def test_per_regime_training(tmp_path: Path, caplog) -> None:
     _write_regime_model(regime_path)
     out_dir = tmp_path / "out"
     cache_dir = tmp_path / "cache"
-    configure_cache(cache_dir)
+    configure_cache(FeatureConfig(cache_dir=cache_dir))
     clear_cache()
     with caplog.at_level(logging.INFO):
         df, feature_cols, _ = _load_logs(data)
-        _extract_features(df, feature_cols, regime_model=regime_path)
-        _extract_features(df, feature_cols, regime_model=regime_path)
+        fe._extract_features(df, feature_cols, regime_model=regime_path)
+        fe._extract_features(df, feature_cols, regime_model=regime_path)
     assert "cache hit for _extract_features" in caplog.text
     train(data, out_dir, regime_model=regime_path, per_regime=True, cache_dir=cache_dir)
     model = json.loads((out_dir / "model.json").read_text())

--- a/tests/test_train_target_clone_multi.py
+++ b/tests/test_train_target_clone_multi.py
@@ -5,11 +5,8 @@ from pathlib import Path
 import numpy as np
 
 from botcopier.data.loading import _load_logs
-from botcopier.features.engineering import (
-    _extract_features,
-    configure_cache,
-    clear_cache,
-)
+import botcopier.features.engineering as fe
+from botcopier.features.engineering import configure_cache, clear_cache, FeatureConfig
 from botcopier.training.pipeline import train
 
 
@@ -21,12 +18,12 @@ def test_multi_horizon_training(tmp_path: Path, caplog) -> None:
     data.write_text("".join(rows))
 
     cache_dir = tmp_path / "cache"
-    configure_cache(cache_dir)
+    configure_cache(FeatureConfig(cache_dir=cache_dir))
     clear_cache()
     df, feature_cols, _ = _load_logs(data)
     with caplog.at_level(logging.INFO):
-        df, feature_cols, _, _ = _extract_features(df, feature_cols)
-        _extract_features(df, feature_cols)
+        df, feature_cols, _, _ = fe._extract_features(df, feature_cols)
+        fe._extract_features(df, feature_cols)
     assert "cache hit for _extract_features" in caplog.text
     assert df["label_h5"].notna().all()
     assert df["label_h20"].notna().all()


### PR DESCRIPTION
## Summary
- Add `FeatureConfig` dataclass capturing cache directory, Kalman parameters and enabled feature flags
- Refactor `configure_cache` and feature extraction to use `FeatureConfig`
- Update training pipeline and tests to configure caching via `FeatureConfig`

## Testing
- `pytest` *(fails: AssertionError and subprocess errors)*


------
https://chatgpt.com/codex/tasks/task_e_68c1c7813cb0832f81c3d3b87ff84e51