### PR TITLE
Add architecture and CLI docs and build in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
           python-version: '3.x'
       - name: Install dependencies
         run: |
-          pip install -r requirements.txt pre-commit
+          pip install -r requirements.txt pre-commit mkdocs mkdocstrings[python]
       - name: Run pre-commit
         run: pre-commit run --all-files
       - name: Run unit tests
@@ -23,3 +23,5 @@ jobs:
         run: pytest -m integration
       - name: Run doctests
         run: PYTHONPATH=. pytest --doctest-glob='docs/*.md'
+      - name: Build docs
+        run: mkdocs build --strict

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,22 +1,13 @@
 # System Architecture
 
-## Data Flow
-
-The platform processes information from log ingestion through to live strategy deployment.
+The system consists of modular components for ingesting data, training models and deploying strategies.
 
 ```mermaid
-flowchart LR
-    A[Log Ingestion] --> B[OTel Collector]
-    B --> C[Processing Pipeline]
-    C --> D[Model Training]
-    D --> E[Strategy Deployment]
+flowchart TB
+    logs[Log Ingestion] --> collector[OTel Collector]
+    collector --> pipeline[Processing Pipeline]
+    pipeline --> registry[(Model Registry)]
+    registry --> deploy[Strategy Deployment]
 ```
 
-1. **Log Ingestion** captures trade and system events.
-2. The **OTel Collector** normalises and forwards telemetry.
-3. The **Processing Pipeline** enriches data and prepares features.
-4. **Model Training** produces strategies based on the processed data.
-5. **Strategy Deployment** pushes trained models to execution services.
-
-This flow ensures that incoming logs ultimately influence the models executing in production.
-
+See the [Data Flow](data_flow.md) page for a step-by-step walkthrough from ingestion to deployment.

--- a/docs/cli_usage.md
+++ b/docs/cli_usage.md
@@ -1,0 +1,21 @@
+# CLI Usage
+
+The project exposes a unified command line interface built with [Typer](https://typer.tiangolo.com/).
+
+```mermaid
+graph TD
+    A[train] --> B[evaluate]
+    B --> C[promote]
+    C --> D[deploy]
+```
+
+Run ``botcopier --help`` to list available commands. Key subcommands include:
+
+- ``train`` – train a model from logs.
+- ``evaluate`` – compare predictions against realised trades.
+- ``online-train`` – update a model continuously from streaming data.
+- ``drift-monitor`` – monitor feature drift against a baseline.
+
+## API
+
+::: botcopier.cli

--- a/docs/data_flow.md
+++ b/docs/data_flow.md
@@ -1,0 +1,24 @@
+# Data Flow
+
+The platform streams telemetry from ingestion to live trading. The diagram below shows the end-to-end flow.
+
+```mermaid
+sequenceDiagram
+    participant Logs
+    participant Collector
+    participant Pipeline
+    participant Registry
+    participant Trader
+    Logs->>Collector: telemetry
+    Collector->>Pipeline: normalised events
+    Pipeline->>Registry: trained models
+    Registry->>Trader: deployed strategies
+```
+
+1. **Logs** are captured from trading and system events.
+2. The **Collector** normalises telemetry into a common schema.
+3. The **Pipeline** enriches data and trains candidate models.
+4. Models and metadata are stored in the **Registry**.
+5. The **Trader** loads promoted models for execution.
+
+See the [Model Registry](model_registry.md) page for details on storing and retrieving models.

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 
 Welcome to the BotCopier documentation. This site covers the system architecture, module APIs, and troubleshooting tips.
 
-For an overview of how data moves through the platform, see the [architecture](architecture.md) page. API details for core modules live in the [reference](api.md).
+For an overview of how data moves through the platform, see the [architecture](architecture.md) and [data flow](data_flow.md) pages. API details for core modules live in the [reference](api.md), and the [CLI usage](cli_usage.md) page explains the command line interface.
 
 See [Model Serving](serve_model.md) for running the FastAPI prediction service.
 

--- a/docs/model_registry.md
+++ b/docs/model_registry.md
@@ -1,0 +1,16 @@
+# Model Registry
+
+The registry stores trained models along with metadata and provides utilities for loading and upgrading them.
+
+```mermaid
+flowchart LR
+    train[Training Pipeline] --> registry[(Model Registry)]
+    registry --> promote[CLI Promote]
+    registry --> serve[Strategy Deployment]
+```
+
+Models are recorded with a version and optional migrations to keep them compatible across releases. Builders are registered under a simple name and retrieved at runtime.
+
+## API
+
+::: botcopier.models.registry

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,6 +2,9 @@ site_name: BotCopier
 nav:
   - Home: index.md
   - Architecture: architecture.md
+  - Data Flow: data_flow.md
+  - Model Registry: model_registry.md
+  - CLI Usage: cli_usage.md
   - API Reference: api.md
   - Troubleshooting: troubleshooting.md
   - Guides:


### PR DESCRIPTION
## Summary
- document architecture, data flow, model registry, and CLI usage with diagrams
- expose API references via mkdocstrings and add navigation entries
- run `mkdocs build` in CI to validate documentation

## Testing
- `pre-commit run --all-files` *(fails: missing type stubs and unused coroutine)*
- `pytest -m "not integration"` *(fails: ModuleNotFoundError: No module named 'pydantic')*
- `pytest -m integration` *(fails: ModuleNotFoundError: No module named 'pydantic')*
- `PYTHONPATH=. pytest --doctest-glob='docs/*.md'` *(fails: ModuleNotFoundError: No module named 'pydantic')*
- `mkdocs build`


------
https://chatgpt.com/codex/tasks/task_e_68c22b49bc20832fa88b2743a14c9c45