### PR TITLE
Add feature plugin discovery

### DIFF
--- a/botcopier/features/anomaly.py
+++ b/botcopier/features/anomaly.py
@@ -6,7 +6,7 @@ from typing import Tuple
 import numpy as np
 from sklearn.ensemble import IsolationForest
 
-from .registry import register_feature
+from .plugins import register_feature
 
 
 @register_feature("clip_train_features")

--- a/botcopier/features/augmentation.py
+++ b/botcopier/features/augmentation.py
@@ -7,7 +7,7 @@ from typing import Tuple
 import numpy as np
 import pandas as pd
 
-from .registry import register_feature
+from .plugins import register_feature
 
 
 @register_feature("augment_dataframe")

--- a/botcopier/features/engineering.py
+++ b/botcopier/features/engineering.py
@@ -52,7 +52,7 @@ def configure_cache(config: FeatureConfig) -> None:
     _CONFIG = config
     _MEMORY = Memory(str(config.cache_dir) if config.cache_dir else None, verbose=0)
 
-    from .registry import FEATURE_REGISTRY
+    from .plugins import FEATURE_REGISTRY
 
     _augmentation._augment_dataframe = _cache_with_logging(
         _augmentation._augment_dataframe_impl, "_augment_dataframe"

--- a/botcopier/features/plugins.py
+++ b/botcopier/features/plugins.py
@@ -1,0 +1,60 @@
+"""Feature plugin registry with entry point discovery."""
+from __future__ import annotations
+
+from collections.abc import Iterable
+from importlib.metadata import entry_points
+from typing import Any, Callable, Dict, Tuple
+
+FeatureResult = Tuple[
+    Any,
+    list[str],
+    dict[str, list[float]],
+    dict[str, list[list[float]]],
+]
+FeatureFunc = Callable[..., FeatureResult]
+
+FEATURE_REGISTRY: Dict[str, FeatureFunc] = {}
+
+
+def register_feature(name: str, fn: FeatureFunc | None = None):
+    """Register *fn* under ``name`` in the feature registry.
+
+    Can be used as a decorator when *fn* is ``None``.
+    """
+
+    def _register(f: FeatureFunc) -> FeatureFunc:
+        FEATURE_REGISTRY[name] = f
+        return f
+
+    if fn is None:
+        return _register
+    return _register(fn)
+
+
+def load_plugins(names: Iterable[str] | None = None) -> None:
+    """Load feature plugins declared via the ``botcopier.features`` entry point.
+
+    Parameters
+    ----------
+    names:
+        Optional iterable of plugin names to load. If omitted, all discovered
+        entry points are loaded.
+    """
+    try:
+        eps = entry_points(group="botcopier.features")
+    except TypeError:  # pragma: no cover - for older Python
+        eps = entry_points().get("botcopier.features", [])
+
+    for ep in eps:
+        if names is not None and ep.name not in names:
+            continue
+        if ep.name in FEATURE_REGISTRY:
+            continue
+        try:
+            fn = ep.load()
+        except Exception:
+            continue
+        register_feature(ep.name, fn)
+
+
+__all__ = ["FEATURE_REGISTRY", "register_feature", "load_plugins"]

--- a/botcopier/features/registry.py
+++ b/botcopier/features/registry.py
@@ -1,33 +1,7 @@
-"""Simple plugin registry for feature functions."""
-from __future__ import annotations
+"""Backward-compatible feature plugin registry.
 
-from typing import Any, Callable, Dict, Tuple
+This module now re-exports symbols from :mod:`botcopier.features.plugins`.
+"""
+from .plugins import FEATURE_REGISTRY, register_feature, load_plugins
 
-try:  # optional pandas/polars types for type checking
-    import pandas as pd
-except Exception:  # pragma: no cover - optional
-    pd = Any  # type: ignore
-try:  # optional polars
-    import polars as pl
-except Exception:  # pragma: no cover - optional
-    pl = Any  # type: ignore
-
-FeatureResult = Tuple[
-    Any,
-    list[str],
-    dict[str, list[float]],
-    dict[str, list[list[float]]],
-]
-FeatureFunc = Callable[..., FeatureResult]
-
-FEATURE_REGISTRY: Dict[str, FeatureFunc] = {}
-
-
-def register_feature(name: str) -> Callable[[FeatureFunc], FeatureFunc]:
-    """Decorator to register a feature function under ``name``."""
-
-    def decorator(func: FeatureFunc) -> FeatureFunc:
-        FEATURE_REGISTRY[name] = func
-        return func
-
-    return decorator
+__all__ = ["FEATURE_REGISTRY", "register_feature", "load_plugins"]

--- a/botcopier/features/technical.py
+++ b/botcopier/features/technical.py
@@ -20,7 +20,7 @@ except Exception:  # pragma: no cover - optional
     dd = None  # type: ignore
     _HAS_DASK = False
 
-from .registry import FEATURE_REGISTRY, register_feature
+from .plugins import FEATURE_REGISTRY, register_feature, load_plugins
 
 try:  # optional polars dependency
     import polars as pl  # type: ignore
@@ -753,6 +753,9 @@ def _extract_features(
         _CONFIG,
         _FEATURE_RESULTS,
     )
+
+    # Dynamically load any third-party plugins requested via configuration
+    load_plugins(_CONFIG.enabled_features)
 
     if _HAS_DASK and isinstance(df, dd.DataFrame):
         sample = df.head()  # compute small sample for metadata

--- a/docs/feature_plugins.md
+++ b/docs/feature_plugins.md
@@ -5,19 +5,33 @@ functions can be plugged in at runtime.
 
 ## Writing a plugin
 
-Create a module on the Python path and decorate a function with
-`botcopier.features.registry.register_feature`:
+Create a module on the Python path and register a function with
+`botcopier.features.plugins.register_feature`:
 
 ```python
-from botcopier.features.registry import register_feature
+from botcopier.features.plugins import register_feature
 
-@register_feature("custom")
 def my_features(df, feature_names, **kwargs):
     # add columns to df and append their names
     df["ones"] = 1.0
     feature_names.append("ones")
     return df, feature_names, {}, {}
+
+register_feature("custom", my_features)
+# or as a decorator:
+# @register_feature("custom")
+# def my_features(...):
+#     ...
 ```
 
-Enable the plugin when training by passing ``--feature custom`` on the CLI or by
-listing it under ``training.features`` in a configuration file.
+Third-party packages can expose features via Python entry points.  In your
+``pyproject.toml`` add:
+
+```
+[project.entry-points."botcopier.features"]
+custom = "my_pkg.my_module:my_features"
+```
+
+BotCopier will automatically discover such plugins when they are enabled.
+Enable a plugin by passing ``--feature custom`` on the CLI or by listing it
+under ``training.features`` in a configuration file.

--- a/tests/test_feature_plugins.py
+++ b/tests/test_feature_plugins.py
@@ -1,0 +1,82 @@
+import types
+import sys
+
+import pandas as pd
+from importlib.metadata import EntryPoint
+
+# stub minimal sklearn module to avoid heavy dependency
+sklearn = types.ModuleType("sklearn")
+sklearn.ensemble = types.ModuleType("sklearn.ensemble")
+sklearn.ensemble.IsolationForest = object
+sklearn.linear_model = types.ModuleType("sklearn.linear_model")
+sklearn.linear_model.LinearRegression = object
+sys.modules.setdefault("sklearn", sklearn)
+sys.modules.setdefault("sklearn.ensemble", sklearn.ensemble)
+sys.modules.setdefault("sklearn.linear_model", sklearn.linear_model)
+
+# stub minimal scipy module
+scipy = types.ModuleType("scipy")
+scipy.signal = types.ModuleType("scipy.signal")
+sys.modules.setdefault("scipy", scipy)
+sys.modules.setdefault("scipy.signal", scipy.signal)
+
+# stub psutil
+sys.modules.setdefault("psutil", types.ModuleType("psutil"))
+
+# stub joblib Memory
+joblib = types.ModuleType("joblib")
+
+class _DummyMemory:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def cache(self, func):
+        def wrapper(*a, **kw):
+            return func(*a, **kw)
+
+        wrapper.clear = lambda: None
+        wrapper.check_call_in_cache = lambda *a, **kw: False
+        return wrapper
+
+    def clear(self):
+        pass
+
+joblib.Memory = _DummyMemory
+sys.modules.setdefault("joblib", joblib)
+
+from botcopier.features.engineering import FeatureConfig, configure_cache
+import botcopier.features.plugins as plugins
+from botcopier.features.plugins import FEATURE_REGISTRY
+from botcopier.features import technical
+
+
+def test_entry_point_plugin(monkeypatch):
+    # create a fake third-party module with a feature function
+    mod = types.ModuleType("thirdparty_mod")
+
+    def feature(df, names, **kwargs):
+        df["ep"] = 1.0
+        names.append("ep")
+        return df, names, {}, {}
+
+    mod.feature = feature
+    sys.modules["thirdparty_mod"] = mod
+
+    # mock entry points to advertise the plugin
+    ep = EntryPoint(name="ep", value="thirdparty_mod:feature", group="botcopier.features")
+    monkeypatch.setattr(
+        plugins,
+        "entry_points",
+        lambda group=None: [ep] if group == "botcopier.features" else [],
+    )
+
+    # enable plugin via configuration
+    configure_cache(FeatureConfig(enabled_features={"ep"}))
+
+    # replace heavy technical plugin with a no-op for the test
+    FEATURE_REGISTRY["technical"] = lambda df, names, **kwargs: (df, names, {}, {})
+
+    df = pd.DataFrame({"price": [1.0]})
+    out, cols, *_ = technical._extract_features(df, [])
+    assert "ep" in cols
+    assert out["ep"].iloc[0] == 1.0


### PR DESCRIPTION
## Summary
- add plugins registry with entry-point discovery for features
- load requested plugins in `_extract_features`
- document plugin development and add entry-point plugin test

## Testing
- `pytest tests/test_feature_plugins.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5f391e7a4832f88feeaf87b681e03