### PR TITLE
feat: add optional order book features

### DIFF
--- a/botcopier/data/feature_schema.py
+++ b/botcopier/data/feature_schema.py
@@ -22,6 +22,9 @@ class FeatureSchema(pa.DataFrameModel):
     book_bid_vol: Series[float] | None = Field(ge=0)
     book_ask_vol: Series[float] | None = Field(ge=0)
     book_imbalance: Series[float] | None = Field(ge=-1, le=1)
+    depth_microprice: Series[float] | None = Field()
+    depth_vol_imbalance: Series[float] | None = Field(ge=-1, le=1)
+    depth_order_flow_imbalance: Series[float] | None = Field()
     equity: Series[float] | None = Field(ge=0)
     margin_level: Series[float] | None = Field(ge=0)
 

--- a/tests/test_orderbook_features.py
+++ b/tests/test_orderbook_features.py
@@ -1,0 +1,28 @@
+import pandas as pd
+from botcopier.features import _extract_features
+from botcopier.features.engineering import configure_cache, FeatureConfig
+
+
+def test_orderbook_features_shapes_and_ranges():
+    df = pd.DataFrame(
+        {
+            "bid": [100.0, 101.0, 102.0],
+            "ask": [101.0, 102.0, 103.0],
+            "bid_depth": [[5, 4], [7, 3], [8, 2]],
+            "ask_depth": [[4, 5], [3, 6], [2, 7]],
+        }
+    )
+    configure_cache(FeatureConfig(enabled_features={"orderbook"}))
+    feats, cols, _, _ = _extract_features(df.copy(), [])
+    configure_cache(FeatureConfig())  # reset for other tests
+
+    assert {"depth_microprice", "depth_vol_imbalance", "depth_order_flow_imbalance"} <= set(
+        cols
+    )
+    assert len(feats) == len(df)
+    # microprice bounded by bid and ask
+    assert ((feats["depth_microprice"] >= feats["bid"]) & (feats["depth_microprice"] <= feats["ask"])).all()
+    # volume imbalance within [-1, 1]
+    assert ((feats["depth_vol_imbalance"] <= 1) & (feats["depth_vol_imbalance"] >= -1)).all()
+    # first order flow imbalance is zero
+    assert abs(feats["depth_order_flow_imbalance"].iloc[0]) < 1e-9


### PR DESCRIPTION
## Summary
- load optional depth snapshots with trades to compute order book features
- derive microprice, volume and order-flow imbalance with --orderbook-features flag
- test new depth-based features

## Testing
- `pytest tests/test_orderbook_features.py -q`
- `pytest tests/test_features_module.py::test_extract_features_basic -q`


------
https://chatgpt.com/codex/tasks/task_e_68c46056e730832fbd69ea079e3b7b05