### PR TITLE
Support meta-learning and streaming RL updates

### DIFF
--- a/meta/__init__.py
+++ b/meta/__init__.py
@@ -1,0 +1,6 @@
+"""Utilities for meta learning experiments."""
+
+from .reptile import ReptileMetaLearner, _logistic_grad, evaluate
+
+__all__ = ["ReptileMetaLearner", "_logistic_grad", "evaluate"]
+

--- a/meta/meta_pretrain.py
+++ b/meta/meta_pretrain.py
@@ -16,7 +16,7 @@ from typing import List, Sequence, Tuple
 import numpy as np
 import pandas as pd
 
-from scripts.meta_adapt import ReptileMetaLearner, _logistic_grad
+from .reptile import ReptileMetaLearner, _logistic_grad
 
 # ---------------------------------------------------------------------------
 # Task sampling

--- a/meta/reptile.py
+++ b/meta/reptile.py
@@ -1,0 +1,69 @@
+"""Lightweight Reptile meta learning utilities.
+
+This module provides a tiny implementation of the Reptile algorithm for a
+logistic regression style model.  It mirrors the helper used by the
+``scripts.meta_adapt`` module but lives in the ``meta`` package so that tests
+and other components can import it without going through the scripts stub.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Sequence, Tuple
+
+import numpy as np
+
+
+def _logistic_grad(w: np.ndarray, X: np.ndarray, y: np.ndarray) -> np.ndarray:
+    """Gradient of logistic loss for weights ``w``."""
+
+    preds = 1.0 / (1.0 + np.exp(-(X @ w)))
+    return X.T @ (preds - y) / len(y)
+
+
+def evaluate(w: np.ndarray, X: np.ndarray, y: np.ndarray) -> float:
+    """Return classification accuracy for ``w`` on ``(X, y)``."""
+
+    preds = 1.0 / (1.0 + np.exp(-(X @ w))) > 0.5
+    return float(np.mean(preds == y))
+
+
+@dataclass
+class ReptileMetaLearner:
+    """Simple Reptile meta learner for dense logistic models."""
+
+    dim: int
+    weights: np.ndarray | None = None
+
+    def __post_init__(self) -> None:  # pragma: no cover - trivial
+        if self.weights is None:
+            self.weights = np.zeros(self.dim, dtype=float)
+
+    def train(
+        self,
+        sessions: Iterable[Tuple[np.ndarray, np.ndarray]],
+        inner_steps: int = 5,
+        inner_lr: float = 0.1,
+        meta_lr: float = 0.1,
+    ) -> None:
+        """Train meta weights from ``sessions`` using the Reptile algorithm."""
+
+        for X, y in sessions:
+            w = self.weights.copy()
+            for _ in range(inner_steps):
+                w -= inner_lr * _logistic_grad(w, X, y)
+            self.weights += meta_lr * (w - self.weights)
+
+    def adapt(
+        self, X: np.ndarray, y: np.ndarray, inner_steps: int = 5, inner_lr: float = 0.1
+    ) -> np.ndarray:
+        """Return task adapted weights for new data ``(X, y)``."""
+
+        w = self.weights.copy()
+        for _ in range(inner_steps):
+            w -= inner_lr * _logistic_grad(w, X, y)
+        return w
+
+
+__all__ = ["ReptileMetaLearner", "_logistic_grad", "evaluate"]
+

--- a/tests/test_meta_online_adaptation.py
+++ b/tests/test_meta_online_adaptation.py
@@ -1,0 +1,58 @@
+import json
+from pathlib import Path
+
+import numpy as np
+
+from meta import ReptileMetaLearner
+from meta.meta_pretrain import save_meta_weights
+from scripts.online_trainer import OnlineTrainer
+
+
+def _make_session(w: np.ndarray, n: int = 100, seed: int = 0):
+    rng = np.random.default_rng(seed)
+    X = rng.normal(size=(n, len(w)))
+    y = (1.0 / (1.0 + np.exp(-(X @ w))) > 0.5).astype(int)
+    return X, y
+
+
+def _to_batch(X: np.ndarray, y: np.ndarray):
+    batch = []
+    for xi, yi in zip(X, y):
+        rec = {f"f{j}": float(xi[j]) for j in range(X.shape[1])}
+        rec["y"] = int(yi)
+        batch.append(rec)
+    return batch
+
+
+def test_meta_initialisation_speeds_adaptation(tmp_path: Path) -> None:
+    np.random.seed(0)
+    w_a = np.array([1.0, 1.0])
+    w_b = np.array([1.0, 0.5])
+
+    Xa, ya = _make_session(w_a, seed=1)
+    Xb_train, yb_train = _make_session(w_b, n=40, seed=2)
+    Xb_val, yb_val = _make_session(w_b, n=200, seed=3)
+
+    meta = ReptileMetaLearner(dim=2)
+    meta.train([(Xa, ya)], inner_steps=25, inner_lr=0.1, meta_lr=0.5)
+
+    model_path = tmp_path / "model.json"
+    save_meta_weights(meta.weights, model_path)
+
+    trainer_meta = OnlineTrainer(model_path=model_path, batch_size=40, run_generator=False)
+    trainer_meta.update(_to_batch(Xb_train, yb_train))
+    preds_meta = trainer_meta.clf.predict(Xb_val)
+    acc_meta = (preds_meta == yb_val).mean()
+
+    scratch_path = tmp_path / "scratch.json"
+    trainer_base = OnlineTrainer(model_path=scratch_path, batch_size=40, run_generator=False)
+    trainer_base.update(_to_batch(Xb_train, yb_train))
+    preds_base = trainer_base.clf.predict(Xb_val)
+    acc_base = (preds_base == yb_val).mean()
+
+    assert acc_meta >= acc_base
+
+    data = json.loads(model_path.read_text())
+    assert "meta" in data and "weights" in data["meta"]
+    assert "adaptation_log" in data and len(data["adaptation_log"]) >= 1
+


### PR DESCRIPTION
## Summary
- add lightweight Reptile meta learner package and wire meta_pretrain to it
- load meta-initialised weights and log online adaptations in `online_trainer`
- enable streaming replay and periodic policy updates in `train_rl_agent`
- test faster adaptation using meta initialisation

## Testing
- `pytest tests/test_meta_pretrain.py tests/test_meta_adapt.py -q`
- `pytest tests/test_meta_online_adaptation.py -q`
- `pytest tests/test_online_trainer.py tests/test_online_trainer_async.py -q` *(fails: async plugin missing)*
- `pytest tests/test_train_rl_agent_offline.py -q` *(fails: gym dependency missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c71228efbc832fa29a8f90a34558a5