### PR TITLE
Add masked autoencoder and pipeline integration

### DIFF
--- a/botcopier/scripts/pretrain_masked.py
+++ b/botcopier/scripts/pretrain_masked.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Pre-train a masked feature autoencoder.
+
+This script trains a simple denoising autoencoder that randomly masks a
+subset of input features and learns to reconstruct them.  The encoder
+weights are saved to ``masked_encoder.pt`` so that downstream models can
+use the compressed representation.
+"""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import pandas as pd
+import torch
+from torch import nn
+from torch.utils.data import DataLoader, TensorDataset
+
+
+def train(
+    data_file: Path,
+    out_dir: Path,
+    *,
+    latent_dim: int = 8,
+    mask_ratio: float = 0.3,
+    epochs: int = 10,
+    batch_size: int = 32,
+    lr: float = 1e-3,
+) -> Path:
+    """Train a masked autoencoder and return path to saved encoder.
+
+    Parameters
+    ----------
+    data_file:
+        CSV file containing feature columns. Any column starting with
+        ``label`` is ignored.
+    out_dir:
+        Directory where ``masked_encoder.pt`` will be written.
+    latent_dim:
+        Dimension of the encoded feature space.
+    mask_ratio:
+        Fraction of features to randomly mask during training.
+    epochs:
+        Number of training epochs.
+    batch_size:
+        Training batch size.
+    lr:
+        Optimiser learning rate.
+    """
+    df = pd.read_csv(data_file)
+    feature_cols = [c for c in df.columns if not c.startswith("label") and c != "profit"]
+    X = df[feature_cols].to_numpy(dtype=float)
+    X_tensor = torch.tensor(X, dtype=torch.float32)
+    dataset = TensorDataset(X_tensor)
+    loader = DataLoader(dataset, batch_size=batch_size, shuffle=True)
+
+    input_dim = X.shape[1]
+
+    class AutoEncoder(nn.Module):
+        def __init__(self, inp: int, latent: int) -> None:
+            super().__init__()
+            self.encoder = nn.Linear(inp, latent)
+            self.decoder = nn.Linear(latent, inp)
+
+        def forward(self, x: torch.Tensor) -> torch.Tensor:  # pragma: no cover - simple
+            return self.decoder(self.encoder(x))
+
+    model = AutoEncoder(input_dim, latent_dim)
+    opt = torch.optim.Adam(model.parameters(), lr=lr)
+
+    for _ in range(epochs):
+        for (batch,) in loader:
+            mask = torch.rand_like(batch) < mask_ratio
+            corrupted = batch.clone()
+            corrupted[mask] = 0.0
+            recon = model(corrupted)
+            loss = ((recon - batch)[mask] ** 2).mean()
+            opt.zero_grad()
+            loss.backward()
+            opt.step()
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    enc_state = model.encoder.state_dict()
+    save_path = out_dir / "masked_encoder.pt"
+    torch.save(
+        {
+            "state_dict": enc_state,
+            "architecture": [input_dim, latent_dim],
+            "mask_ratio": mask_ratio,
+        },
+        save_path,
+    )
+    return save_path
+
+
+def main() -> None:  # pragma: no cover - CLI wrapper
+    p = argparse.ArgumentParser(description="Pretrain masked autoencoder")
+    p.add_argument("data_file", help="CSV file with feature columns")
+    p.add_argument("out_dir", help="Output directory for encoder")
+    p.add_argument("--latent-dim", type=int, default=8)
+    p.add_argument("--mask-ratio", type=float, default=0.3)
+    p.add_argument("--epochs", type=int, default=10)
+    p.add_argument("--batch-size", type=int, default=32)
+    p.add_argument("--lr", type=float, default=1e-3)
+    args = p.parse_args()
+    train(
+        Path(args.data_file),
+        Path(args.out_dir),
+        latent_dim=args.latent_dim,
+        mask_ratio=args.mask_ratio,
+        epochs=args.epochs,
+        batch_size=args.batch_size,
+        lr=args.lr,
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()

--- a/tests/test_masked_encoder.py
+++ b/tests/test_masked_encoder.py
@@ -1,0 +1,62 @@
+import json
+from pathlib import Path
+
+import pandas as pd
+from sklearn.datasets import make_classification
+
+from botcopier.training.pipeline import train
+from scripts.pretrain_masked import train as pretrain_encoder
+
+
+def _make_dataset(path: Path) -> Path:
+    X, y = make_classification(
+        n_samples=60,
+        n_features=4,
+        n_informative=3,
+        n_redundant=0,
+        random_state=0,
+        flip_y=0.2,
+    )
+    cols = ["spread", "volume", "hour_sin", "hour_cos"]
+    df = pd.DataFrame(X, columns=cols)
+    df.insert(0, "label", y)
+    df.to_csv(path, index=False)
+    return path
+
+
+def test_masked_encoder_changes_dim_and_improves_metrics(tmp_path: Path) -> None:
+    data = _make_dataset(tmp_path / "data.csv")
+
+    out_base = tmp_path / "base"
+    train(data, out_base, n_splits=2, mi_threshold=0.0, cluster_correlation=1.0)
+    base_model = json.loads((out_base / "model.json").read_text())
+    n_base = len(base_model["feature_names"])
+    acc_base = base_model["cv_accuracy"]
+
+    enc_dir = tmp_path / "enc"
+    pretrain_encoder(
+        data,
+        enc_dir,
+        latent_dim=3,
+        mask_ratio=0.3,
+        epochs=400,
+        batch_size=16,
+    )
+    enc_path = enc_dir / "masked_encoder.pt"
+
+    out_mask = tmp_path / "mask"
+    train(
+        data,
+        out_mask,
+        pretrain_mask=enc_path,
+        n_splits=2,
+        mi_threshold=0.0,
+        cluster_correlation=1.0,
+    )
+    mask_model = json.loads((out_mask / "model.json").read_text())
+    n_mask = len(mask_model["feature_names"])
+    acc_mask = mask_model["cv_accuracy"]
+
+    assert n_mask < n_base
+    assert acc_mask >= acc_base
+    assert mask_model.get("masked_encoder", {}).get("mask_ratio") == 0.3


### PR DESCRIPTION
## Summary
- add `pretrain_masked` script training a masked autoencoder and saving `masked_encoder.pt`
- allow `pipeline.train` to load the masked encoder before scaling when `pretrain_mask` is provided and log encoder metadata
- record encoder architecture and mask ratio in `model.json`
- test that the masked encoder reduces feature count and does not hurt validation metrics

## Testing
- `pytest tests/test_masked_encoder.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5bca37d48832f983c3882a532256f