### PR TITLE
feat: add dask data loading and deterministic tests

### DIFF
--- a/docs/dask_mode.md
+++ b/docs/dask_mode.md
@@ -1,0 +1,20 @@
+# Dask Mode
+
+BotCopier can operate in a parallel, out-of-core mode powered by [Dask](https://www.dask.org/).
+Enable it by passing the `--dask` flag to any command that relies on
+`botcopier.data.loading._load_logs`.
+
+## Memory and Parallelism
+
+Dask uses multiple worker processes to execute computations. The number of
+workers and the memory available to each worker can be controlled with the
+`DASK_WORKERS` and `DASK_MEMORY_LIMIT` environment variables respectively:
+
+```bash
+export DASK_WORKERS=2      # number of parallel workers
+export DASK_MEMORY_LIMIT="1GB"  # per-worker memory cap
+```
+
+These settings allow feature extraction to scale beyond a single machine's
+memory limits. Results are computed lazily and realised only at model-fit time
+when `.compute()` is invoked.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ authors = [{name = "BotCopier Developers"}]
 dependencies = [
     "numpy",
     "pandas",
+    "dask[dataframe]",
     "great_expectations",
     "scikit-learn",
     "joblib",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 numpy
 pandas
+dask[dataframe]
 great_expectations
 scikit-learn
 scipy

--- a/tests/test_dask_determinism.py
+++ b/tests/test_dask_determinism.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+import numpy as np
+
+from botcopier.data.loading import _load_logs
+from botcopier.features.technical import _extract_features
+
+
+def test_pandas_dask_equivalence():
+    data = Path("tests/fixtures/trades_small.csv")
+    pdf, feats, _ = _load_logs(data)
+    ddf, feats2, _ = _load_logs(data, dask=True)
+    assert feats == feats2
+    pdf_feat, feats, *_ = _extract_features(pdf.copy(), feats)
+    ddf_feat, feats, *_ = _extract_features(ddf, feats)
+    pd_vals = pdf_feat[feats].fillna(0).to_numpy()
+    dd_vals = ddf_feat.compute()[feats].fillna(0).to_numpy()
+    assert np.allclose(pd_vals, dd_vals)


### PR DESCRIPTION
## Summary
- support optional Dask DataFrame loading via `--dask`
- propagate Dask through feature extraction and training pipeline
- document Dask memory/parallelism settings and add equivalence test

## Testing
- `pytest tests/test_dask_determinism.py::test_pandas_dask_equivalence -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4e2ab4464832f8180f3bd2eea8db4