### PR TITLE
Add model explanation reporting

### DIFF
--- a/botcopier/scripts/explain_model.py
+++ b/botcopier/scripts/explain_model.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""Generate model explanation report combining SHAP, Integrated Gradients and
+permutation importance.
+
+The module exposes :func:`generate_explanations` which is used by the
+training pipeline to create a lightweight report of feature importances.
+The report is written as Markdown (and a companion HTML file) and
+contains the top features ranked by the different attribution methods.
+
+The implementation intentionally keeps dependencies minimal.  ``shap`` is
+attempted but optional; for linear models a simple fallback based on the
+model coefficients is employed.  Integrated Gradients are approximated for
+linear models and return zero for unsupported estimators.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Sequence
+
+import numpy as np
+import pandas as pd
+from sklearn.inspection import permutation_importance
+
+# ---------------------------------------------------------------------------
+# Helper utilities
+
+
+def _linear_coefficients(model) -> np.ndarray | None:
+    """Extract linear model coefficients if available."""
+    if hasattr(model, "coef_"):
+        coef = getattr(model, "coef_")
+        if coef is not None:
+            return np.asarray(coef).ravel()
+    if hasattr(model, "named_steps"):
+        steps = getattr(model, "named_steps")
+        if "logreg" in steps:
+            return np.asarray(steps["logreg"].coef_).ravel()
+    if hasattr(model, "base_estimator"):
+        return _linear_coefficients(model.base_estimator)
+    return None
+
+
+def _shap_importance(model, X: np.ndarray) -> np.ndarray:
+    """Compute mean absolute SHAP values for ``X``."""
+    try:  # optional dependency
+        import shap  # type: ignore
+
+        explainer = shap.Explainer(model, X)
+        shap_values = explainer(X)
+        values = np.asarray(getattr(shap_values, "values", shap_values))
+        if values.ndim == 3:  # for models with output dimension
+            values = values[..., 1]
+        return np.abs(values).mean(axis=0)
+    except Exception:
+        coef = _linear_coefficients(model)
+        if coef is None:
+            return np.zeros(X.shape[1], dtype=float)
+        return np.abs(coef) * np.std(X, axis=0)
+
+
+def _integrated_gradients(
+    model, X: np.ndarray, baseline: np.ndarray | None
+) -> np.ndarray:
+    """Approximate Integrated Gradients for linear models."""
+    coef = _linear_coefficients(model)
+    if coef is None:
+        return np.zeros(X.shape[1], dtype=float)
+    if baseline is None:
+        baseline = np.zeros_like(X)
+    ig = (X - baseline) * coef
+    return np.abs(ig).mean(axis=0)
+
+
+def _permutation_importance(model, X: np.ndarray, y: np.ndarray) -> np.ndarray:
+    try:
+        result = permutation_importance(
+            model, X, y, n_repeats=5, random_state=0, scoring="accuracy"
+        )
+        return np.abs(result.importances_mean)
+    except Exception:
+        return np.zeros(X.shape[1], dtype=float)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+
+
+def generate_explanations(
+    model,
+    X: np.ndarray,
+    y: np.ndarray,
+    feature_names: Sequence[str],
+    out_file: Path,
+) -> Path:
+    """Generate an explanation report for ``model`` on ``X``.
+
+    Parameters
+    ----------
+    model:
+        Fitted estimator exposing ``predict`` and ``score``.
+    X:
+        Feature matrix used for training.
+    y:
+        Target vector.
+    feature_names:
+        Names corresponding to columns of ``X``.
+    out_file:
+        Destination path for the Markdown report.  An HTML companion with the
+        same stem is also written.
+    """
+
+    shap_vals = _shap_importance(model, X)
+    ig_vals = _integrated_gradients(model, X, baseline=X.mean(axis=0, keepdims=True))
+    perm_vals = _permutation_importance(model, X, y)
+
+    df = pd.DataFrame(
+        {
+            "feature": list(feature_names),
+            "shap": shap_vals,
+            "integrated_gradients": ig_vals,
+            "permutation_importance": perm_vals,
+        }
+    )
+    df.sort_values("shap", ascending=False, inplace=True)
+
+    out_file.parent.mkdir(parents=True, exist_ok=True)
+    md_table = df.to_markdown(index=False)
+    out_file.write_text(f"# Model Explanation\n\n{md_table}\n")
+    html_path = out_file.with_suffix(".html")
+    html_path.write_text(f"<h1>Model Explanation</h1>\n{df.to_html(index=False)}")
+    return out_file
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point (best-effort)
+
+
+def main() -> None:  # pragma: no cover - convenience wrapper
+    p = argparse.ArgumentParser(description="Generate model explanation report")
+    p.add_argument("model", type=Path, help="Path to model.json")
+    p.add_argument(
+        "data",
+        type=Path,
+        help="CSV file with training data containing label column and features",
+    )
+    p.add_argument("out", type=Path, help="Output report path (.md or .html)")
+    args = p.parse_args()
+
+    data = json.loads(args.model.read_text())
+    feature_names = data.get("feature_names", [])
+    if not feature_names:
+        raise SystemExit("model.json missing feature_names")
+
+    df = pd.read_csv(args.data)
+    label_col = next((c for c in df.columns if c.startswith("label")), None)
+    if label_col is None:
+        raise SystemExit("no label column found in data")
+    X = df[feature_names].to_numpy(dtype=float)
+    y = df[label_col].to_numpy(dtype=float)
+
+    # very small logistic regression reconstruction for CLI usage
+    from sklearn.linear_model import LogisticRegression
+    from sklearn.pipeline import Pipeline
+    from sklearn.preprocessing import StandardScaler
+
+    coefficients = np.asarray(data.get("coefficients", []))
+    intercept = float(data.get("intercept", 0.0))
+    model = Pipeline([("scale", StandardScaler()), ("logreg", LogisticRegression())])
+    model.named_steps["logreg"].coef_ = coefficients.reshape(1, -1)
+    model.named_steps["logreg"].intercept_ = np.array([intercept])
+    model.named_steps["logreg"].classes_ = np.array([0, 1])
+    model.named_steps["scale"].fit(np.zeros_like(X))
+
+    generate_explanations(model, X, y, feature_names, args.out)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/docs/model_explanations.md
+++ b/docs/model_explanations.md
@@ -1,0 +1,23 @@
+# Model Explanations
+
+`botcopier.scripts.explain_model` generates feature attribution reports using
+three techniques:
+
+- **SHAP** values (falling back to coefficient based estimates when SHAP is not
+  available)
+- **Integrated Gradients** for linear models
+- **Permutation importance** based on sklearn
+
+The training pipeline automatically runs this script after fitting a model. A
+Markdown report together with an HTML version is stored under
+`reports/explanations/` inside the output directory. The relative path to the
+report is also recorded in `model.json` under the key `explanation_report`.
+
+To run the script standalone on an existing `model.json` and training data:
+
+```bash
+python -m botcopier.scripts.explain_model model.json trades.csv reports/explanations.md
+```
+
+The input CSV must contain a label column (prefixed with `label`) and the feature
+columns expected by the model.

--- a/tests/test_model_explanations.py
+++ b/tests/test_model_explanations.py
@@ -1,0 +1,30 @@
+import json
+from pathlib import Path
+
+from botcopier.training.pipeline import train
+
+
+def test_explanation_report_created(tmp_path: Path) -> None:
+    data_file = tmp_path / "trades_raw.csv"
+    rows = [
+        "label,price,volume,spread,hour,symbol\n",
+        "1,1.0,100,1.0,0,EURUSD\n",
+        "0,1.1,110,1.1,1,EURUSD\n",
+        "1,1.2,120,1.2,2,EURUSD\n",
+        "0,1.3,130,1.3,3,EURUSD\n",
+    ]
+    data_file.write_text("".join(rows))
+
+    out_dir = tmp_path / "out"
+    train(data_file, out_dir, n_splits=2, cv_gap=1, param_grid=[{}])
+
+    model_path = out_dir / "model.json"
+    model = json.loads(model_path.read_text())
+    assert "explanation_report" in model
+
+    report_path = out_dir / model["explanation_report"]
+    assert report_path.exists()
+    content = report_path.read_text()
+    # ensure top features appear in the report
+    for feat in model["feature_names"][:2]:
+        assert feat in content


### PR DESCRIPTION
## Summary
- add `explain_model.py` script to compute SHAP, integrated gradients, and permutation importance and render a combined report
- run explanation script in training pipeline and record report path in `model.json`
- document usage and add tests for generated explanation report

## Testing
- `pytest tests/test_model_explanations.py tests/test_full_pipeline.py -q`
- `pre-commit run --files botcopier/scripts/explain_model.py botcopier/training/pipeline.py docs/model_explanations.md tests/test_model_explanations.py` *(fails: mypy errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68c5de518a04832f9b725d352ebb1edc