### PR TITLE
Add FastAPI model serving script and deployment docs

### DIFF
--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:22.04 AS base
 
 RUN apt-get update && apt-get install -y \
     build-essential \
@@ -12,4 +12,9 @@ WORKDIR /opt/BotCopier
 COPY . .
 RUN pip3 install --no-cache-dir .
 
+FROM base AS serve-model
+EXPOSE 8000
+CMD ["uvicorn", "scripts.serve_model:app", "--host", "0.0.0.0", "--port", "8000"]
+
+FROM base AS build
 CMD ["bash"]

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,3 +4,4 @@ Welcome to the BotCopier documentation. This site covers the system architecture
 
 For an overview of how data moves through the platform, see the [architecture](architecture.md) page. API details for core modules live in the [reference](api.md).
 
+See [Model Serving](serve_model.md) for running the FastAPI prediction service.

--- a/docs/serve_model.md
+++ b/docs/serve_model.md
@@ -1,0 +1,27 @@
+# Model Serving
+
+`serve_model.py` runs a FastAPI application that loads `model.json` and exposes a `/predict` endpoint.
+The endpoint accepts a batch of feature vectors and returns probabilities from the model.
+
+## Run locally
+
+```bash
+uvicorn scripts.serve_model:app --reload
+```
+
+Example request:
+
+```bash
+curl -X POST http://localhost:8000/predict \
+  -H "Content-Type: application/json" \
+  -d '{"instances": [[0, 0, 0, 0], [1, 1, 1, 1]]}'
+```
+
+## Docker
+
+A Docker target named `serve-model` is provided for deployment:
+
+```bash
+docker build -f Dockerfile.ubuntu --target serve-model -t botcopier-model .
+docker run -p 8000:8000 botcopier-model
+```

--- a/scripts/serve_model.py
+++ b/scripts/serve_model.py
@@ -1,0 +1,51 @@
+import json
+import math
+from pathlib import Path
+from typing import List
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+
+# Load model.json at startup
+BASE_DIR = Path(__file__).resolve().parent.parent
+MODEL_PATH = BASE_DIR / "model.json"
+with open(MODEL_PATH, "r", encoding="utf-8") as f:
+    MODEL = json.load(f)
+
+app = FastAPI(title="BotCopier Model Server")
+
+
+class PredictionRequest(BaseModel):
+    """Request payload containing feature batches."""
+
+    instances: List[List[float]]
+
+
+class PredictionResponse(BaseModel):
+    """Model predictions for each input batch."""
+
+    predictions: List[float]
+
+
+def _predict_one(features: List[float]) -> float:
+    """Simple linear model with sigmoid activation."""
+
+    coeffs = MODEL.get("entry_coefficients", [])
+    intercept = MODEL.get("entry_intercept", 0.0)
+    if len(features) != len(coeffs):
+        raise ValueError("feature length mismatch")
+    score = sum(c * f for c, f in zip(coeffs, features)) + intercept
+    return 1.0 / (1.0 + math.exp(-score))
+
+
+@app.post("/predict", response_model=PredictionResponse)
+async def predict(req: PredictionRequest) -> PredictionResponse:
+    """Return predictions for a batch of feature vectors."""
+
+    results: List[float] = []
+    for features in req.instances:
+        try:
+            results.append(_predict_one(features))
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return PredictionResponse(predictions=results)


### PR DESCRIPTION
## Summary
- add `serve_model.py` FastAPI app for batch predictions from `model.json`
- document running the server and Docker deployment target
- extend Dockerfile with `serve-model` stage for serving via uvicorn

## Testing
- `pre-commit run --files scripts/serve_model.py Dockerfile.ubuntu docs/serve_model.md docs/index.md` *(fails: mypy reports missing stubs and type errors across repository)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'numpy', 'grpc', 'nats', 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68c22474eca0832faa7615f81001c1ca