### PR TITLE
Add PPO-based threshold agent and tests

### DIFF
--- a/tests/test_meta_strategy.py
+++ b/tests/test_meta_strategy.py
@@ -1,7 +1,14 @@
 import numpy as np
 import pandas as pd
+import pytest
 
-from scripts.meta_strategy import RollingMetrics, select_model, train_meta_model
+from scripts.meta_strategy import (
+    HAS_SB3,
+    RollingMetrics,
+    ThresholdAgent,
+    select_model,
+    train_meta_model,
+)
 
 
 def test_partial_fit_updates_coefficients_and_selection() -> None:
@@ -42,3 +49,48 @@ def test_weighted_ensemble_adapts_to_performance() -> None:
     assert weights2[1] > weights2[0]
     # Ensemble output shifts toward model 1 prediction
     assert out2 > out1
+
+
+@pytest.mark.skipif(not HAS_SB3, reason="stable-baselines3 not installed")
+def test_threshold_agent_adapts_to_regime_shift() -> None:
+    rng = np.random.default_rng(0)
+    n = 200
+    regimes = np.array([0] * (n // 2) + [1] * (n // 2))
+    features = regimes.reshape(-1, 1).astype(np.float32)
+    true_prob = np.where(regimes == 0, 0.3, 0.7)
+    probs = np.clip(true_prob + rng.normal(0, 0.05, size=n), 0, 1)
+    profits = np.where(rng.random(n) < true_prob, 1.0, -1.0)
+    agent = ThresholdAgent()
+    agent.train(features, probs, profits, training_steps=500)
+
+    thresholds = []
+    for f, p in zip(features, probs):
+        th, _ = agent.act(f, float(p))
+        thresholds.append(th)
+
+    first_mean = np.mean(thresholds[: n // 2])
+    second_mean = np.mean(thresholds[n // 2 :])
+    assert first_mean > second_mean
+
+
+@pytest.mark.skipif(not HAS_SB3, reason="stable-baselines3 not installed")
+def test_threshold_agent_outperforms_static_baseline() -> None:
+    rng = np.random.default_rng(1)
+    n = 200
+    regimes = np.array([0] * (n // 2) + [1] * (n // 2))
+    features = regimes.reshape(-1, 1).astype(np.float32)
+    true_prob = np.where(regimes == 0, 0.3, 0.7)
+    probs = np.clip(true_prob + rng.normal(0, 0.05, size=n), 0, 1)
+    profits = np.where(rng.random(n) < true_prob, 1.0, -1.0)
+    agent = ThresholdAgent()
+    agent.train(features, probs, profits, training_steps=500)
+
+    rl_profit = 0.0
+    baseline_profit = 0.0
+    for f, p, r in zip(features, probs, profits):
+        th, trade = agent.act(f, float(p))
+        if trade:
+            rl_profit += r
+        if p >= 0.5:
+            baseline_profit += r
+    assert rl_profit >= baseline_profit


### PR DESCRIPTION
## Summary
- introduce optional PPO threshold agent observing regime features and model probabilities
- log time-varying trade thresholds during inference
- add tests ensuring thresholds adapt to regime shifts and beat static baselines

## Testing
- `pytest tests/test_meta_strategy.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c5cd00f2e0832fac4cceec43bf3071