### PR TITLE
docs: expand API and contribution guides

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1,30 +1,29 @@
 # API Reference
 
-## Data Loading
+## Data
 
 ::: botcopier.data.loading
 
-## Feature Engineering
+::: botcopier.data.schema
+
+## Features
 
 ::: botcopier.features.engineering
 
-## Data Augmentation
-
 ::: botcopier.features.augmentation
-
-## Anomaly Utilities
 
 ::: botcopier.features.anomaly
 
-## Technical Features
-
 ::: botcopier.features.technical
 
-## Training Pipeline
+::: botcopier.features.registry
+
+## Models
+
+::: botcopier.models.registry
+
+::: botcopier.models.schema
+
+## Training
 
 ::: botcopier.training.pipeline
-
-## Logging Utilities
-
-::: logging_utils
-

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -10,4 +10,13 @@ flowchart TB
     registry --> deploy[Strategy Deployment]
 ```
 
+## Deployment Topology
+
+```mermaid
+flowchart LR
+    registry[(Model Registry)] --> service[Deployment Service]
+    service --> trader[Trading Bot]
+    service --> monitor[Monitoring]
+```
+
 See the [Data Flow](data_flow.md) page for a step-by-step walkthrough from ingestion to deployment.

--- a/docs/coding_standards.md
+++ b/docs/coding_standards.md
@@ -1,0 +1,14 @@
+# Coding Standards
+
+The project uses [`pre-commit`](https://pre-commit.com/) to enforce style and static analysis.
+The following tools run automatically:
+
+- `black` for formatting
+- `isort` for import ordering
+- `ruff` for linting
+- `mypy` for type checking
+
+Run all checks locally before committing:
+```bash
+pre-commit run --all-files
+```

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,14 @@
+# Contributing
+
+Thank you for your interest in improving BotCopier.
+
+Before submitting a pull request:
+
+1. Review the [coding standards](coding_standards.md).
+2. Run all [tests](testing.md) and ensure they pass.
+3. Use `pre-commit` to apply formatting and static analysis:
+   ```bash
+   pre-commit run --all-files
+   ```
+
+Please open an issue for major changes so we can discuss the approach.

--- a/docs/data_flow.md
+++ b/docs/data_flow.md
@@ -1,6 +1,8 @@
 # Data Flow
 
-The platform streams telemetry from ingestion to live trading. The diagram below shows the end-to-end flow.
+The platform streams telemetry from ingestion to live trading.
+
+## Sequence Diagram
 
 ```mermaid
 sequenceDiagram

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -1,0 +1,23 @@
+# Getting Started
+
+Follow these steps to set up the BotCopier project locally.
+
+## Installation
+1. Clone the repository and change into the directory.
+2. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+## Documentation
+Build the documentation locally with:
+```bash
+mkdocs serve
+```
+This launches a local server with live reload.
+
+## Running Tests
+Execute the test suite to ensure everything is working:
+```bash
+pytest
+```

--- a/docs/model_registry.md
+++ b/docs/model_registry.md
@@ -2,6 +2,8 @@
 
 The registry stores trained models along with metadata and provides utilities for loading and upgrading them.
 
+## Registry Diagram
+
 ```mermaid
 flowchart LR
     train[Training Pipeline] --> registry[(Model Registry)]

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,12 @@
+# Testing
+
+Run the full test suite with [`pytest`](https://docs.pytest.org/):
+
+```bash
+pytest
+```
+
+Build the documentation to validate examples and markdown:
+```bash
+mkdocs build
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,11 +1,16 @@
 site_name: BotCopier
 nav:
   - Home: index.md
+  - Getting Started: getting_started.md
   - Architecture: architecture.md
   - Data Flow: data_flow.md
   - Model Registry: model_registry.md
   - CLI Usage: cli_usage.md
   - API Reference: api.md
+  - Contributing:
+      - Overview: contributing.md
+      - Coding Standards: coding_standards.md
+      - Testing: testing.md
   - Troubleshooting: troubleshooting.md
   - Guides:
       - Hardware-aware Training: hardware-training.md


### PR DESCRIPTION
## Summary
- add getting started, contributing, coding standards, and testing guides
- expand mkdocstrings API references for data, features, models, and training packages
- include deployment topology diagram and update site navigation

## Testing
- `pre-commit run --files mkdocs.yml docs/api.md docs/architecture.md docs/data_flow.md docs/model_registry.md docs/coding_standards.md docs/contributing.md docs/getting_started.md docs/testing.md`
- `pytest` *(fails: AssertionError in tests/test_extra_price_features.py, etc.)*
- `mkdocs build`

------
https://chatgpt.com/codex/tasks/task_e_68c262487db0832f9636f867a09fa284