### PR TITLE
Add Purged Walk-Forward cross-validation and extended metrics

### DIFF
--- a/botcopier/models/registry.py
+++ b/botcopier/models/registry.py
@@ -50,9 +50,15 @@ class _FeatureClipper(BaseEstimator, TransformerMixin):
 
 
 def _fit_logreg(
-    X: np.ndarray, y: np.ndarray
+    X: np.ndarray, y: np.ndarray, *, C: float = 1.0
 ) -> tuple[dict[str, list | float], Callable[[np.ndarray], np.ndarray]]:
-    """Fit logistic regression within a preprocessing pipeline."""
+    """Fit logistic regression within a preprocessing pipeline.
+
+    Parameters
+    ----------
+    C:
+        Inverse regularisation strength passed to :class:`~sklearn.linear_model.LogisticRegression`.
+    """
 
     clip_low = np.quantile(X, 0.01, axis=0)
     clip_high = np.quantile(X, 0.99, axis=0)
@@ -60,7 +66,7 @@ def _fit_logreg(
         [
             ("clip", _FeatureClipper(clip_low, clip_high)),
             ("scale", RobustScaler()),
-            ("logreg", LogisticRegression(max_iter=1000)),
+            ("logreg", LogisticRegression(max_iter=1000, C=C)),
         ]
     )
     pipeline.fit(X, y)

--- a/tests/test_end_to_end_pipeline.py
+++ b/tests/test_end_to_end_pipeline.py
@@ -38,5 +38,5 @@ def test_end_to_end_pipeline():
     vec = DictVectorizer(sparse=False)
     X = vec.fit_transform(feats)
     clf = fit_logistic_regression(X, labels)
-    acc = evaluate_model(clf, X, labels)
-    assert acc == 1.0
+    metrics = evaluate_model(clf, X, labels)
+    assert metrics["accuracy"] == 1.0

--- a/tests/test_evaluation_module.py
+++ b/tests/test_evaluation_module.py
@@ -8,5 +8,8 @@ def test_evaluate_model():
     X = np.array([[0.0], [1.0], [2.0], [3.0]])
     y = np.array([0, 0, 1, 1])
     clf = LogisticRegression(max_iter=100).fit(X, y)
-    acc = evaluate_model(clf, X, y)
-    assert acc == 1.0
+    metrics = evaluate_model(clf, X, y)
+    assert metrics["accuracy"] == 1.0
+    assert metrics["roc_auc"] == 1.0
+    assert metrics["pr_auc"] == 1.0
+    assert "reliability_curve" in metrics


### PR DESCRIPTION
## Summary
- incorporate Purged Walk-Forward splitter into training pipeline with fold-wise logging and hyperparameter selection
- extend evaluation utilities with ROC-AUC, PR-AUC, Brier score, Sharpe/Sortino ratios, and calibration curves
- allow logistic regression builder to tune regularisation strength

## Testing
- `pytest tests/test_target_clone_cross_validation.py tests/test_evaluation_module.py tests/test_end_to_end_pipeline.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c21994ee58832fb4cab46d7f6be5a9