### PR TITLE
Add Pandera feature schema validation

### DIFF
--- a/botcopier/data/feature_schema.py
+++ b/botcopier/data/feature_schema.py
@@ -1,0 +1,26 @@
+"""Schema for engineered features produced by :func:`_extract_features`."""
+from __future__ import annotations
+
+import pandera as pa
+from pandera import Field
+from pandera.typing import Series
+
+
+class FeatureSchema(pa.DataFrameModel):
+    """Validation schema for feature columns."""
+
+    atr: Series[float] | None = Field(ge=0)
+    sl_dist_atr: Series[float] | None = Field(ge=0)
+    tp_dist_atr: Series[float] | None = Field(ge=0)
+    book_bid_vol: Series[float] | None = Field(ge=0)
+    book_ask_vol: Series[float] | None = Field(ge=0)
+    book_imbalance: Series[float] | None = Field(ge=-1, le=1)
+    equity: Series[float] | None = Field(ge=0)
+    margin_level: Series[float] | None = Field(ge=0)
+
+    class Config:
+        strict = False
+        coerce = True
+
+
+__all__ = ["FeatureSchema"]

--- a/botcopier/training/pipeline.py
+++ b/botcopier/training/pipeline.py
@@ -24,6 +24,7 @@ except ImportError:  # pragma: no cover - optional
 from pydantic import ValidationError
 
 from botcopier.data.loading import _load_logs
+from botcopier.data.feature_schema import FeatureSchema
 from botcopier.features.anomaly import _clip_train_features
 from botcopier.features.engineering import FeatureConfig, configure_cache
 from botcopier.features.technical import (
@@ -130,6 +131,7 @@ def train(
                 feature_names = list(FEATURE_COLUMNS)
             else:
                 chunk, feature_names, _, _ = _extract_features(chunk, feature_names)
+            FeatureSchema.validate(chunk[feature_names])
             if label_col is None:
                 label_col = next(
                     (c for c in chunk.columns if c.startswith("label")), None
@@ -157,6 +159,7 @@ def train(
             feature_names = list(FEATURE_COLUMNS)
         else:
             df, feature_names, _, _ = _extract_features(df, feature_names)
+        FeatureSchema.validate(df[feature_names])
         label_col = next((c for c in df.columns if c.startswith("label")), None)
         if label_col is None:
             raise ValueError("no label column found")

--- a/tests/test_feature_schema.py
+++ b/tests/test_feature_schema.py
@@ -1,0 +1,17 @@
+import pandas as pd
+import pandera as pa
+import pytest
+
+from botcopier.data.feature_schema import FeatureSchema
+
+
+def test_type_violation():
+    df = pd.DataFrame({"atr": ["bad"], "sl_dist_atr": [1.0]})
+    with pytest.raises(pa.errors.SchemaError):
+        FeatureSchema.validate(df)
+
+
+def test_range_violation():
+    df = pd.DataFrame({"atr": [1.0], "sl_dist_atr": [-1.0]})
+    with pytest.raises(pa.errors.SchemaError):
+        FeatureSchema.validate(df)


### PR DESCRIPTION
## Summary
- add pandera-based FeatureSchema for engineered features
- validate features against schema in training pipeline
- test schema with type and range violations

## Testing
- `pytest tests/test_feature_schema.py -q`
- `pytest tests/test_train_target_clone_scaler.py::test_scaler_robust_with_outliers -q`


------
https://chatgpt.com/codex/tasks/task_e_68c3118a4e08832f978c065819b7c096