### PR TITLE
Add property-based tests and integrate into CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,9 +20,11 @@ jobs:
       - name: Run pre-commit
         run: pre-commit run --all-files
       - name: Run unit tests
-        run: pytest -m "not integration"
+        run: pytest -m "not integration" --ignore=tests/property
       - name: Run integration tests
         run: pytest -m integration
+      - name: Run property tests
+        run: HYPOTHESIS_MAX_EXAMPLES=25 pytest tests/property
       - name: Run doctests
         run: PYTHONPATH=. pytest --doctest-glob='docs/*.md'
       - name: Build docs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ optuna = ["optuna"]
 ray = ["ray[tune]"]
 rl = ["stable-baselines3", "sb3-contrib"]
 gpu = ["torch", "torch_geometric", "onnxruntime-gpu"]
+dev = ["pytest", "pytest-asyncio", "hypothesis"]
 
 [tool.setuptools.packages.find]
 include = ["botcopier*", "scripts", "schemas"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ pyyaml
 typer
 pytest
 pytest-asyncio
+hypothesis
 aiohttp
 prometheus_client
 opentelemetry-sdk

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,8 @@ ALLOWED = {
     "test_benchmarks.py",
     "test_nats_publisher_async.py",
     "test_online_trainer_async.py",
+    "property",
+    "test_invariants.py",
 }
 
 

--- a/tests/property/strategies.py
+++ b/tests/property/strategies.py
@@ -1,0 +1,54 @@
+"""Hypothesis strategies for property tests."""
+import numpy as np
+from hypothesis import strategies as st
+from hypothesis.extra.numpy import array_shapes, arrays
+from hypothesis.extra.pandas import column, data_frames, range_indexes
+
+
+def trade_logs():
+    """Generate synthetic trade log DataFrames."""
+    return data_frames(
+        columns=[
+            column(
+                "price",
+                st.floats(-1e6, 1e6, allow_nan=False, allow_infinity=False),
+            ),
+            column(
+                "spread",
+                st.floats(0, 1e3, allow_nan=False, allow_infinity=False),
+            ),
+        ],
+        index=range_indexes(min_size=1, max_size=50),
+    )
+
+
+def feature_matrices():
+    """Generate random feature matrices."""
+    shapes = array_shapes(min_dims=2, max_dims=2, min_side=1, max_side=10)
+    return arrays(
+        np.float64,
+        shapes,
+        elements=st.floats(-1e3, 1e3, allow_nan=False, allow_infinity=False),
+    )
+
+
+def model_parameters():
+    """Generate model parameter dictionaries for scaling."""
+
+    def build(size: int):
+        return st.fixed_dictionaries(
+            {
+                "feature_mean": st.lists(
+                    st.floats(-1e3, 1e3, allow_nan=False, allow_infinity=False),
+                    min_size=size,
+                    max_size=size,
+                ),
+                "feature_std": st.lists(
+                    st.floats(0.1, 1e3, allow_nan=False, allow_infinity=False),
+                    min_size=size,
+                    max_size=size,
+                ),
+            }
+        )
+
+    return st.integers(1, 10).flatmap(build)

--- a/tests/property/test_invariants.py
+++ b/tests/property/test_invariants.py
@@ -1,0 +1,39 @@
+"""Property-based tests for core invariants."""
+import numpy as np
+from hypothesis import HealthCheck, assume, given, settings
+from sklearn.preprocessing import StandardScaler
+
+from botcopier.data.loading import _compute_meta_labels
+from botcopier.scripts.model_fitting import scale_features
+from tests.property.strategies import feature_matrices, model_parameters, trade_logs
+
+
+@given(feature_matrices())
+@settings(max_examples=20)
+def test_feature_scaling_roundtrip(X: np.ndarray) -> None:
+    scaler = StandardScaler()
+    scaled = scale_features(scaler, X)
+    recovered = scaler.inverse_transform(scaled)
+    assert np.allclose(recovered, X)
+
+
+@given(trade_logs())
+@settings(max_examples=20)
+def test_meta_label_bounds(df) -> None:
+    prices = df["price"].to_numpy()
+    spreads = df["spread"].to_numpy()
+    tp = prices + spreads
+    sl = prices - spreads
+    _, _, _, meta = _compute_meta_labels(prices, tp, sl, hold_period=5)
+    assert ((meta >= 0) & (meta <= 1)).all()
+
+
+@given(feature_matrices(), model_parameters())
+@settings(max_examples=20, suppress_health_check=[HealthCheck.filter_too_much])
+def test_manual_scaling_roundtrip(X: np.ndarray, params: dict) -> None:
+    mean = np.array(params["feature_mean"])
+    std = np.array(params["feature_std"])
+    assume(X.shape[1] == len(mean))
+    scaled = (X - mean) / std
+    recovered = scaled * std + mean
+    assert np.allclose(recovered, X)


### PR DESCRIPTION
## Summary
- include Hypothesis as a dev dependency
- add generators and property tests for feature scaling and label bounds
- run property tests in CI with limited examples

## Testing
- `pre-commit run --files .github/workflows/ci.yml pyproject.toml requirements.txt tests/property/strategies.py tests/property/test_invariants.py tests/conftest.py` *(fails: mypy missing stubs and type errors)*
- `HYPOTHESIS_MAX_EXAMPLES=5 pytest tests/property`


------
https://chatgpt.com/codex/tasks/task_e_68c25f633a18832f898b1d1b8aa481b2