### PR TITLE
Handle skewed features with PowerTransformer

### DIFF
--- a/tests/test_power_transform.py
+++ b/tests/test_power_transform.py
@@ -1,0 +1,41 @@
+import json
+
+import numpy as np
+import pandas as pd
+from sklearn.preprocessing import PowerTransformer
+
+from botcopier.training.pipeline import train
+
+
+def test_power_transform_reduces_variance(tmp_path):
+    rng = np.random.default_rng(0)
+    n = 200
+    df = pd.DataFrame(
+        {
+            "label": rng.integers(0, 2, size=n),
+            "spread": rng.exponential(scale=2.0, size=n),
+            "hour": np.zeros(n),
+        }
+    )
+    data = tmp_path / "trades_raw.csv"
+    df.to_csv(data, index=False)
+    out_dir = tmp_path / "out"
+    train(data, out_dir)
+    model = json.loads((out_dir / "model.json").read_text())
+    pt = model.get("power_transformer")
+    assert pt is not None
+    assert "spread" in pt["features"]
+    idx = pt["features"].index("spread")
+    pt_obj = PowerTransformer(method="yeo-johnson")
+    pt_obj.lambdas_ = np.array([pt["lambdas"][idx]])
+    from sklearn.preprocessing import StandardScaler
+    scaler = StandardScaler()
+    scaler.mean_ = np.array([pt["mean"][idx]])
+    scaler.scale_ = np.array([pt["scale"][idx]])
+    pt_obj._scaler = scaler
+    pt_obj.n_features_in_ = 1
+    X = df[["spread"]].to_numpy()
+    var_before = X.var()
+    var_after = pt_obj.transform(X).var()
+    assert var_after < var_before
+

--- a/tests/test_train_target_clone_scaler.py
+++ b/tests/test_train_target_clone_scaler.py
@@ -1,7 +1,8 @@
 import json
 
 import numpy as np
-from sklearn.preprocessing import RobustScaler
+import pandas as pd
+from sklearn.preprocessing import PowerTransformer, RobustScaler
 
 from botcopier.training.pipeline import train, _load_logs, _extract_features
 
@@ -28,6 +29,12 @@ def test_scaler_robust_with_outliers(tmp_path):
     df, features, _ = _load_logs(data)
     df, features, _, _ = _extract_features(df, features)
     X = df[features].to_numpy(dtype=float)
+    skew = pd.DataFrame(X, columns=features).skew().abs()
+    skew_cols = skew[skew > 1.0].index.tolist()
+    if skew_cols:
+        pt = PowerTransformer(method="yeo-johnson")
+        idx = [features.index(c) for c in skew_cols]
+        X[:, idx] = pt.fit_transform(X[:, idx])
     clip_min = np.quantile(X, 0.01, axis=0)
     clip_max = np.quantile(X, 0.99, axis=0)
     X_c = np.clip(X, clip_min, clip_max)


### PR DESCRIPTION
## Summary
- Fit Yeo-Johnson PowerTransformer on highly skewed numeric features during training and store parameters in model metadata
- Apply the same transformation in the inference service before prediction
- Add regression test ensuring the transformation reduces variance and update scaler test

## Testing
- `pytest tests/test_power_transform.py -q`
- `pytest tests/test_train_target_clone_scaler.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4b0900dec832fa3ffaba55bbdff94