### PR TITLE
Use pydantic for model parameters

### DIFF
--- a/botcopier/models/schema.py
+++ b/botcopier/models/schema.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ModelParams(BaseModel):
+    """Flexible model parameter schema persisted as JSON.
+
+    A ``version`` field allows backward compatibility checks.  All other
+    parameters are accepted and round-tripped without explicit declaration
+    so older and newer model files can coexist.
+    """
+
+    feature_names: list[str] = Field(default_factory=list)
+    version: int = 1
+
+    model_config = ConfigDict(extra="allow")
+
+
+__all__ = ["ModelParams"]

--- a/botcopier/scripts/generate_mql4_from_model.py
+++ b/botcopier/scripts/generate_mql4_from_model.py
@@ -10,10 +10,11 @@ compiled directly.
 from __future__ import annotations
 
 import argparse
-import json
 import re
 from pathlib import Path
 from typing import Sequence
+
+from botcopier.models.schema import ModelParams
 
 # Mapping from feature name to MQL4 runtime expression.
 # Add new feature mappings here as additional model features appear.
@@ -287,7 +288,8 @@ def insert_get_feature(
     model: Path, template: Path, calendar_file: Path | None = None
 ) -> None:
     """Insert generated GetFeature and session models into ``template``."""
-    data = json.loads(model.read_text())
+    params = ModelParams.model_validate_json(model.read_text())
+    data = params.model_dump()
     # If a distilled student exists and no explicit models are provided, expose
     # it under the ``models`` key so the template receives logistic coefficients.
     if "distilled" in data and not data.get("models"):


### PR DESCRIPTION
## Summary
- add `ModelParams` pydantic model with `version` field
- use `ModelParams.model_validate_json()` and `.model_dump_json()` instead of `json.load`/`json.dump`
- update scripts and pipeline to work with structured model parameters

## Testing
- `pytest` *(fails: AssertionError, CalledProcessError, AttributeError)*

------
https://chatgpt.com/codex/tasks/task_e_68c1f90b8d08832f886a4abe4bbc64b7