### PR TITLE
feat: add structured error handling

### DIFF
--- a/botcopier/exceptions.py
+++ b/botcopier/exceptions.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+"""Custom exception hierarchy for BotCopier."""
+
+from datetime import datetime
+from typing import Optional, Union
+
+
+class BotCopierError(Exception):
+    """Base class for all BotCopier exceptions.
+
+    Parameters
+    ----------
+    message:
+        Human readable description of the error.
+    symbol:
+        Optional trading symbol associated with the error.
+    timestamp:
+        Timestamp of the event that triggered the error.  May be a
+        :class:`~datetime.datetime` instance or string.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        symbol: Optional[str] = None,
+        timestamp: Optional[Union[datetime, str]] = None,
+    ) -> None:
+        context: list[str] = []
+        if symbol:
+            context.append(f"symbol={symbol}")
+        if timestamp:
+            if isinstance(timestamp, datetime):
+                ts = timestamp.isoformat()
+            else:
+                ts = str(timestamp)
+            context.append(f"timestamp={ts}")
+        if context:
+            message = f"{message} ({', '.join(context)})"
+        super().__init__(message)
+        self.symbol = symbol
+        self.timestamp = timestamp
+
+
+class DataError(BotCopierError):
+    """Errors related to data loading or validation."""
+
+
+class ModelError(BotCopierError):
+    """Errors raised during model training or inference."""
+
+
+class ServiceError(BotCopierError):
+    """Errors originating from external services."""
+
+
+__all__ = ["BotCopierError", "DataError", "ModelError", "ServiceError"]


### PR DESCRIPTION
## Summary
- add custom exception hierarchy to carry context like symbol and timestamp
- log structured errors from CLI via new `error_handler` decorator
- use DataError and specific exception types when evaluating predictions

## Testing
- `pre-commit run --files botcopier/exceptions.py botcopier/cli/__init__.py botcopier/scripts/evaluation.py` *(fails: missing type stubs and mypy errors)*
- `pytest tests/test_evaluate.py`
- `python -m botcopier.cli --help` *(fails: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68c262226a20832fb5feb6a9b119f006