### PR TITLE
Add active validator with metric monitoring and retrain trigger

### DIFF
--- a/botcopier/scripts/active_validator.py
+++ b/botcopier/scripts/active_validator.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Periodically evaluate live predictions against ground truth."""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections.abc import Callable, Iterable, Sequence
+
+try:  # pragma: no cover - optional dependency
+    from otel_logging import setup_logging  # type: ignore
+except Exception:  # pragma: no cover
+    def setup_logging(name: str) -> None:
+        logging.basicConfig(level=logging.INFO)
+
+
+logger = logging.getLogger(__name__)
+setup_logging("active_validator")
+
+MetricFn = Callable[[Sequence[int], Sequence[int]], float]
+
+
+def default_metric(preds: Sequence[int], truth: Sequence[int]) -> float:
+    """Simple accuracy metric."""
+    if not truth:
+        return 0.0
+    correct = sum(p == t for p, t in zip(preds, truth))
+    return float(correct) / len(truth)
+
+
+class ActiveValidator:
+    """Validate predictions and trigger retraining when performance degrades."""
+
+    def __init__(
+        self,
+        metric_fn: MetricFn | None = None,
+        *,
+        threshold: float = 0.8,
+        retrain_cb: Callable[[], None] | None = None,
+        adjust_cb: Callable[[float], None] | None = None,
+        interval: float = 60.0,
+    ) -> None:
+        self.metric_fn = metric_fn or default_metric
+        self.threshold = threshold
+        self.retrain_cb = retrain_cb or (lambda: None)
+        self.adjust_cb = adjust_cb
+        self.interval = interval
+        self.history: list[float] = []
+
+    def evaluate(self, preds: Sequence[int], truth: Sequence[int]) -> float:
+        """Evaluate one batch of predictions and act on degradation."""
+        metric = self.metric_fn(preds, truth)
+        self.history.append(metric)
+        logger.info("validation metric", extra={"metric": metric})
+        if metric < self.threshold:
+            logger.warning("metric below threshold", extra={"metric": metric})
+            self.retrain_cb()
+            if self.adjust_cb:
+                self.adjust_cb(metric)
+        return metric
+
+    def run(
+        self,
+        prediction_stream: Iterable[Sequence[int]],
+        truth_stream: Iterable[Sequence[int]],
+        *,
+        iterations: int | None = None,
+    ) -> None:
+        """Continuously evaluate prediction stream against ground truth."""
+        for i, (preds, truth) in enumerate(zip(prediction_stream, truth_stream)):
+            self.evaluate(preds, truth)
+            if iterations is not None and i + 1 >= iterations:
+                break
+            time.sleep(self.interval)

--- a/tests/test_active_validator.py
+++ b/tests/test_active_validator.py
@@ -1,0 +1,38 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from scripts.active_validator import ActiveValidator
+
+
+def test_retrain_on_metric_decay():
+    calls: list[str] = []
+
+    def retrain():
+        calls.append("retrained")
+
+    validator = ActiveValidator(threshold=0.8, retrain_cb=retrain)
+    truth = [1, 0, 1, 1]
+    good = [1, 0, 1, 1]
+    bad = [0, 0, 1, 1]  # accuracy 0.75
+
+    m1 = validator.evaluate(good, truth)
+    assert m1 == 1.0
+    m2 = validator.evaluate(bad, truth)
+    assert m2 == 0.75
+    assert calls == ["retrained"]
+    m3 = validator.evaluate(good, truth)
+    assert m3 == 1.0
+    assert calls == ["retrained"]
+
+
+def test_no_retrain_when_metrics_good():
+    calls: list[str] = []
+
+    validator = ActiveValidator(threshold=0.5, retrain_cb=lambda: calls.append("r"))
+    truth = [1, 0]
+    preds = [1, 1]  # accuracy 0.5 which equals threshold
+    metric = validator.evaluate(preds, truth)
+    assert metric == 0.5
+    assert calls == []


### PR DESCRIPTION
## Summary
- add `ActiveValidator` script to monitor live predictions, log metrics, and trigger retraining or threshold adjustments when performance drops
- test validator to ensure retraining activates on metric decay and remains quiet when metrics are acceptable

## Testing
- `pytest tests/test_active_validator.py -q`
- `pytest -q` *(fails: e.g. `test_extra_price_features`, `test_generate`)*

------
https://chatgpt.com/codex/tasks/task_e_68c6082d6c68832f8512f89e74f47d3c