### PR TITLE
feat: add entity graph features

### DIFF
--- a/botcopier/training/pipeline.py
+++ b/botcopier/training/pipeline.py
@@ -672,6 +672,8 @@ def train(
             model["depth_cnn"] = technical_features._DEPTH_CNN_STATE
         if getattr(technical_features, "_CSD_PARAMS", None) is not None:
             model["csd_params"] = technical_features._CSD_PARAMS
+        if getattr(technical_features, "_GRAPH_SNAPSHOT", None) is not None:
+            model["graph_snapshot"] = technical_features._GRAPH_SNAPSHOT
         if cluster_map:
             model["feature_clusters"] = cluster_map
         if calibration_info is not None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,6 +41,7 @@ transformers
 pytorch-forecasting; extra == "tft"
 torch
 torch_geometric
+networkx
 mlflow
 
 # Optional extras

--- a/tests/test_graph_features.py
+++ b/tests/test_graph_features.py
@@ -1,2 +1,50 @@
+import json
+from pathlib import Path
+
+import networkx as nx
+import pandas as pd
 import pytest
-pytestmark = pytest.mark.skip(reason="legacy MQL4 functionality removed")
+
+import botcopier.features.technical as technical
+from botcopier.models.schema import ModelParams
+
+
+def _build_graph() -> nx.Graph:
+    g = nx.Graph()
+    g.add_node("SYM", type="symbol")
+    g.add_node("COMP", type="entity")
+    g.add_node("SEC", type="sector")
+    g.add_node("A1", type="article", sentiment=0.1)
+    g.add_edge("SYM", "COMP")
+    g.add_edge("COMP", "SEC")
+    g.add_edge("A1", "COMP")
+    return g
+
+
+def test_graph_features_update(tmp_path: Path) -> None:
+    df = pd.DataFrame({"symbol": ["SYM"], "price": [1.0]})
+    g = _build_graph()
+    feats: list[str] = []
+    out, feats1, *_ = technical._extract_features(df.copy(), feats, entity_graph=g)
+    assert out["graph_article_count"].iloc[0] == 1
+    assert out["graph_sentiment"].iloc[0] == 0.1
+    assert "graph_article_count" in feats1
+    assert "graph_sentiment" in feats1
+
+    # Add a new entity and article connected via the sector
+    g.add_node("COMP2", type="entity")
+    g.add_edge("COMP2", "SEC")
+    g.add_node("A2", type="article", sentiment=0.6)
+    g.add_edge("A2", "COMP2")
+
+    out2, feats2, *_ = technical._extract_features(df.copy(), [], entity_graph=g)
+    assert out2["graph_article_count"].iloc[0] == 2
+    assert out2["graph_sentiment"].iloc[0] == pytest.approx(0.35)
+
+    # Graph snapshot serialized into model.json
+    params = ModelParams(feature_names=feats2, graph_snapshot=technical._GRAPH_SNAPSHOT)
+    model_path = tmp_path / "model.json"
+    model_path.write_text(params.model_dump_json())
+    data = json.loads(model_path.read_text())
+    assert "graph_snapshot" in data
+    assert any(n.get("id") == "SYM" for n in data["graph_snapshot"]["nodes"])


### PR DESCRIPTION
## Summary
- compute graph-derived article and sentiment features using NetworkX
- store graph snapshots in model.json
- cover graph feature updates with tests

## Testing
- `pytest -q tests/test_graph_features.py`
- `pre-commit run --files botcopier/features/technical.py botcopier/training/pipeline.py requirements.txt tests/test_graph_features.py` *(fails: ModuleNotFoundError: ... etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68c5d0374a14832f8a57946e2020d34e