### PR TITLE
Expand pre-commit coverage

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,20 +3,17 @@ repos:
     rev: 23.12.1
     hooks:
       - id: black
-        files: ^botcopier/.*\.py$
   - repo: https://github.com/PyCQA/isort
     rev: 5.13.2
     hooks:
       - id: isort
-        files: ^botcopier/.*\.py$
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.1.5
     hooks:
       - id: ruff
-        files: ^botcopier/.*\.py$
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.6.1
     hooks:
       - id: mypy
         pass_filenames: false
-        args: [botcopier/__init__.py]
+        args: ["botcopier", "tests"]


### PR DESCRIPTION
## Summary
- widen formatter and linter hooks to run across tests and root modules
- run mypy on `botcopier` package and tests via pre-commit

## Testing
- `pre-commit run --all-files` *(fails: black reformatted many files; mypy found numerous errors)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68c1e70008a4832fbc8a5237980f0b70