### PR TITLE
Generate model card from training metrics

### DIFF
--- a/botcopier/scripts/model_card.py
+++ b/botcopier/scripts/model_card.py
@@ -14,6 +14,12 @@ _TEMPLATE = """
 ## Model Parameters
 - **Version:** {{ params.version }}
 - **Features:** {{ params.feature_names | join(', ') }}
+{% if params.metadata %}
+## Metadata
+{% for key, value in params.metadata.items() %}
+- **{{ key }}:** {{ value }}
+{% endfor %}
+{% endif %}
 
 ## Metrics
 {% for key, value in metrics.items() %}- **{{ key }}:** {{ '%.4f' | format(value) if value is not none else 'N/A' }}


### PR DESCRIPTION
## Summary
- extend model card template to include metadata and metrics
- track aggregated metrics in training pipeline and emit a model card

## Testing
- `pre-commit run --files botcopier/scripts/model_card.py botcopier/training/pipeline.py` *(fails: isort modified file, mypy missing stubs)*
- `SKIP=mypy pre-commit run --files botcopier/scripts/model_card.py botcopier/training/pipeline.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy' and other missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68c3526f9234832fa5012c0d84924345