### PR TITLE
Use asyncio for network scripts

### DIFF
--- a/botcopier/scripts/nats_publisher.py
+++ b/botcopier/scripts/nats_publisher.py
@@ -3,33 +3,44 @@
 import argparse
 import asyncio
 import json
+
 import nats
-from proto import trade_event_pb2, metric_event_pb2
 
-async def async_main(args) -> None:
-    nc = await nats.connect(args.servers)
-    js = nc.jetstream()
-    with open(args.file) as f:
-        data = json.load(f)
-    if args.type == "trade":
-        msg = trade_event_pb2.TradeEvent(**data)
-        subject = "trades"
-    else:
-        msg = metric_event_pb2.MetricEvent(**data)
-        subject = "metrics"
-    payload = bytes([args.schema_version]) + msg.SerializeToString()
-    await js.publish(subject, payload)
-    await nc.close()
+from proto import metric_event_pb2, trade_event_pb2
 
 
-def main() -> int:
+async def async_main(argv: list[str] | None = None) -> None:
+    """Publish a single event to NATS using ``asyncio``."""
     p = argparse.ArgumentParser(description="Publish a single event to NATS")
     p.add_argument("type", choices=["trade", "metric"], help="event type")
     p.add_argument("file", help="JSON file containing event fields")
-    p.add_argument("--servers", default="nats://127.0.0.1:4222", help="NATS server URLs")
-    p.add_argument("--schema-version", type=int, default=1, help="schema version byte")
-    args = p.parse_args()
-    asyncio.run(async_main(args))
+    p.add_argument(
+        "--servers", default="nats://127.0.0.1:4222", help="NATS server URLs"
+    )
+    p.add_argument(
+        "--schema-version", type=int, default=1, help="schema version byte"
+    )
+    args = p.parse_args(argv)
+
+    nc = await nats.connect(args.servers)
+    try:
+        js = nc.jetstream()
+        with open(args.file) as f:
+            data = json.load(f)
+        if args.type == "trade":
+            msg = trade_event_pb2.TradeEvent(**data)
+            subject = "trades"
+        else:
+            msg = metric_event_pb2.MetricEvent(**data)
+            subject = "metrics"
+        payload = bytes([args.schema_version]) + msg.SerializeToString()
+        await js.publish(subject, payload)
+    finally:
+        await nc.close()
+
+
+def main(argv: list[str] | None = None) -> int:
+    asyncio.run(async_main(argv))
     return 0
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,8 @@ ALLOWED = {
     "test_full_pipeline.py",
     "performance",
     "test_benchmarks.py",
+    "test_nats_publisher_async.py",
+    "test_online_trainer_async.py",
 }
 
 

--- a/tests/test_nats_publisher_async.py
+++ b/tests/test_nats_publisher_async.py
@@ -1,0 +1,38 @@
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from scripts.nats_publisher import async_main
+
+
+@pytest.mark.asyncio
+async def test_async_main_publishes(tmp_path: Path):
+    data = {"event_id": 1}
+    event_file = tmp_path / "trade.json"
+    event_file.write_text(json.dumps(data))
+
+    class FakeNC:
+        def __init__(self):
+            self.js = type("JS", (), {"publish": AsyncMock()})()
+
+        def jetstream(self):
+            return self.js
+
+        async def close(self):
+            pass
+
+    fake_nc = FakeNC()
+
+    with patch("scripts.nats_publisher.nats.connect", return_value=fake_nc) as mock_conn:
+        await async_main([
+            "trade",
+            str(event_file),
+            "--servers",
+            "nats://test",
+            "--schema-version",
+            "2",
+        ])
+        mock_conn.assert_called_once()
+        fake_nc.js.publish.assert_awaited_once()

--- a/tests/test_online_trainer_async.py
+++ b/tests/test_online_trainer_async.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from scripts.online_trainer import async_main
+
+
+@pytest.mark.asyncio
+async def test_async_main_uses_csv(tmp_path: Path):
+    csv_path = tmp_path / "trades.csv"
+    csv_path.write_text("a,b,y\n1,0,1\n")
+    model_path = tmp_path / "model.json"
+    called = {}
+
+    def fake_tail(path):
+        called["path"] = path
+
+    with patch(
+        "scripts.online_trainer.OnlineTrainer.tail_csv", side_effect=fake_tail
+    ) as mock_tail, patch("botcopier.config.settings.save_params"):
+        await async_main(["--csv", str(csv_path), "--model", str(model_path)])
+        assert called["path"] == csv_path
+        assert mock_tail.called


### PR DESCRIPTION
## Summary
- refactor `scripts/nats_publisher` to expose async entrypoint and use asyncio
- convert `scripts/online_trainer` networking to async and add `async_main`
- add pytest-asyncio tests for new async flows

## Testing
- `pytest tests/test_nats_publisher_async.py tests/test_online_trainer_async.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c220e41e4c832f96f1c934f112343c