### PR TITLE
Add strategy data contract and CI test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,8 @@ jobs:
         run: dvc pull
       - name: Run pre-commit
         run: pre-commit run --all-files
+      - name: Run data contract tests
+        run: pytest tests/test_data_contract.py
       - name: Run unit tests
         run: pytest -m "not integration" --ignore=tests/property
       - name: Run integration tests

--- a/schemas/strategy_contract.yaml
+++ b/schemas/strategy_contract.yaml
@@ -6,3 +6,7 @@ features:
   - name: fractal_dim
     dtype: float
     shape: [1]
+predictions:
+  - name: probability
+    dtype: float
+    shape: [1]


### PR DESCRIPTION
## Summary
- define feature and prediction schema for strategy pipeline
- validate full pipeline output against schema
- run data contract test in CI

## Testing
- `SKIP=mypy pre-commit run --files schemas/strategy_contract.yaml tests/test_data_contract.py .github/workflows/ci.yml`
- `pytest tests/test_data_contract.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c64a97c6d8832fbdc7daf2aaec6fd2