### PR TITLE
Add ONNX export utilities and inference script

### DIFF
--- a/botcopier/models/registry.py
+++ b/botcopier/models/registry.py
@@ -125,6 +125,7 @@ def _fit_logreg(
 
     def _predict(arr: np.ndarray) -> np.ndarray:
         return pipeline.predict_proba(arr)[:, 1]
+    _predict.model = pipeline  # type: ignore[attr-defined]
 
     meta = {
         "coefficients": clf.coef_.ravel().tolist(),
@@ -226,6 +227,8 @@ if _HAS_TORCH:
             with torch.no_grad():
                 arr_t = torch.tensor(arr, dtype=torch.float32, device=dev)
                 return torch.sigmoid(model(arr_t)).cpu().numpy().squeeze(-1)
+        _predict.model = model  # type: ignore[attr-defined]
+        _predict.device = dev  # type: ignore[attr-defined]
 
         state = model.state_dict()
         return {k: v.cpu().tolist() for k, v in state.items()}, _predict

--- a/botcopier/onnx_utils.py
+++ b/botcopier/onnx_utils.py
@@ -1,0 +1,115 @@
+"""Utility helpers for exporting models to ONNX and validating them.
+
+This module provides convenience functions to convert scikit-learn and
+PyTorch models to the ONNX format.  The resulting graphs are validated using
+``onnxruntime`` to ensure operator and shape compatibility.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+try:  # Optional dependencies
+    import onnx
+    import onnxruntime as ort
+except Exception:  # pragma: no cover - optional import failure
+    onnx = None  # type: ignore
+    ort = None  # type: ignore
+
+try:  # Scikit-learn ONNX conversion
+    from skl2onnx import convert_sklearn
+    from skl2onnx.common.data_types import FloatTensorType
+    from sklearn.base import BaseEstimator
+except Exception:  # pragma: no cover - optional import failure
+    convert_sklearn = None  # type: ignore
+    FloatTensorType = None  # type: ignore
+    BaseEstimator = object
+
+try:  # PyTorch ONNX export
+    import torch
+except Exception:  # pragma: no cover - optional import failure
+    torch = None  # type: ignore
+
+
+def _runtime_check(model_path: Path, sample: np.ndarray) -> None:
+    """Run ``onnx.checker`` and an ``onnxruntime`` session.
+
+    Parameters
+    ----------
+    model_path:
+        Path to the ONNX graph.
+    sample:
+        Sample feature array used to execute a dummy forward pass.
+    """
+
+    if onnx is None or ort is None:  # pragma: no cover - optional
+        return
+    onnx_model = onnx.load(str(model_path))
+    onnx.checker.check_model(onnx_model)
+    sess = ort.InferenceSession(str(model_path), providers=["CPUExecutionProvider"])
+    inp = sess.get_inputs()[0].name
+    arr = sample.astype(np.float32)
+    if arr.ndim == 1:
+        arr = arr.reshape(1, -1)
+    sess.run(None, {inp: arr[:1]})
+
+
+def convert_sklearn_model(model: BaseEstimator, sample: np.ndarray, out: Path, *, opset: int = 17) -> None:
+    """Convert a scikit-learn model to ONNX format and validate it."""
+
+    if convert_sklearn is None or FloatTensorType is None:  # pragma: no cover - optional
+        raise RuntimeError("skl2onnx is required to convert scikit-learn models")
+    initial_types = [("input", FloatTensorType([None, sample.shape[1]]))]
+    onx = convert_sklearn(model, initial_types=initial_types, target_opset=opset)
+    out.write_bytes(onx.SerializeToString())
+    _runtime_check(out, sample)
+
+
+def convert_torch_model(model: "torch.nn.Module", sample: np.ndarray, out: Path, *, opset: int = 17) -> None:
+    """Export a PyTorch model to ONNX format and validate it."""
+
+    if torch is None:  # pragma: no cover - optional
+        raise RuntimeError("PyTorch is required to export models")
+    model.eval()
+    dummy = torch.as_tensor(sample[:1], dtype=torch.float32)
+    torch.onnx.export(
+        model,
+        dummy,
+        str(out),
+        opset_version=opset,
+        input_names=["input"],
+        output_names=["output"],
+    )
+    _runtime_check(out, sample)
+
+
+def export_model(model: Any, sample: np.ndarray, out: Path, *, opset: int = 17) -> Path:
+    """Export ``model`` to ONNX format.
+
+    The function dispatches to the appropriate converter based on the model
+    type (scikit-learn or PyTorch).  ``sample`` is a representative input used
+    both for schema generation and for a dummy runtime check.
+
+    Returns
+    -------
+    Path
+        The path to the written ONNX file.
+    """
+
+    if torch is not None and isinstance(model, torch.nn.Module):
+        convert_torch_model(model, sample, out, opset=opset)
+    elif isinstance(model, BaseEstimator):
+        convert_sklearn_model(model, sample, out, opset=opset)
+    else:
+        raise TypeError(f"Unsupported model type for ONNX export: {type(model)!r}")
+    return out
+
+
+__all__ = [
+    "convert_sklearn_model",
+    "convert_torch_model",
+    "export_model",
+]

--- a/botcopier/training/pipeline.py
+++ b/botcopier/training/pipeline.py
@@ -288,6 +288,14 @@ def train(
         out_dir.mkdir(parents=True, exist_ok=True)
         params = ModelParams(**model)
         (out_dir / "model.json").write_text(params.model_dump_json())
+        model_obj = getattr(predict_fn, "model", None)
+        if model_obj is not None:
+            try:
+                from botcopier.onnx_utils import export_model
+
+                export_model(model_obj, X, out_dir / "model.onnx")
+            except Exception:  # pragma: no cover - best effort
+                logger.exception("Failed to export ONNX model")
         if mlflow_active:
             mlflow.log_param("model_type", model_type)
             mlflow.log_param("n_features", len(feature_names))

--- a/scripts/onnx_predict.py
+++ b/scripts/onnx_predict.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+"""Run inference on an exported ONNX model."""
+
+import argparse
+from pathlib import Path
+
+import numpy as np
+import onnxruntime as ort
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description="Predict using ONNX model")
+    p.add_argument("model", type=Path, help="Path to model.onnx")
+    p.add_argument("features", help="Comma separated feature values")
+    args = p.parse_args()
+
+    sess = ort.InferenceSession(str(args.model), providers=["CPUExecutionProvider"])
+    input_name = sess.get_inputs()[0].name
+    feats = np.array([float(x) for x in args.features.split(",")], dtype=np.float32)
+    if feats.ndim == 1:
+        feats = feats.reshape(1, -1)
+    preds = sess.run(None, {input_name: feats})[0]
+    print(",".join(str(float(x)) for x in np.asarray(preds).ravel()))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add `onnx_utils` module with helpers to convert scikit-learn and PyTorch models to ONNX and validate them with onnxruntime
- Attach trained estimators to prediction functions and export ONNX graphs during training
- Provide `scripts/onnx_predict.py` demonstrating minimal ONNX inference

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68c23f22c8b0832fb60af3e767fbfe49