### PR TITLE
feat: add pydantic settings and config-aware CLI

### DIFF
--- a/botcopier/config/__init__.py
+++ b/botcopier/config/__init__.py
@@ -1,0 +1,5 @@
+"""Configuration utilities for BotCopier."""
+
+from .settings import DataConfig, TrainingConfig, save_params
+
+__all__ = ["DataConfig", "TrainingConfig", "save_params"]

--- a/botcopier/config/settings.py
+++ b/botcopier/config/settings.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List, Optional
+
+import yaml
+from pydantic_settings import BaseSettings
+
+
+class DataConfig(BaseSettings):
+    """Paths and data-related options."""
+
+    log_dir: Optional[Path] = None
+    out_dir: Optional[Path] = None
+    files_dir: Optional[Path] = None
+    metrics_file: Optional[Path] = None
+    tick_file: Optional[Path] = None
+    baseline_file: Optional[Path] = None
+    recent_file: Optional[Path] = None
+    uncertain_file: Optional[Path] = None
+    csv: Optional[Path] = None
+    data: Optional[Path] = None
+    out: Optional[Path] = None
+    pred_file: Optional[Path] = None
+    actual_log: Optional[Path] = None
+    drift_scores: Optional[Path] = None
+    flag_file: Optional[Path] = None
+
+    model_config = {"env_prefix": "DATA_"}
+
+
+class TrainingConfig(BaseSettings):
+    """Training and evaluation parameters."""
+
+    win_rate_threshold: float = 0.4
+    drawdown_threshold: float = 0.2
+    drift_threshold: float = 0.2
+    drift_method: str = "psi"
+    uncertain_weight: float = 2.0
+    interval: Optional[float] = None
+
+    batch_size: int = 32
+    lr: float = 0.01
+    lr_decay: float = 1.0
+    flight_host: str = "127.0.0.1"
+    flight_port: int = 8815
+    flight_path: str = "trades"
+    drift_interval: float = 300.0
+    cache_dir: Optional[Path] = None
+    model: Path = Path("model.json")
+    features: List[str] = []
+    label: str = "best_model"
+    model_type: str = "logreg"
+    window: int = 60
+
+    model_config = {"env_prefix": "TRAIN_"}
+
+
+def save_params(
+    data: DataConfig,
+    training: TrainingConfig,
+    path: Path = Path("params.yaml"),
+) -> None:
+    """Persist resolved configuration values to ``params.yaml``."""
+    try:
+        existing = yaml.safe_load(path.read_text()) or {}
+    except Exception:
+        existing = {}
+    existing["data"] = {
+        k: str(v) if isinstance(v, Path) else v for k, v in data.model_dump().items()
+    }
+    existing["training"] = {
+        k: str(v) if isinstance(v, Path) else v
+        for k, v in training.model_dump().items()
+    }
+    path.write_text(yaml.safe_dump(existing, sort_keys=False))

--- a/botcopier/scripts/meta_strategy.py
+++ b/botcopier/scripts/meta_strategy.py
@@ -63,7 +63,9 @@ def train_meta_model(
             classes = clf.classes_
         clf.partial_fit(X, y, classes=classes)
     else:
-        clf = LogisticRegression(multi_class="multinomial", solver="lbfgs", max_iter=200)
+        clf = LogisticRegression(
+            multi_class="multinomial", solver="lbfgs", max_iter=200
+        )
         clf.fit(X, y)
 
     coeffs = clf.coef_
@@ -121,11 +123,12 @@ class RollingMetrics:
 
     def update(self, model_idx: int, profit: float, correct: bool) -> None:
         """Update rolling statistics for ``model_idx``."""
-        self.profit[model_idx] = (1 - self.alpha) * self.profit[model_idx] + self.alpha * float(profit)
-        self.accuracy[model_idx] = (
-            (1 - self.alpha) * self.accuracy[model_idx]
-            + self.alpha * (1.0 if correct else 0.0)
-        )
+        self.profit[model_idx] = (1 - self.alpha) * self.profit[
+            model_idx
+        ] + self.alpha * float(profit)
+        self.accuracy[model_idx] = (1 - self.alpha) * self.accuracy[
+            model_idx
+        ] + self.alpha * (1.0 if correct else 0.0)
 
     def weights(self) -> np.ndarray:
         """Return exponential weights derived from recent performance."""
@@ -145,20 +148,18 @@ class RollingMetrics:
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Train meta gating model")
-    parser.add_argument("--data", help="CSV file with regime features and best_model column")
+    parser.add_argument(
+        "--data", help="CSV file with regime features and best_model column"
+    )
     parser.add_argument("--out", help="Output JSON file for gating parameters")
     parser.add_argument("--features", nargs="+", help="Feature column names")
     parser.add_argument("--label", help="Label column name")
     args = parser.parse_args()
 
-    from config.settings import DataConfig, TrainingConfig, save_params
+    from botcopier.config.settings import DataConfig, TrainingConfig, save_params
 
     data_cfg = DataConfig(
-        **{
-            k: getattr(args, k)
-            for k in ["data", "out"]
-            if getattr(args, k) is not None
-        }
+        **{k: getattr(args, k) for k in ["data", "out"] if getattr(args, k) is not None}
     )
     train_cfg = TrainingConfig(
         **{


### PR DESCRIPTION
## Summary
- add DataConfig and TrainingConfig using pydantic BaseSettings
- load and persist configuration via CLI context
- refactor online trainer to accept config objects

## Testing
- `pre-commit run --files botcopier/config/__init__.py botcopier/config/settings.py botcopier/cli/__init__.py botcopier/scripts/auto_retrain.py botcopier/scripts/meta_strategy.py botcopier/scripts/online_trainer.py` *(fails: tests/test_meta_labeling.py:52: error: Value of type "Iterable[Any] | Any" is not indexable  [index])* 
- `python -m botcopier.cli --help` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68c21d430d68832fab6befa29a5b7816