### PR TITLE
feat: sanitize logs by removing duplicates and outliers

### DIFF
--- a/tests/test_data_sanitization.py
+++ b/tests/test_data_sanitization.py
@@ -1,0 +1,42 @@
+import logging
+import sys
+import types
+
+import pandas as pd
+
+stub = types.SimpleNamespace(
+    _augment_dataframe=lambda df, ratio: df,
+    _augment_dtw_dataframe=lambda df, ratio: df,
+)
+sys.modules.setdefault("botcopier.features.augmentation", stub)
+
+from botcopier.data.loading import _drop_duplicates_and_outliers, _load_logs
+
+
+def _build_df() -> pd.DataFrame:
+    times = pd.date_range("2020-01-01", periods=100, freq="T")
+    base = pd.DataFrame({"event_time": times, "price": 1.0})
+    dup = base.iloc[[0]]
+    outlier_time = times[-1] + pd.Timedelta(minutes=1)
+    outlier = pd.DataFrame({"event_time": [outlier_time], "price": [1000.0]})
+    return pd.concat([dup, base, outlier], ignore_index=True)
+
+
+def test_drop_duplicates_and_outliers():
+    df = _build_df()
+    cleaned, dup_cnt, out_cnt = _drop_duplicates_and_outliers(df)
+    assert dup_cnt == 1
+    assert out_cnt == 1
+    assert len(cleaned) == 100
+
+
+def test_load_logs_reports_sanitization(tmp_path, caplog):
+    df = _build_df()
+    file_path = tmp_path / "trades_raw.csv"
+    df.to_csv(file_path, index=False)
+    with caplog.at_level(logging.INFO):
+        loaded, _, _ = _load_logs(file_path)
+    assert len(loaded) == 100
+    assert any(
+        "Removed 1 duplicate rows and 1 outlier rows" in m for m in caplog.messages
+    )


### PR DESCRIPTION
## Summary
- remove duplicate and outlier rows from loaded logs using z-score filtering
- log counts of dropped rows during log loading
- test that log sanitation runs and reports correctly

## Testing
- `SKIP=mypy pre-commit run --files botcopier/data/loading.py tests/test_data_sanitization.py`
- `pytest tests/test_data_sanitization.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c38167f784832fba232fe65b15bae5