### PR TITLE
Add performance benchmarks and tutorial docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,5 +23,14 @@ jobs:
         run: mypy .
       - name: Run tests
         run: pytest
+      - name: Verify tutorials
+        run: PYTHONPATH=. pytest --doctest-glob="docs/*.md" docs
+      - name: Run performance benchmarks
+        run: pytest tests/performance --benchmark-only --benchmark-autosave
+      - name: Upload benchmark data
+        uses: actions/upload-artifact@v3
+        with:
+          name: pytest-benchmarks
+          path: .benchmarks
       - name: Build documentation
         run: mkdocs build --strict

--- a/docs/data_loading_tutorial.md
+++ b/docs/data_loading_tutorial.md
@@ -1,0 +1,17 @@
+# Data Loading and Feature Engineering
+
+This tutorial demonstrates how to load trade logs and derive features.
+
+```python
+>>> from pathlib import Path
+>>> from botcopier.data.loading import _load_logs
+>>> from botcopier.features.engineering import _extract_features
+>>> df, feature_cols, _ = _load_logs(Path('tests/fixtures/trades_small.csv'))
+>>> bool(len(df))
+True
+>>> _, cols, *_ = _extract_features(df, feature_names=list(feature_cols))
+>>> set(cols) == set(feature_cols)
+True
+>>> 
+```
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,6 +6,8 @@ nav:
   - Troubleshooting: troubleshooting.md
   - Guides:
       - Hardware-aware Training: hardware-training.md
+  - Tutorials:
+      - Data Loading and Feature Engineering: data_loading_tutorial.md
 markdown_extensions:
   - admonition
   - pymdownx.superfences

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,8 @@ ALLOWED = {
     "test_generate_mql4_from_model.py",
     "test_batch_backtest.py",
     "test_full_pipeline.py",
+    "performance",
+    "test_benchmarks.py",
 }
 
 

--- a/tests/performance/test_benchmarks.py
+++ b/tests/performance/test_benchmarks.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+
+from botcopier.data.loading import _load_logs
+from botcopier.features.engineering import _extract_features
+
+
+def test_load_logs_benchmark(benchmark):
+    """Benchmark the log loading routine."""
+    data_file = Path("tests/fixtures/trades_small.csv")
+    benchmark(lambda: _load_logs(data_file))
+
+
+def test_feature_engineering_benchmark(benchmark):
+    """Benchmark feature extraction."""
+    data_file = Path("tests/fixtures/trades_small.csv")
+    df, feature_cols, _ = _load_logs(data_file)
+    benchmark(lambda: _extract_features(df.copy(), feature_names=list(feature_cols)))


### PR DESCRIPTION
## Summary
- add pytest-benchmark scenarios for log loading and feature extraction
- document data loading and feature engineering with runnable tutorial
- run docs doctests and capture benchmark results in CI

## Testing
- `pre-commit run --files tests/performance/test_benchmarks.py tests/conftest.py docs/data_loading_tutorial.md mkdocs.yml .github/workflows/ci.yml` (mypy skipped)
- `PYTHONPATH=. pytest --doctest-glob="docs/*.md" docs`
- `pytest tests/performance --benchmark-only`


------
https://chatgpt.com/codex/tasks/task_e_68c1fd4b7054832fb3e508a4c9d39322