### PR TITLE
Add confidence-weighted online trainer and tests

### DIFF
--- a/botcopier/config/settings.py
+++ b/botcopier/config/settings.py
@@ -54,6 +54,7 @@ class TrainingConfig(BaseSettings):
     model_type: str = "logreg"
     window: int = 60
     random_seed: int = 0
+    online_model: str = "sgd"
 
     model_config = {"env_prefix": "TRAIN_"}
 

--- a/tests/test_online_conf_weighted.py
+++ b/tests/test_online_conf_weighted.py
@@ -1,0 +1,49 @@
+import numpy as np
+from pathlib import Path
+
+from botcopier.scripts.online_trainer import OnlineTrainer
+
+
+def _generate_stream():
+    rng = np.random.default_rng(0)
+    X1 = rng.normal(size=(50, 1))
+    y1 = (X1[:, 0] > 0).astype(int)
+    X2 = rng.normal(size=(50, 1))
+    y2 = (X2[:, 0] < 0).astype(int)  # concept drift: decision flips
+    X = np.vstack([X1, X2])
+    y = np.concatenate([y1, y2])
+    return X, y
+
+
+def _train(trainer: OnlineTrainer, X: np.ndarray, y: np.ndarray) -> None:
+    for xi, yi in zip(X, y):
+        trainer.update([{"f0": float(xi[0]), "y": int(yi)}])
+
+
+def test_confidence_weighted_updates_and_outperforms(tmp_path: Path) -> None:
+    X, y = _generate_stream()
+    # train confidence weighted model
+    cw_path = tmp_path / "cw.json"
+    trainer_cw = OnlineTrainer(cw_path, batch_size=1, run_generator=False, online_model="confidence_weighted")
+    trainer_cw.clf.r = 0.1
+    _train(trainer_cw, X, y)
+    # ensure weights updated
+    assert np.linalg.norm(trainer_cw.clf.w) > 0
+    # save and reload to check variance persistence
+    trainer_cw._save()
+    w_before = trainer_cw.clf.w.copy()
+    sigma_before = trainer_cw.clf.sigma.copy()
+    trainer_cw2 = OnlineTrainer(cw_path, batch_size=1, run_generator=False, online_model="confidence_weighted")
+    assert np.allclose(trainer_cw2.clf.w, w_before)
+    assert np.allclose(trainer_cw2.clf.sigma, sigma_before)
+    # accuracy after drift period
+    X_last, y_last = X[-20:], y[-20:]
+    acc_cw = (trainer_cw.clf.predict(X_last) == y_last).mean()
+
+    # baseline SGD
+    sgd_path = tmp_path / "sgd.json"
+    trainer_sgd = OnlineTrainer(sgd_path, batch_size=1, run_generator=False)
+    _train(trainer_sgd, X[:80], y[:80])
+    acc_sgd = (trainer_sgd.clf.predict(X_last) == y_last).mean()
+
+    assert acc_cw >= acc_sgd


### PR DESCRIPTION
## Summary
- implement diagonal ConfidenceWeighted classifier and register it
- extend online trainer to load `--online-model` including confidence logging and variance persistence
- add streaming test demonstrating confidence-weighted updates outperform stale SGD

## Testing
- `pytest tests/test_online_conf_weighted.py -q`
- `pytest tests/test_online_trainer.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4dc624d4c832f9b87d038cc85d9b7