### PR TITLE
Add sequential drift detection in online trainer

### DIFF
--- a/botcopier/scripts/sequential_drift.py
+++ b/botcopier/scripts/sequential_drift.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Sequential drift detection utilities.
+
+This module provides lightweight implementations of the Page-Hinkley and
+CUSUM change detection tests.  They operate on a stream of numeric values
+representing summary statistics (for example feature means) and emit a
+boolean flag when a significant change is detected.  The detectors keep a
+small amount of state making them suitable for online processing.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class PageHinkley:
+    """Classic Page-Hinkley test for detecting distribution shifts.
+
+    Parameters
+    ----------
+    delta:
+        Minimum magnitude of changes to accumulate.  Smaller values make the
+        detector more sensitive to noise.
+    threshold:
+        Detection threshold.  When the accumulated statistic exceeds this
+        value a drift event is raised.
+    min_samples:
+        Number of initial observations required before drift can be reported.
+    """
+
+    delta: float = 0.005
+    threshold: float = 50.0
+    min_samples: int = 30
+
+    def __post_init__(self) -> None:  # pragma: no cover - simple init
+        self.reset()
+
+    def reset(self) -> None:
+        """Reset internal state."""
+        self._n = 0
+        self._mean = 0.0
+        self._cum = 0.0
+        self._min_cum = 0.0
+
+    def update(self, value: float) -> bool:
+        """Update the detector with ``value``.
+
+        Returns ``True`` when a drift event is detected.
+        """
+
+        self._n += 1
+        # incremental mean
+        self._mean += (value - self._mean) / self._n
+        # cumulative difference from the mean, penalised by ``delta``
+        self._cum += value - self._mean - self.delta
+        self._min_cum = min(self._min_cum, self._cum)
+        if self._n >= self.min_samples and self._cum - self._min_cum > self.threshold:
+            self.reset()
+            return True
+        return False
+
+
+@dataclass
+class CusumDetector:
+    """Cumulative sum (CUSUM) detector.
+
+    A simple two-sided CUSUM test which tracks positive and negative
+    excursions from the running mean.  A drift is reported whenever either
+    side exceeds ``threshold``.
+    """
+
+    drift: float = 0.0
+    threshold: float = 5.0
+
+    def __post_init__(self) -> None:  # pragma: no cover - simple init
+        self.reset()
+
+    def reset(self) -> None:
+        self._n = 0
+        self._mean = 0.0
+        self._gpos = 0.0
+        self._gneg = 0.0
+
+    def update(self, value: float) -> bool:
+        self._n += 1
+        self._mean += (value - self._mean) / self._n
+        self._gpos = max(0.0, self._gpos + value - self._mean - self.drift)
+        self._gneg = min(0.0, self._gneg + value - self._mean + self.drift)
+        if self._gpos > self.threshold or abs(self._gneg) > self.threshold:
+            self.reset()
+            return True
+        return False
+
+
+__all__ = ["PageHinkley", "CusumDetector"]
+

--- a/tests/test_online_trainer.py
+++ b/tests/test_online_trainer.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import numpy as np
 
 from scripts.online_trainer import OnlineTrainer
+from scripts.sequential_drift import PageHinkley
 
 
 def test_online_trainer_updates(tmp_path: Path):
@@ -58,8 +59,7 @@ def test_conformal_bounds_change(tmp_path: Path):
 def test_regime_shift_triggers_reset(tmp_path: Path, caplog):
     model_path = tmp_path / "model.json"
     trainer = OnlineTrainer(model_path=model_path, batch_size=5)
-    trainer.cp_window = 4
-    trainer.cp_threshold = 1.0
+    trainer.drift_detector = PageHinkley(delta=0.1, threshold=1.0, min_samples=5)
     baseline = [{"a": 0.0, "b": 0.0, "y": 0} for _ in range(5)]
     for _ in range(4):
         trainer.update(baseline)

--- a/tests/test_sequential_drift.py
+++ b/tests/test_sequential_drift.py
@@ -1,0 +1,13 @@
+from scripts.sequential_drift import PageHinkley
+
+
+def test_page_hinkley_detects_expected_change():
+    detector = PageHinkley(delta=0.1, threshold=1.0, min_samples=5)
+    data = [0.0] * 10 + [1.0] * 10
+    alarm = None
+    for i, v in enumerate(data):
+        if detector.update(v):
+            alarm = i
+            break
+    assert alarm == 11
+


### PR DESCRIPTION
## Summary
- implement Page-Hinkley and CUSUM drift detectors
- integrate Page-Hinkley in online trainer for sequential drift checks
- test sequential drift on synthetic data and trainer regime shifts

## Testing
- `pytest tests/test_sequential_drift.py tests/test_online_trainer.py::test_regime_shift_triggers_reset tests/test_online_trainer.py::test_online_trainer_updates tests/test_online_trainer.py::test_online_trainer_logs_validation tests/test_online_trainer.py::test_conformal_bounds_change tests/test_online_trainer.py::test_learning_rate_decay_and_validation tests/test_online_trainer.py::test_calibration_parameters_evolve -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4f5087e94832f9529fd9fbb6b006f