### PR TITLE
feat: add global seed utility

### DIFF
--- a/botcopier/cli/__init__.py
+++ b/botcopier/cli/__init__.py
@@ -127,6 +127,7 @@ def train(
         "-f",
         help="Enable feature plugin; can be passed multiple times",
     ),
+    random_seed: Optional[int] = typer.Option(None, help="Random seed"),
 ) -> None:
     """Train a model from trade logs."""
     data_cfg, train_cfg = _cfg(ctx)
@@ -140,6 +141,8 @@ def train(
         train_cfg = train_cfg.model_copy(update={"cache_dir": cache_dir})
     if features is not None:
         train_cfg = train_cfg.model_copy(update={"features": list(features)})
+    if random_seed is not None:
+        train_cfg = train_cfg.model_copy(update={"random_seed": random_seed})
     ctx.obj["config"] = {"data": data_cfg, "training": train_cfg}
     if data_cfg.data is None or data_cfg.out is None:
         raise typer.BadParameter("data_dir and out_dir must be provided")
@@ -150,6 +153,7 @@ def train(
         model_type=train_cfg.model_type,
         cache_dir=train_cfg.cache_dir,
         features=train_cfg.features,
+        random_seed=train_cfg.random_seed,
     )
 
 

--- a/botcopier/config/settings.py
+++ b/botcopier/config/settings.py
@@ -53,6 +53,7 @@ class TrainingConfig(BaseSettings):
     label: str = "best_model"
     model_type: str = "logreg"
     window: int = 60
+    random_seed: int = 0
 
     model_config = {"env_prefix": "TRAIN_"}
 

--- a/botcopier/scripts/bandit_router.py
+++ b/botcopier/scripts/bandit_router.py
@@ -17,9 +17,11 @@ import random
 import threading
 from typing import List
 
+import uvicorn
 from fastapi import FastAPI
 from pydantic import BaseModel
-import uvicorn
+
+from botcopier.utils.random import set_seed
 
 
 class BanditRouter:
@@ -123,12 +125,12 @@ def main() -> None:
     parser.add_argument(
         "--models", type=int, default=1, help="number of models to route between"
     )
-    parser.add_argument(
-        "--method", choices=["thompson", "ucb"], default="thompson"
-    )
+    parser.add_argument("--method", choices=["thompson", "ucb"], default="thompson")
     parser.add_argument("--state-file", default="bandit_state.json")
+    parser.add_argument("--random-seed", type=int, default=0)
     args = parser.parse_args()
 
+    set_seed(args.random_seed)
     router = BanditRouter(args.models, args.method, args.state_file)
     app = create_app(router)
     uvicorn.run(app, host=args.host, port=args.port)

--- a/botcopier/scripts/federated_buffer.py
+++ b/botcopier/scripts/federated_buffer.py
@@ -20,11 +20,10 @@ import grpc
 import numpy as np
 from google.protobuf import empty_pb2
 
+from botcopier.utils.random import set_seed
 from logging_utils import setup_logging
-
 from proto import federated_buffer_pb2 as pb2
 from proto import federated_buffer_pb2_grpc as pb2_grpc
-
 
 Experience = Tuple[np.ndarray, int, float, np.ndarray]
 
@@ -148,9 +147,11 @@ def main() -> None:
     p.add_argument("mode", choices=["server", "upload", "download"])
     p.add_argument("--address", default="127.0.0.1:50051")
     p.add_argument("--file", help="path to JSON file for upload/download")
+    p.add_argument("--random-seed", type=int, default=0)
     args = p.parse_args()
 
     logger = setup_logging(__name__)
+    set_seed(args.random_seed)
 
     if args.mode == "server":
         server = serve(args.address)

--- a/botcopier/scripts/train_price_gan.py
+++ b/botcopier/scripts/train_price_gan.py
@@ -23,6 +23,8 @@ import numpy as np
 import torch
 from torch import nn, optim
 
+from botcopier.utils.random import set_seed
+
 
 class Generator(nn.Module):
     """Simple fully connected generator."""
@@ -39,7 +41,9 @@ class Generator(nn.Module):
             nn.Linear(128, seq_len),
         )
 
-    def forward(self, z: torch.Tensor) -> torch.Tensor:  # pragma: no cover - simple pass
+    def forward(
+        self, z: torch.Tensor
+    ) -> torch.Tensor:  # pragma: no cover - simple pass
         return self.net(z)
 
 
@@ -57,7 +61,9 @@ class Discriminator(nn.Module):
             nn.Sigmoid(),
         )
 
-    def forward(self, x: torch.Tensor) -> torch.Tensor:  # pragma: no cover - simple pass
+    def forward(
+        self, x: torch.Tensor
+    ) -> torch.Tensor:  # pragma: no cover - simple pass
         return self.net(x)
 
 
@@ -108,9 +114,9 @@ def train_gan(seqs: np.ndarray, epochs: int, latent_dim: int) -> Generator:
             # Train discriminator
             z = torch.randn(bsz, latent_dim, device=device)
             fake = gen(z).detach()
-            loss_d = criterion(disc(real), torch.ones(bsz, 1, device=device)) + criterion(
-                disc(fake), torch.zeros(bsz, 1, device=device)
-            )
+            loss_d = criterion(
+                disc(real), torch.ones(bsz, 1, device=device)
+            ) + criterion(disc(fake), torch.zeros(bsz, 1, device=device))
             opt_d.zero_grad()
             loss_d.backward()
             opt_d.step()
@@ -172,8 +178,9 @@ def main() -> None:  # pragma: no cover - CLI entry point
     p.add_argument("--seq-len", type=int, default=20, help="Sequence length")
     p.add_argument("--epochs", type=int, default=200, help="Training epochs")
     p.add_argument("--latent-dim", type=int, default=16, help="Latent dimension")
+    p.add_argument("--random-seed", type=int, default=0)
     args = p.parse_args()
-
+    set_seed(args.random_seed)
     seqs = load_tick_sequences(Path(args.tick_file), args.seq_len)
     gen = train_gan(seqs, args.epochs, args.latent_dim)
     save_model(gen, Path(args.out))

--- a/botcopier/utils/__init__.py
+++ b/botcopier/utils/__init__.py
@@ -1,0 +1,5 @@
+"""Utility helpers for reproducibility and randomness control."""
+
+from .random import set_seed
+
+__all__ = ["set_seed"]

--- a/botcopier/utils/random.py
+++ b/botcopier/utils/random.py
@@ -1,0 +1,24 @@
+"""Utilities for deterministic behavior across libraries."""
+from __future__ import annotations
+
+import random
+
+import numpy as np
+
+try:  # optional torch dependency
+    import torch  # type: ignore
+except Exception:  # pragma: no cover - torch optional
+    torch = None  # type: ignore
+
+
+def set_seed(seed: int) -> None:
+    """Seed ``random``, ``numpy`` and ``torch`` for reproducibility."""
+    random.seed(seed)
+    np.random.seed(seed)
+    if torch is not None:
+        try:
+            torch.manual_seed(seed)
+            if hasattr(torch, "cuda"):
+                torch.cuda.manual_seed_all(seed)
+        except Exception:  # pragma: no cover - best effort
+            pass

--- a/config/settings.py
+++ b/config/settings.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
-from pathlib import Path
-from typing import Optional, List
-
 import logging
-from pydantic_settings import BaseSettings
+from pathlib import Path
+from typing import List, Optional
+
 import yaml
+from pydantic_settings import BaseSettings
 
 logger = logging.getLogger(__name__)
 
@@ -49,11 +49,14 @@ class TrainingConfig(BaseSettings):
     model: Path = Path("model.json")
     features: List[str] = []
     label: str = "best_model"
+    random_seed: int = 0
 
     model_config = {"env_prefix": "TRAIN_"}
 
 
-def save_params(data: DataConfig, training: TrainingConfig, path: Path = Path("params.yaml")) -> None:
+def save_params(
+    data: DataConfig, training: TrainingConfig, path: Path = Path("params.yaml")
+) -> None:
     """Persist resolved configuration values to ``params.yaml``."""
     try:
         existing = yaml.safe_load(path.read_text()) or {}
@@ -64,6 +67,7 @@ def save_params(data: DataConfig, training: TrainingConfig, path: Path = Path("p
         k: str(v) if isinstance(v, Path) else v for k, v in data.model_dump().items()
     }
     existing["training"] = {
-        k: str(v) if isinstance(v, Path) else v for k, v in training.model_dump().items()
+        k: str(v) if isinstance(v, Path) else v
+        for k, v in training.model_dump().items()
     }
     path.write_text(yaml.safe_dump(existing, sort_keys=False))


### PR DESCRIPTION
## Summary
- ensure reproducible runs with botcopier.utils.set_seed seeding random, NumPy and Torch
- seed training pipeline, online trainer and key scripts from config.random_seed
- persist seed in model.json metadata for auditability

## Testing
- `pre-commit run --files botcopier/utils/__init__.py botcopier/utils/random.py botcopier/config/settings.py config/settings.py botcopier/training/pipeline.py botcopier/scripts/online_trainer.py botcopier/scripts/train_rl_agent.py botcopier/scripts/train_price_gan.py botcopier/scripts/federated_buffer.py botcopier/scripts/bandit_router.py botcopier/cli/__init__.py` *(fails: mypy errors in unrelated files)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'opentelemetry')*

------
https://chatgpt.com/codex/tasks/task_e_68c30d3611a0832f96702cf3d3f7cc37