### PR TITLE
Add training pipeline profiling and benchmark

### DIFF
--- a/docs/profiling.md
+++ b/docs/profiling.md
@@ -1,0 +1,27 @@
+# Pipeline profiling
+
+The training pipeline can be profiled to identify performance bottlenecks in
+feature extraction, model fitting, and evaluation.
+
+## Generating profiles
+
+Use the helper script to run the pipeline under `cProfile` and emit reports:
+
+```bash
+python scripts/profile_pipeline.py DATA.csv OUTPUT_DIR --open
+```
+
+This creates several `.prof` files inside `OUTPUT_DIR/profiles` including
+`feature_extraction.prof`, `model_fit.prof`, `evaluation.prof` and a
+`full_pipeline.prof` capturing the entire run.
+
+## Reading profiles
+
+Profiles can be inspected with [snakeviz](https://jiffyclub.github.io/snakeviz/):
+
+```bash
+snakeviz OUTPUT_DIR/profiles/model_fit.prof
+```
+
+The browser interface shows call graphs and cumulative timings to guide
+optimisation efforts.

--- a/scripts/profile_pipeline.py
+++ b/scripts/profile_pipeline.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+"""Profile the training pipeline with cProfile and visualise via snakeviz."""
+
+from __future__ import annotations
+
+import argparse
+import cProfile
+from pathlib import Path
+
+import snakeviz.cli as snakeviz_cli
+
+from botcopier.models.registry import MODEL_REGISTRY
+from botcopier.training.pipeline import train
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Profile pipeline performance")
+    parser.add_argument("data_dir", type=Path)
+    parser.add_argument("out_dir", type=Path)
+    parser.add_argument(
+        "--model-type",
+        choices=list(MODEL_REGISTRY.keys()),
+        default="logreg",
+        help="model type to train",
+    )
+    parser.add_argument(
+        "--open",
+        action="store_true",
+        help="open generated profiles in a browser using snakeviz",
+    )
+    args = parser.parse_args()
+
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+    profiles_dir = args.out_dir / "profiles"
+    profiles_dir.mkdir(exist_ok=True)
+
+    profiler = cProfile.Profile()
+    profiler.runcall(
+        train,
+        args.data_dir,
+        args.out_dir,
+        model_type=args.model_type,
+        profile=True,
+    )
+    full_profile = profiles_dir / "full_pipeline.prof"
+    profiler.dump_stats(str(full_profile))
+
+    if args.open:
+        for prof in profiles_dir.glob("*.prof"):
+            snakeviz_cli.main([str(prof)])
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/tests/performance/test_pipeline_perf.py
+++ b/tests/performance/test_pipeline_perf.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+import shutil
+
+from botcopier.training.pipeline import train
+
+
+def test_pipeline_training_benchmark(benchmark, tmp_path):
+    """Benchmark the end-to-end training pipeline on a small dataset."""
+    rows = [
+        "label,price,volume,spread,hour,symbol\n",
+        "0,1.0,100,1.5,0,EURUSD\n",
+        "1,1.1,110,1.6,1,EURUSD\n",
+        "0,1.2,120,1.7,2,EURUSD\n",
+        "1,1.3,130,1.8,3,EURUSD\n",
+    ]
+    data_file = tmp_path / "trades.csv"
+    data_file.write_text("".join(rows))
+
+    def run() -> None:
+        out_dir = tmp_path / "out"
+        if out_dir.exists():
+            shutil.rmtree(out_dir)
+        train(data_file, out_dir)
+
+    benchmark(run)


### PR DESCRIPTION
## Summary
- add `--profile` option to training pipeline that saves cProfile reports for feature extraction, fitting and evaluation
- provide `scripts/profile_pipeline.py` utility to run the pipeline under cProfile and view results with snakeviz
- document profiling workflow and add a pytest-benchmark regression test

## Testing
- `pytest tests/performance/test_pipeline_perf.py::test_pipeline_training_benchmark -q`


------
https://chatgpt.com/codex/tasks/task_e_68c603f3a030832f85ba497e8570c7ab