### PR TITLE
Add strategy data contract and validation test

### DIFF
--- a/schemas/strategy_contract.yaml
+++ b/schemas/strategy_contract.yaml
@@ -1,0 +1,8 @@
+# Data contract for strategy feature set
+features:
+  - name: spread
+    dtype: float
+    shape: [1]
+  - name: fractal_dim
+    dtype: float
+    shape: [1]

--- a/tests/test_data_contract.py
+++ b/tests/test_data_contract.py
@@ -1,0 +1,43 @@
+import json
+from pathlib import Path
+
+import pandas as pd
+import yaml
+
+from botcopier.training.pipeline import train
+from botcopier.data.loading import _load_logs
+from botcopier.features.technical import _extract_features
+
+
+def test_data_contract(tmp_path: Path) -> None:
+    """Run full training pipeline and validate model against contract."""
+    schema = yaml.safe_load(Path("schemas/strategy_contract.yaml").read_text())
+    expected = [f["name"] for f in schema["features"]]
+
+    # prepare synthetic training logs
+    data_file = tmp_path / "trades_raw.csv"
+    rows = [
+        "label,price,volume,spread,hour,symbol\n",
+        "1,1.0,100,1.0,0,EURUSD\n",
+        "0,1.1,110,1.1,1,EURUSD\n",
+        "1,1.2,120,1.2,2,EURUSD\n",
+        "0,1.3,130,1.3,3,EURUSD\n",
+    ]
+    data_file.write_text("".join(rows))
+
+    # run training pipeline
+    out_dir = tmp_path / "out"
+    train(data_file, out_dir, n_splits=2, cv_gap=1, param_grid=[{}])
+
+    model = json.loads((out_dir / "model.json").read_text())
+
+    # verify feature ordering and coefficient shape
+    assert model["feature_names"] == expected
+    assert len(model["coefficients"]) == len(expected)
+
+    # validate feature types using extraction pipeline
+    logs, feature_names, _ = _load_logs(data_file)
+    df, feature_names, *_ = _extract_features(logs, feature_names)
+    for spec in schema["features"]:
+        col = df[spec["name"]]
+        assert pd.api.types.is_numeric_dtype(col)


### PR DESCRIPTION
## Summary
- define `schemas/strategy_contract.yaml` specifying canonical feature order and types
- add `tests/test_data_contract.py` to run training pipeline and validate artifacts against the contract

## Testing
- `pytest tests/test_data_contract.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5fc5e9098832f8aac298618ea6e32