### PR TITLE
Implement curriculum-based training stages

### DIFF
--- a/botcopier/training/curriculum.py
+++ b/botcopier/training/curriculum.py
@@ -1,0 +1,98 @@
+"""Utilities for curriculum learning during training."""
+from __future__ import annotations
+
+import logging
+from typing import Sequence, Tuple, List, Dict
+
+import numpy as np
+
+from botcopier.models.registry import get_model
+
+logger = logging.getLogger(__name__)
+
+
+def _apply_curriculum(
+    X: np.ndarray,
+    y: np.ndarray,
+    profits: np.ndarray,
+    sample_weight: np.ndarray,
+    *,
+    model_type: str,
+    gpu_kwargs: dict[str, object],
+    grad_clip: float,
+    threshold: float,
+    steps: int,
+    R: np.ndarray | None = None,
+    regime_feature_names: Sequence[str] | None = None,
+) -> Tuple[
+    np.ndarray,
+    np.ndarray,
+    np.ndarray,
+    np.ndarray,
+    np.ndarray | None,
+    List[Dict[str, object]],
+]:
+    """Stage datasets from simple to complex and train sequentially.
+
+    Returns filtered arrays and curriculum metadata.
+    """
+    if threshold <= 0.0 or steps <= 0 or not profits.size:
+        return X, y, profits, sample_weight, R, []
+
+    order = np.argsort(np.abs(profits))
+    phases = np.array_split(order, steps)
+    curriculum_meta: List[Dict[str, object]] = []
+    final_idx = phases[0]
+
+    for phase_num in range(1, steps + 1):
+        idx_current = np.concatenate(phases[:phase_num])
+        if len(idx_current) < 2:
+            final_idx = idx_current
+            break
+        split = max(1, int(len(idx_current) * 0.8))
+        tr_idx = idx_current[:split]
+        val_idx = idx_current[split:]
+        builder = get_model(model_type)
+        kwargs = dict(**gpu_kwargs)
+        if model_type == "moe" and R is not None and regime_feature_names is not None:
+            model, pred_fn = builder(
+                X[tr_idx],
+                y[tr_idx],
+                regime_features=R[tr_idx],
+                regime_feature_names=regime_feature_names,
+                sample_weight=sample_weight[tr_idx],
+                grad_clip=grad_clip,
+                **kwargs,
+            )
+            prob_val = pred_fn(X[val_idx], R[val_idx])
+        else:
+            if model_type != "transformer":
+                kwargs["sample_weight"] = sample_weight[tr_idx]
+            if model_type in {"moe", "transformer"}:
+                kwargs["grad_clip"] = grad_clip
+            model, pred_fn = builder(X[tr_idx], y[tr_idx], **kwargs)
+            prob_val = pred_fn(X[val_idx])
+        val_profit = float(np.mean(profits[val_idx] * (prob_val >= 0.5)))
+        curriculum_meta.append(
+            {
+                "phase": phase_num,
+                "n_samples": int(len(idx_current)),
+                "val_profit": val_profit,
+            }
+        )
+        logger.info(
+            "Curriculum phase %d: n=%d val_profit=%.6f",
+            phase_num,
+            len(idx_current),
+            val_profit,
+        )
+        final_idx = idx_current
+        if val_profit < threshold:
+            break
+
+    X_sel = X[final_idx]
+    y_sel = y[final_idx]
+    profits_sel = profits[final_idx]
+    weight_sel = sample_weight[final_idx]
+    R_sel = R[final_idx] if R is not None else None
+    return X_sel, y_sel, profits_sel, weight_sel, R_sel, curriculum_meta

--- a/tests/test_curriculum_training.py
+++ b/tests/test_curriculum_training.py
@@ -1,0 +1,37 @@
+import pytest
+
+np = pytest.importorskip("numpy")
+
+from botcopier.training.curriculum import _apply_curriculum
+
+def test_curriculum_progression():
+    magnitudes = np.concatenate([
+        np.full(30, 0.001),
+        np.full(30, 0.01),
+        np.full(30, 0.1),
+    ])
+    signs = np.concatenate([
+        np.repeat([1, -1], 15),
+        np.repeat([1, -1], 15),
+        np.repeat([1, -1], 15),
+    ])
+    profits = magnitudes
+    X = (signs * 10).reshape(-1, 1)
+    y = (signs > 0).astype(float)
+    sample_weight = magnitudes
+    X_sel, y_sel, prof_sel, w_sel, R_sel, meta = _apply_curriculum(
+        X,
+        y,
+        profits,
+        sample_weight,
+        model_type="logreg",
+        gpu_kwargs={},
+        grad_clip=1.0,
+        threshold=1e-6,
+        steps=3,
+    )
+    assert len(meta) == 3
+    vals = [m["val_profit"] for m in meta]
+    assert vals[0] < vals[1] < vals[2]
+    assert len(prof_sel) == len(profits)
+    assert R_sel is None


### PR DESCRIPTION
## Summary
- stage training data from low to high volatility and progress when validation profit passes a threshold
- record curriculum phase metadata in the saved model
- add regression test for curriculum progression

## Testing
- `pytest tests/test_curriculum_training.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c5ef3397a0832fa52c85181b768d92