### PR TITLE
Vectorize Kalman filtering

### DIFF
--- a/tests/test_kalman_vectorized.py
+++ b/tests/test_kalman_vectorized.py
@@ -1,0 +1,23 @@
+import numpy as np
+from botcopier.scripts.features import _kalman_filter_series, _kalman_update, KALMAN_DEFAULT_PARAMS
+
+
+def python_kalman(values, params):
+    state = {}
+    lvl = []
+    tr = []
+    for v in values:
+        l, t = _kalman_update(state, float(v), **params)
+        lvl.append(l)
+        tr.append(t)
+    return np.array(lvl), np.array(tr)
+
+
+def test_kalman_filter_series_matches_python():
+    rng = np.random.default_rng(0)
+    values = rng.standard_normal(128).astype(float)
+    params = KALMAN_DEFAULT_PARAMS
+    lvl_nb, tr_nb = _kalman_filter_series(values, params["process_var"], params["measurement_var"])
+    lvl_py, tr_py = python_kalman(values, params)
+    assert np.allclose(lvl_nb, lvl_py)
+    assert np.allclose(tr_nb, tr_py)


### PR DESCRIPTION
## Summary
- add numba-accelerated `_kalman_filter_series` for batched Kalman updates
- replace Python loops in feature extractor with vectorized Kalman filter
- test parity between vectorized and original Kalman implementations

## Testing
- `pytest tests/test_kalman_vectorized.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c2144c2c34832fbbb83a957f70877a