### PR TITLE
feat: add Mahalanobis-based OOD detection

### DIFF
--- a/botcopier/metrics.py
+++ b/botcopier/metrics.py
@@ -23,6 +23,12 @@ TRADE_COUNTER = Counter(
     "Number of processed trades",
 )
 
+# Counter for out-of-distribution samples
+OOD_COUNTER = Counter(
+    "botcopier_ood_total",
+    "Number of OOD samples encountered",
+)
+
 
 def start_metrics_server(port: int) -> None:
     """Start the Prometheus metrics HTTP server on ``port``."""

--- a/tests/test_ood_detection.py
+++ b/tests/test_ood_detection.py
@@ -1,0 +1,16 @@
+import numpy as np
+from botcopier.scripts import serve_model as sm
+
+
+def test_mahalanobis_ood_flag():
+    """Samples far from training mean should be flagged as OOD."""
+    sm.MODEL = {"entry_coefficients": [1.0, 1.0], "entry_intercept": 0.0}
+    sm.FEATURE_NAMES = ["f1", "f2"]
+    sm.FEATURE_METADATA = []
+    sm.OOD_MEAN = np.zeros(2)
+    sm.OOD_INV = np.eye(2)
+    sm.OOD_THRESHOLD = 1.0
+    sm.OOD_COUNTER._value.set(0)
+    pred = sm._predict_one([10.0, 10.0])
+    assert pred == 0.0
+    assert sm.OOD_COUNTER._value.get() == 1


### PR DESCRIPTION
## Summary
- compute feature mean/covariance after training and derive 99th percentile Mahalanobis threshold
- store covariance stats in model.json and expose OOD rate metric
- reject OOD samples at inference and log via new Prometheus counter
- add regression test for OOD flagging

## Testing
- `pytest tests/test_ood_detection.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5d2ab9178832f81629149d082a360