### PR TITLE
Add CSD-based cross-symbol spectral features

### DIFF
--- a/botcopier/cli/__init__.py
+++ b/botcopier/cli/__init__.py
@@ -95,6 +95,9 @@ def main(
     orderbook_features: bool = typer.Option(
         False, help="Include order book derived features"
     ),
+    csd_features: bool = typer.Option(
+        False, help="Include cross spectral density features"
+    ),
 ) -> None:
     """Configure global options for all commands."""
     logging.basicConfig(level=getattr(logging, log_level.upper(), logging.INFO))
@@ -133,6 +136,9 @@ def train(
     orderbook_features: bool = typer.Option(
         False, help="Include order book derived features"
     ),
+    csd_features: bool = typer.Option(
+        False, help="Include cross spectral density features"
+    ),
     random_seed: Optional[int] = typer.Option(None, help="Random seed"),
     hrp_allocation: bool = typer.Option(
         False, help="Compute hierarchical risk parity allocation"
@@ -153,6 +159,10 @@ def train(
     if orderbook_features:
         feats = set(train_cfg.features or [])
         feats.add("orderbook")
+        train_cfg = train_cfg.model_copy(update={"features": list(feats)})
+    if csd_features:
+        feats = set(train_cfg.features or [])
+        feats.add("csd")
         train_cfg = train_cfg.model_copy(update={"features": list(feats)})
     if random_seed is not None:
         train_cfg = train_cfg.model_copy(update={"random_seed": random_seed})
@@ -248,6 +258,9 @@ def online_train(
     orderbook_features: bool = typer.Option(
         False, help="Include order book derived features"
     ),
+    csd_features: bool = typer.Option(
+        False, help="Include cross spectral density features"
+    ),
 ) -> None:
     """Continuously update a model from streaming trade events."""
     data_cfg, train_cfg = _cfg(ctx)
@@ -281,6 +294,10 @@ def online_train(
     if orderbook_features:
         feats = set(train_cfg.features or [])
         feats.add("orderbook")
+        updates_train["features"] = list(feats)
+    if csd_features:
+        feats = set(train_cfg.features or [])
+        feats.add("csd")
         updates_train["features"] = list(feats)
     if updates_data:
         data_cfg = data_cfg.model_copy(update=updates_data)

--- a/model.json
+++ b/model.json
@@ -1,6 +1,8 @@
 {
   "feature_windows": {
     "hurst": 50,
-    "fractal_dim": 50
-  }
+    "fractal_dim": 50,
+    "csd": 16
+  },
+  "csd_freq_bins": 16
 }

--- a/tests/test_csd_features.py
+++ b/tests/test_csd_features.py
@@ -1,0 +1,39 @@
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+from botcopier.features import _extract_features
+from botcopier.features.engineering import FeatureConfig, configure_cache
+
+
+def test_csd_features_shapes_and_ranges(tmp_path):
+    times = np.arange(32)
+    data = []
+    for sym, phase in [("EURUSD", 0.0), ("USDCHF", 0.5)]:
+        prices = np.sin(2 * np.pi * 0.1 * times + phase)
+        for t, p in zip(times, prices):
+            data.append({"event_time": t, "symbol": sym, "price": p})
+    df = pd.DataFrame(data)
+
+    configure_cache(FeatureConfig(enabled_features={"csd"}))
+    feats, cols, _, _ = _extract_features(
+        df.copy(), [], symbol_graph=Path("symbol_graph.json")
+    )
+    configure_cache(FeatureConfig())
+
+    assert {
+        "csd_freq_USDCHF",
+        "csd_coh_USDCHF",
+        "csd_freq_EURUSD",
+        "csd_coh_EURUSD",
+    } <= set(cols)
+    assert len(feats) == len(df)
+    freq_cols = [c for c in feats.columns if c.startswith("csd_freq_")]
+    coh_cols = [c for c in feats.columns if c.startswith("csd_coh_")]
+    for c in freq_cols:
+        series = feats[c].dropna()
+        assert series.between(0.0, 0.5).all()
+    for c in coh_cols:
+        series = feats[c].dropna()
+        assert series.between(0.0, 1.0).all()


### PR DESCRIPTION
## Summary
- add cross-spectral density feature extraction for symbol pairs with dominant frequency and coherence outputs
- gate CSD features behind `--csd-features` CLI option and persist parameters
- test CSD feature shapes and valid numeric ranges

## Testing
- `pre-commit run --files botcopier/features/technical.py botcopier/training/pipeline.py botcopier/cli/__init__.py tests/test_csd_features.py model.json` *(failed: mypy missing stubs)*
- `pytest tests/test_csd_features.py tests/test_orderbook_features.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c5c90d83fc832f872db29bb774342d