### PR TITLE
feat: add hierarchical option policies

### DIFF
--- a/botcopier/rl/options.py
+++ b/botcopier/rl/options.py
@@ -1,0 +1,99 @@
+import numpy as np
+from typing import List
+
+try:  # pragma: no cover - optional dependency
+    from gym import Env, spaces  # type: ignore
+except Exception:  # pragma: no cover - gymnasium fallback
+    from gymnasium import Env, spaces  # type: ignore
+
+
+class OptionSkill:
+    """Base class for low-level skills used by high-level options."""
+
+    def __init__(self, action: int) -> None:
+        self.action = int(action)
+
+    def act(self, state: np.ndarray) -> int:  # pragma: no cover - trivial
+        del state
+        return self.action
+
+
+class EntrySkill(OptionSkill):
+    """Skill representing order entry."""
+
+    def __init__(self) -> None:
+        super().__init__(0)
+
+
+class ExitSkill(OptionSkill):
+    """Skill representing exiting a position."""
+
+    def __init__(self) -> None:
+        super().__init__(1)
+
+
+class RiskSkill(OptionSkill):
+    """Skill representing risk management actions."""
+
+    def __init__(self) -> None:
+        super().__init__(2)
+
+
+def default_skills() -> List[OptionSkill]:
+    """Return the default set of skills: entry, exit and risk."""
+
+    return [EntrySkill(), ExitSkill(), RiskSkill()]
+
+
+class OptionTradeEnv(Env):
+    """Environment where actions select high-level skills."""
+
+    def __init__(
+        self,
+        states: np.ndarray,
+        actions: np.ndarray,
+        rewards: np.ndarray,
+        skills: List[OptionSkill] | None = None,
+    ) -> None:
+        super().__init__()
+        self.states = np.asarray(states, dtype=np.float32)
+        self.actions = np.asarray(actions, dtype=int)
+        self.rewards = np.asarray(rewards, dtype=np.float32)
+        self.skills = skills or default_skills()
+        self.action_space = spaces.Discrete(len(self.skills))
+        self.observation_space = spaces.Box(
+            -np.inf,
+            np.inf,
+            shape=(self.states.shape[1],),
+            dtype=np.float32,
+        )
+        self.idx = 0
+
+    def reset(self, *, seed: int | None = None, options: dict | None = None):  # type: ignore[override]
+        del seed, options
+        self.idx = 0
+        return self.states[self.idx], {}
+
+    def step(self, option: int):  # type: ignore[override]
+        option = int(option)
+        skill = self.skills[option]
+        correct = skill.act(self.states[self.idx]) == self.actions[self.idx]
+        reward = float(self.rewards[self.idx]) if correct else 0.0
+        self.idx += 1
+        done = self.idx >= len(self.states)
+        obs = self.states[self.idx] if not done else self.states[-1]
+        return obs, reward, done, False, {}
+
+
+def evaluate_option_policy(model, env: OptionTradeEnv) -> float:
+    """Evaluate ``model`` on ``env`` returning the total reward."""
+
+    obs, _ = env.reset()
+    total = 0.0
+    for _ in range(len(env.states)):
+        action, _ = model.predict(obs, deterministic=True)
+        obs, r, done, _, _ = env.step(int(action))
+        total += float(r)
+        if done:
+            break
+    return total

--- a/model.json
+++ b/model.json
@@ -8,5 +8,7 @@
   "automl_controller": {
     "q_values": {},
     "best_action": null
-  }
+  },
+  "options": ["entry", "exit", "risk"],
+  "option_weights_file": "option_policy.zip"
 }

--- a/tests/test_option_policies.py
+++ b/tests/test_option_policies.py
@@ -1,0 +1,76 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from tests import HAS_SB3, HAS_NUMPY
+
+if HAS_NUMPY:
+    import numpy as np
+
+if HAS_SB3 and HAS_NUMPY:
+    from scripts.train_rl_agent import train_options
+    from scripts.replay_decisions import replay_option_policy
+    from botcopier.rl.options import OptionTradeEnv, default_skills, evaluate_option_policy
+    from stable_baselines3 import PPO
+
+pytestmark = pytest.mark.skipif(
+    not (HAS_SB3 and HAS_NUMPY), reason="stable-baselines3 or numpy not installed"
+)
+
+
+def _build_synthetic_dataset():
+    states = []
+    actions = []
+    rewards = []
+    for _ in range(10):
+        states.append([1.0, 0.0, 0.0])
+        actions.append(0)
+        rewards.append(1.0)
+    for _ in range(10):
+        states.append([0.0, 1.0, 0.0])
+        actions.append(1)
+        rewards.append(1.0)
+    for _ in range(10):
+        states.append([0.0, 0.0, 1.0])
+        actions.append(2)
+        rewards.append(1.0)
+    return (
+        np.array(states, dtype=np.float32),
+        np.array(actions, dtype=int),
+        np.array(rewards, dtype=float),
+    )
+
+
+def test_option_policy_improves_reward(tmp_path: Path) -> None:
+    states, actions, rewards = _build_synthetic_dataset()
+    model_info = train_options(
+        states,
+        actions,
+        rewards,
+        tmp_path,
+        training_steps=200,
+        learning_rate=0.1,
+    )
+    weights_file = tmp_path / model_info["option_weights_file"]
+    assert weights_file.exists()
+
+    model = PPO.load(str(weights_file))
+    env = OptionTradeEnv(states, actions, rewards, default_skills())
+    trained_reward = evaluate_option_policy(model, env)
+
+    env_rand = OptionTradeEnv(states, actions, rewards, default_skills())
+    obs, _ = env_rand.reset()
+    random_total = 0.0
+    for _ in range(len(actions)):
+        act = env_rand.action_space.sample()
+        obs, r, done, _, _ = env_rand.step(int(act))
+        random_total += r
+        if done:
+            break
+
+    assert trained_reward > random_total
+
+    # ensure replay script can load and evaluate
+    stats = replay_option_policy(states, actions, rewards, model_info, tmp_path)
+    assert stats["total_reward"] == pytest.approx(trained_reward)


### PR DESCRIPTION
## Summary
- introduce option skills and hierarchical environment for RL training
- extend train_rl_agent with option policy training and persistence
- update replay_decisions to replay option-based models
- add model metadata and tests for option policies

## Testing
- ⚠️ `pip install stable-baselines3==1.8.0` (fails: extras_require must be dict)
- ⚠️ `pytest tests/test_train_rl_agent.py::test_train_rl_agent_sb3 -q` (skipped)
- ⚠️ `pytest tests/test_option_policies.py -q` (skipped)


------
https://chatgpt.com/codex/tasks/task_e_68c5e68f4e74832fa50052be565affe0