### PR TITLE
Integrate Feast feature store for parity between training and inference

### DIFF
--- a/botcopier/feature_store/feast_repo/__init__.py
+++ b/botcopier/feature_store/feast_repo/__init__.py
@@ -1,0 +1,1 @@
+"""Feast feature repository for BotCopier."""

--- a/botcopier/feature_store/feast_repo/feature_views.py
+++ b/botcopier/feature_store/feast_repo/feature_views.py
@@ -1,0 +1,45 @@
+"""Feast feature view definitions for core BotCopier features."""
+from __future__ import annotations
+
+from datetime import timedelta
+from pathlib import Path
+
+from feast import Entity, FeatureView, Field, FileSource
+from feast.types import Float32
+
+# Define the raw data source.  The path is resolved relative to this file so that
+# the feature repository can be moved without breaking the configuration.
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DATA_PATH = REPO_ROOT / "data" / "trades.parquet"
+
+trade_source = FileSource(
+    path=str(DATA_PATH),
+    timestamp_field="event_time",
+    created_timestamp_column="created",
+)
+
+# Entity representing a traded symbol.
+symbol = Entity(name="symbol", join_keys=["symbol"])
+
+# Core set of engineered features used across training and inference.  These are
+# lightweight temporal encodings that are always present in the raw logs.
+trade_features_view = FeatureView(
+    name="trade_features",
+    entities=[symbol],
+    ttl=timedelta(days=1),
+    schema=[
+        Field(name="hour_sin", dtype=Float32),
+        Field(name="hour_cos", dtype=Float32),
+        Field(name="dow_sin", dtype=Float32),
+        Field(name="dow_cos", dtype=Float32),
+        Field(name="month_sin", dtype=Float32),
+        Field(name="month_cos", dtype=Float32),
+        Field(name="dom_sin", dtype=Float32),
+        Field(name="dom_cos", dtype=Float32),
+    ],
+    online=True,
+    source=trade_source,
+)
+
+# Export list of feature names for consumers.
+FEATURE_COLUMNS = [field.name for field in trade_features_view.schema]


### PR DESCRIPTION
## Summary
- define core Feast feature views for temporal encodings
- load offline features from Feast in the training pipeline
- fetch online features from the same views during inference and REST serving

## Testing
- `pre-commit run --files botcopier/feature_store/feast_repo/__init__.py botcopier/feature_store/feast_repo/feature_views.py botcopier/training/pipeline.py botcopier/scripts/online_trainer.py botcopier/scripts/serve_model.py` (fails: mypy reported multiple errors) 
- `pytest` (fails: ModuleNotFoundError: No module named 'prometheus_client')

------
https://chatgpt.com/codex/tasks/task_e_68c264ca29c0832f8b3c058d2f1533c3