### PR TITLE
Add plugin documentation and direct registration test

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,6 +14,7 @@ nav:
   - Troubleshooting: troubleshooting.md
   - Guides:
       - Hardware-aware Training: hardware-training.md
+      - Feature Plugins: feature_plugins.md
   - Tutorials:
       - Data Loading and Feature Engineering: data_loading_tutorial.md
 markdown_extensions:


### PR DESCRIPTION
## Summary
- expose feature plugin registry in docs navigation
- test direct feature registration with `register_feature`

## Testing
- `pytest tests/test_feature_plugins.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6488be4ec832f8a016f21ff7e8fea