### PR TITLE
feat: add memory-mapped CSV loading

### DIFF
--- a/docs/data_loading_tutorial.md
+++ b/docs/data_loading_tutorial.md
@@ -12,6 +12,15 @@ True
 >>> _, cols, *_ = _extract_features(df, feature_names=list(feature_cols))
 >>> set(cols) == set(feature_cols)
 True
->>> 
+>>>
 ```
+
+## Memory considerations
+
+When ``lite_mode`` is ``False`` the loader inspects the file size before
+reading. Files larger than a configurable threshold are accessed using a
+memory-mapped or ``pyarrow.dataset`` reader. This avoids loading the entire
+dataset into RAM but may incur a slight performance penalty for random access.
+For smaller files the data is read eagerly into memory which provides faster
+subsequent access at the cost of peak memory usage.
 


### PR DESCRIPTION
## Summary
- use memory-mapped/pyarrow dataset when large CSVs are loaded
- document memory-mapped loading trade-offs
- test both in-memory and memory-mapped CSV paths

## Testing
- `pytest tests/test_chunked_loading.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c45af4c5d4832fb225d6a6b4e28cf3