### PR TITLE
feat: add risk-aware optimization and selection

### DIFF
--- a/tests/test_hyperparam_log.py
+++ b/tests/test_hyperparam_log.py
@@ -19,7 +19,8 @@ def test_hyperparam_csv_contains_best_trial(tmp_path: Path):
     assert data["metadata"]["hyperparam_log"] == "hyperparams.csv"
 
     df = pd.read_csv(csv_path)
-    best_number = data["metadata"]["best_trial"]["number"]
-    best_value = data["metadata"]["best_trial"]["value"]
-    best_row = df[df["trial"] == best_number].iloc[0]
-    assert best_row["value"] == pytest.approx(best_value)
+    selected = data["metadata"]["selected_trial"]
+    best_row = df[df["trial"] == selected["number"]].iloc[0]
+    assert best_row["profit"] == pytest.approx(selected["profit"])
+    assert best_row["sharpe"] == pytest.approx(selected["sharpe"])
+    assert best_row["max_drawdown"] == pytest.approx(selected["max_drawdown"])


### PR DESCRIPTION
## Summary
- enable multi-objective Optuna studies with profit, Sharpe and drawdown
- penalise risk breaches in RL/heuristic reward functions
- skip models breaching risk limits during promotion

## Testing
- `pre-commit run --files train_target_clone.py automl/controller.py botcopier/training/pipeline.py botcopier/scripts/automl_controller.py botcopier/scripts/promote_best_models.py tests/test_hyperparam_log.py tests/test_promote_best_models.py` *(fails: mypy errors in unrelated files)*
- `pytest tests/test_hyperparam_log.py tests/test_promote_best_models.py`

------
https://chatgpt.com/codex/tasks/task_e_68c6446dfc00832f859b20fdc378599f