### PR TITLE
Ensure deterministic seeding in training modules

### DIFF
--- a/botcopier/scripts/online_trainer.py
+++ b/botcopier/scripts/online_trainer.py
@@ -631,9 +631,8 @@ async def run(data_cfg: "DataConfig", train_cfg: "TrainingConfig") -> None:
     """Run the online trainer with ``data_cfg`` and ``train_cfg`` asynchronously."""
     from botcopier.config.settings import DataConfig, TrainingConfig, save_params
 
-    save_params(data_cfg, train_cfg)
-
     set_seed(train_cfg.random_seed)
+    save_params(data_cfg, train_cfg)
     trainer = OnlineTrainer(
         train_cfg.model,
         train_cfg.batch_size,


### PR DESCRIPTION
## Summary
- seed training pipeline via explicit `random_seed` argument and record in `model.json`
- seed online trainer at startup for reproducibility

## Testing
- `pytest -q` *(fails: 15 failed, 6 passed, 14 warnings, 2 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c3678dc478832fb249a2c7e0d0791f