### PR TITLE
Add GPU parameter support and flag

### DIFF
--- a/botcopier/training/pipeline.py
+++ b/botcopier/training/pipeline.py
@@ -109,7 +109,14 @@ def train(
     ]
     load_kwargs = {k: kwargs[k] for k in load_keys if k in kwargs}
     logs, feature_names, _ = _load_logs(data_dir, **load_kwargs)
-    gpu_kwargs = {"use_gpu": True} if use_gpu else {}
+    gpu_kwargs: dict[str, object] = {}
+    if use_gpu:
+        if model_type == "xgboost":
+            gpu_kwargs.update({"tree_method": "gpu_hist", "predictor": "gpu_predictor"})
+        elif model_type == "catboost":
+            gpu_kwargs.update({"device": "gpu"})
+        elif model_type == "transformer":
+            gpu_kwargs.update({"device": "cuda"})
     fs_repo = Path(__file__).resolve().parents[1] / "feature_store" / "feast_repo"
     y_list: list[np.ndarray] = []
     X_list: list[np.ndarray] = []

--- a/tests/test_model_fitting.py
+++ b/tests/test_model_fitting.py
@@ -116,7 +116,9 @@ def test_early_stopping_reduces_overfit(caplog) -> None:
     assert clf_es.best_iteration < 49
 
 
-@pytest.mark.skipif(not _HAS_CUDA, reason="CUDA is unavailable")
+@pytest.mark.skipif(
+    not _HAS_CUDA, reason="CUDA is unavailable or torch not installed"
+)
 def test_xgb_gpu_parameter_forwarding() -> None:
     pytest.importorskip("xgboost")
     X, y = make_classification(n_samples=50, n_features=4, random_state=0)
@@ -124,7 +126,9 @@ def test_xgb_gpu_parameter_forwarding() -> None:
     assert clf.get_xgb_params().get("tree_method") == "gpu_hist"
 
 
-@pytest.mark.skipif(not _HAS_CUDA, reason="CUDA is unavailable")
+@pytest.mark.skipif(
+    not _HAS_CUDA, reason="CUDA is unavailable or torch not installed"
+)
 def test_catboost_gpu_parameter_forwarding() -> None:
     pytest.importorskip("catboost")
     X, y = make_classification(n_samples=50, n_features=4, random_state=0)


### PR DESCRIPTION
## Summary
- allow passing GPU-specific parameters to XGBoost and CatBoost builders
- forward GPU parameters from training pipeline via `--use-gpu`
- skip GPU tests when CUDA/torch not available

## Testing
- `pytest tests/test_model_fitting.py -k gpu_parameter_forwarding -q`


------
https://chatgpt.com/codex/tasks/task_e_68c3508e7c38832f85d96cad927d5b52