### PR TITLE
Add CNN orderbook depth embeddings

### DIFF
--- a/botcopier/training/pipeline.py
+++ b/botcopier/training/pipeline.py
@@ -36,8 +36,10 @@ try:  # optional dask support
 except Exception:  # pragma: no cover - optional
     dd = None  # type: ignore
     _HAS_DASK = False
+from opentelemetry import trace
 from pydantic import ValidationError
 
+import botcopier.features.technical as technical_features
 from botcopier.config.settings import TrainingConfig
 from botcopier.data.feature_schema import FeatureSchema
 from botcopier.data.loading import _load_logs
@@ -54,7 +56,6 @@ from botcopier.scripts.model_card import generate_model_card
 from botcopier.scripts.splitters import PurgedWalkForward
 from botcopier.utils.random import set_seed
 from logging_utils import setup_logging
-from opentelemetry import trace
 
 try:  # optional feast dependency
     from feast import FeatureStore  # type: ignore
@@ -634,6 +635,8 @@ def train(
             **model_data,
             "model_type": model_type,
         }
+        if getattr(technical_features, "_DEPTH_CNN_STATE", None) is not None:
+            model["depth_cnn"] = technical_features._DEPTH_CNN_STATE
         if cluster_map:
             model["feature_clusters"] = cluster_map
         if calibration_info is not None:

--- a/tests/test_depth_cnn_embeddings.py
+++ b/tests/test_depth_cnn_embeddings.py
@@ -1,0 +1,35 @@
+import json
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+import botcopier.features.engineering as fe
+import botcopier.features.technical as technical
+
+
+def test_depth_cnn_deterministic(tmp_path: Path) -> None:
+    fe.configure_cache(fe.FeatureConfig(enabled_features={"orderbook"}))
+    df = pd.DataFrame(
+        {
+            "bid_depth": [np.array([1.0, 2.0, 3.0]), np.array([2.0, 3.0, 4.0])],
+            "ask_depth": [np.array([1.0, 1.0, 1.0]), np.array([1.0, 2.0, 3.0])],
+            "bid": [1.0, 1.0],
+            "ask": [1.1, 1.1],
+        }
+    )
+    df1, feats1, _, _ = technical._extract_features(df.copy(), [])
+    state = technical._DEPTH_CNN_STATE
+    assert state is not None
+    model_file = tmp_path / "model.json"
+    model_file.write_text(json.dumps({"depth_cnn": state}))
+
+    import importlib
+
+    tech = importlib.import_module("botcopier.features.technical")
+    tech._DEPTH_CNN_STATE = None
+    saved = json.loads(model_file.read_text())["depth_cnn"]
+    df2, feats2, _, _ = technical._extract_features(df.copy(), [], depth_cnn=saved)
+    emb_cols = [c for c in feats1 if c.startswith("depth_cnn_")]
+    for col in emb_cols:
+        assert np.allclose(df1[col], df2[col])


### PR DESCRIPTION
## Summary
- add lightweight CNN to encode bid/ask depth arrays
- persist depth CNN parameters in model.json during training
- test deterministic depth CNN embeddings

## Testing
- `pre-commit run --files botcopier/features/technical.py botcopier/training/pipeline.py tests/test_depth_cnn_embeddings.py` *(fails: mypy errors in unrelated files)*
- `pytest tests/test_depth_cnn_embeddings.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5ae9d32a4832fb21a435361543dd5