### PR TITLE
feat: add metric registry and CLI selection

### DIFF
--- a/botcopier/scripts/train_target_clone.py
+++ b/botcopier/scripts/train_target_clone.py
@@ -41,6 +41,12 @@ def main() -> None:
         action="store_true",
         help="enable Ray for distributed trials and folds",
     )
+    p.add_argument(
+        "--metric",
+        action="append",
+        dest="metrics",
+        help="classification metric to compute (repeatable)",
+    )
     args = p.parse_args()
 
     if args.distributed:
@@ -55,6 +61,7 @@ def main() -> None:
         tracking_uri=args.tracking_uri,
         experiment_name=args.experiment_name,
         distributed=args.distributed,
+        metrics=args.metrics,
     )
 
 

--- a/metrics/__init__.py
+++ b/metrics/__init__.py
@@ -1,0 +1,4 @@
+"""Metric registry exposed for convenience."""
+from .registry import get_metrics, register_metric
+
+__all__ = ["get_metrics", "register_metric"]

--- a/metrics/registry.py
+++ b/metrics/registry.py
@@ -1,0 +1,24 @@
+"""Simple metric registry for classification metrics."""
+from __future__ import annotations
+
+from typing import Callable, Dict, Sequence
+
+MetricFn = Callable[[object, object, object | None], object]
+
+_REGISTRY: Dict[str, MetricFn] = {}
+
+
+def register_metric(name: str, fn: MetricFn) -> None:
+    """Register a metric callable under ``name``."""
+    _REGISTRY[name] = fn
+
+
+def get_metrics(selected: Sequence[str] | None = None) -> Dict[str, MetricFn]:
+    """Return metric callables filtered by ``selected`` names.
+
+    If ``selected`` is ``None``, all registered metrics are returned.
+    Unknown names are ignored.
+    """
+    if selected is None:
+        return dict(_REGISTRY)
+    return {name: _REGISTRY[name] for name in selected if name in _REGISTRY}


### PR DESCRIPTION
## Summary
- add simple metric registry to manage classification metrics
- refactor evaluation metrics to use registry
- allow training scripts to choose metrics via `--metric`

## Testing
- `SKIP=mypy pre-commit run --files metrics/registry.py metrics/__init__.py botcopier/scripts/evaluation.py botcopier/training/pipeline.py botcopier/scripts/train_target_clone.py`
- `pytest` *(fails: No module named 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_e_68c455fac97c832f86e61efcb8901ee6