### PR TITLE
Add model card generation and CI artifact upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,5 +29,11 @@ jobs:
         run: PYTHONPATH=. pytest --doctest-glob='docs/*.md'
       - name: Build docs
         run: mkdocs build --strict
+      - name: Upload model cards
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: model-card
+          path: '**/model_card.md'
       - name: Push DVC data
         run: dvc push

--- a/botcopier/scripts/model_card.py
+++ b/botcopier/scripts/model_card.py
@@ -1,0 +1,43 @@
+"""Utilities for generating simple Markdown model cards."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Mapping
+
+from jinja2 import Environment, select_autoescape
+
+from botcopier.models.schema import ModelParams
+
+_TEMPLATE = """
+# Model Card
+
+## Model Parameters
+- **Version:** {{ params.version }}
+- **Features:** {{ params.feature_names | join(', ') }}
+
+## Metrics
+{% for key, value in metrics.items() %}- **{{ key }}:** {{ '%.4f' | format(value) if value is not none else 'N/A' }}
+{% endfor %}
+"""
+
+
+def generate_model_card(
+    model_params: ModelParams,
+    metrics: Mapping[str, object],
+    output_path: Path,
+) -> None:
+    """Render and write a simple model card.
+
+    Parameters
+    ----------
+    model_params:
+        Parameters describing the trained model.
+    metrics:
+        Aggregated evaluation metrics.
+    output_path:
+        Location to write the rendered markdown file.
+    """
+    env = Environment(autoescape=select_autoescape())
+    template = env.from_string(_TEMPLATE)
+    content = template.render(params=model_params, metrics=metrics)
+    Path(output_path).write_text(content)

--- a/botcopier/training/pipeline.py
+++ b/botcopier/training/pipeline.py
@@ -33,6 +33,7 @@ from botcopier.features.technical import (
 from botcopier.models.registry import MODEL_REGISTRY, get_model, load_params
 from botcopier.models.schema import ModelParams
 from botcopier.scripts.evaluation import _classification_metrics
+from botcopier.scripts.model_card import generate_model_card
 from botcopier.scripts.splitters import PurgedWalkForward
 from logging_utils import setup_logging
 
@@ -377,6 +378,7 @@ def train(
         params = ModelParams(**model)
         (out_dir / "model.json").write_text(params.model_dump_json())
         model_obj = getattr(predict_fn, "model", None)
+        generate_model_card(params, best_agg, out_dir / "model_card.md")
         if model_obj is not None:
             try:
                 from botcopier.onnx_utils import export_model

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -10,3 +10,10 @@ Build the documentation to validate examples and markdown:
 ```bash
 mkdocs build
 ```
+
+## Viewing model card artifacts
+
+Training runs write a `model_card.md` summarising parameters and evaluation
+metrics. Continuous integration uploads these cards as workflow artifacts. To
+inspect them, open the relevant GitHub Actions run and download the
+**model-card** artifact from the *Artifacts* section.

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ river
 psutil
 pydantic
 pydantic-settings
+jinja2
 pyyaml
 typer
 pytest


### PR DESCRIPTION
## Summary
- add Jinja2-powered model card generator and integrate into training pipeline
- upload generated model cards as CI artifacts and document where to find them
- declare Jinja2 dependency

## Testing
- `pre-commit run --files botcopier/scripts/model_card.py botcopier/training/pipeline.py .github/workflows/ci.yml docs/testing.md requirements.txt` (fails: Library stubs not installed for `google.protobuf.internal` and others)
- `pytest -q` (fails: No module named 'pandas')

------
https://chatgpt.com/codex/tasks/task_e_68c30972a864832faf0c5e835e663bd0