### PR TITLE
Add tests for missing optional dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,17 @@ on:
   pull_request:
 
 jobs:
+  minimal:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+      - name: Run optional dependency tests
+        run: pytest tests/optional
   test:
     runs-on: ubuntu-latest
     steps:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,8 @@ ALLOWED = {
     "test_online_trainer_async.py",
     "property",
     "test_invariants.py",
+    "optional",
+    "test_missing_dependencies.py",
 }
 
 

--- a/tests/optional/test_missing_dependencies.py
+++ b/tests/optional/test_missing_dependencies.py
@@ -1,0 +1,34 @@
+import importlib
+import sys
+
+import pytest
+
+
+def test_missing_xgboost_raises(monkeypatch):
+    monkeypatch.setitem(sys.modules, "xgboost", None)
+    sys.modules.pop("botcopier.models.registry", None)
+    registry = importlib.import_module("botcopier.models.registry")
+    with pytest.raises(ImportError, match="xgboost is required"):
+        registry._fit_xgboost_classifier()
+    monkeypatch.undo()
+    importlib.reload(registry)
+
+
+def test_missing_catboost_raises(monkeypatch):
+    monkeypatch.setitem(sys.modules, "catboost", None)
+    sys.modules.pop("botcopier.models.registry", None)
+    registry = importlib.import_module("botcopier.models.registry")
+    with pytest.raises(ImportError, match="catboost is required"):
+        registry._fit_catboost_classifier()
+    monkeypatch.undo()
+    importlib.reload(registry)
+
+
+def test_missing_polars_fallback(monkeypatch):
+    monkeypatch.setitem(sys.modules, "polars", None)
+    sys.modules.pop("botcopier.features.technical", None)
+    technical = importlib.import_module("botcopier.features.technical")
+    assert technical.pl is None
+    assert not technical._HAS_POLARS
+    monkeypatch.undo()
+    importlib.reload(technical)


### PR DESCRIPTION
## Summary
- add tests covering ImportError/fallback behaviors when optional packages are missing
- enable new tests in a minimal CI job

## Testing
- `SKIP=mypy pre-commit run --files tests/optional/test_missing_dependencies.py tests/conftest.py .github/workflows/ci.yml`
- `pytest tests/optional`


------
https://chatgpt.com/codex/tasks/task_e_68c45d7c8fb0832f9d6e632081a4060b