### PR TITLE
Add n_jobs option for parallel feature extraction

### DIFF
--- a/botcopier/training/pipeline.py
+++ b/botcopier/training/pipeline.py
@@ -92,6 +92,7 @@ def train(
     distributed: bool = False,
     use_gpu: bool = False,
     random_seed: int = 0,
+    n_jobs: int | None = None,
     **kwargs: object,
 ) -> None:
     """Train a model selected from the registry."""
@@ -141,7 +142,9 @@ def train(
                 chunk = chunk.merge(feat_df, on=["symbol", "event_time"], how="left")
                 feature_names = list(FEATURE_COLUMNS)
             else:
-                chunk, feature_names, _, _ = _extract_features(chunk, feature_names)
+                chunk, feature_names, _, _ = _extract_features(
+                    chunk, feature_names, n_jobs=n_jobs
+                )
             FeatureSchema.validate(chunk[feature_names], lazy=True)
             if label_col is None:
                 label_col = next(
@@ -169,7 +172,9 @@ def train(
             df = df.merge(feat_df, on=["symbol", "event_time"], how="left")
             feature_names = list(FEATURE_COLUMNS)
         else:
-            df, feature_names, _, _ = _extract_features(df, feature_names)
+            df, feature_names, _, _ = _extract_features(
+                df, feature_names, n_jobs=n_jobs
+            )
         FeatureSchema.validate(df[feature_names], lazy=True)
         label_col = next((c for c in df.columns if c.startswith("label")), None)
         if label_col is None:

--- a/tests/test_n_jobs_deterministic.py
+++ b/tests/test_n_jobs_deterministic.py
@@ -1,0 +1,47 @@
+import json
+from pathlib import Path
+
+import pandas as pd
+
+from botcopier.features.technical import _extract_features_impl
+from botcopier.training.pipeline import train
+
+
+def _sample_df() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "open": [1.0, 1.1, 1.2, 1.3, 1.4, 1.5],
+            "high": [1.1, 1.2, 1.3, 1.4, 1.5, 1.6],
+            "low": [0.9, 1.0, 1.1, 1.2, 1.3, 1.4],
+            "close": [1.05, 1.15, 1.25, 1.35, 1.45, 1.55],
+            "volume": [100, 110, 120, 130, 140, 150],
+            "price": [1.05, 1.15, 1.25, 1.35, 1.45, 1.55],
+            "symbol": ["EURUSD"] * 6,
+            "event_time": pd.date_range("2020-01-01", periods=6, freq="H"),
+            "label": [0, 1, 0, 1, 0, 1],
+        }
+    )
+
+
+def test_extract_features_deterministic_n_jobs() -> None:
+    df = _sample_df()
+    feature_names: list[str] = []
+    df1, fn1, emb1, gnn1 = _extract_features_impl(df.copy(), feature_names.copy(), n_jobs=1)
+    df2, fn2, emb2, gnn2 = _extract_features_impl(df.copy(), feature_names.copy(), n_jobs=2)
+    pd.testing.assert_frame_equal(df1, df2)
+    assert fn1 == fn2
+    assert emb1 == emb2
+    assert gnn1 == gnn2
+
+
+def test_train_deterministic_n_jobs(tmp_path: Path) -> None:
+    data = tmp_path / "data.csv"
+    df = _sample_df()
+    df.to_csv(data, index=False)
+    out1 = tmp_path / "out1"
+    out2 = tmp_path / "out2"
+    train(data, out1, n_jobs=1, n_splits=2)
+    train(data, out2, n_jobs=2, n_splits=2)
+    model1 = json.loads((out1 / "model.json").read_text())
+    model2 = json.loads((out2 / "model.json").read_text())
+    assert model1 == model2


### PR DESCRIPTION
## Summary
- add `n_jobs` parameter to feature extraction and training pipeline
- compute graph embeddings in parallel with indicator extraction
- ensure deterministic results across different `n_jobs`

## Testing
- `pytest tests/test_n_jobs_deterministic.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c38e29e304832f8c697667c4089d04