### PR TITLE
feat: add policy gradient controller with persistence

### DIFF
--- a/tests/test_automl_controller.py
+++ b/tests/test_automl_controller.py
@@ -34,3 +34,11 @@ def test_automl_controller_converges(tmp_path):
         "features": ["f1", "f2"],
         "model": "tree",
     }
+
+    # Ensure the policy is persisted and reused on a fresh instance
+    warm = AutoMLController(features, models, model_path=model_file)
+    assert warm.select_best() == (("f1", "f2"), "tree")
+
+    # When reuse is disabled the policy should reset
+    cold = AutoMLController(features, models, model_path=model_file, reuse=False)
+    assert cold.select_best() != (("f1", "f2"), "tree")


### PR DESCRIPTION
## Summary
- expand AutoML controller to default to registered models and persist policy
- update AutoML controller tests to verify warm-start and reset behaviors

## Testing
- `pytest tests/test_automl_controller.py::test_automl_controller_converges -q`

------
https://chatgpt.com/codex/tasks/task_e_68c6f19b95f0832fbabdaa45be445b6e