### PR TITLE
Add rolling validator with property and chaos tests

### DIFF
--- a/tests/property/test_dsl_parsing.py
+++ b/tests/property/test_dsl_parsing.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import numpy as np
+from hypothesis import given, strategies as st
+
+from botcopier.strategy.dsl import (
+    Add,
+    And,
+    Constant,
+    Div,
+    EMA,
+    GT,
+    LT,
+    Mul,
+    Or,
+    Position,
+    Price,
+    SMA,
+    StopLoss,
+    Sub,
+    deserialize,
+    serialize,
+)
+from tests.property.strategies import price_series
+
+
+# Strategy for generating random DSL expressions
+expr_strategy = st.recursive(
+    st.one_of(
+        st.just(Price()),
+        st.builds(SMA, st.integers(1, 3)),
+        st.builds(EMA, st.integers(1, 3)),
+        st.builds(Constant, st.floats(-10, 10, allow_nan=False, allow_infinity=False)),
+    ),
+    lambda children: st.one_of(
+        st.builds(Add, children, children),
+        st.builds(Sub, children, children),
+        st.builds(Mul, children, children),
+        st.builds(Div, children, children),
+        st.builds(GT, children, children),
+        st.builds(LT, children, children),
+        st.builds(And, children, children),
+        st.builds(Or, children, children),
+        st.builds(Position, children, st.floats(-5, 5, allow_nan=False, allow_infinity=False)),
+        st.builds(StopLoss, children, st.floats(0, 5, allow_nan=False, allow_infinity=False)),
+    ),
+    max_leaves=10,
+)
+
+
+@given(expr_strategy, price_series())
+def test_serialize_roundtrip(expr, prices):
+    data = serialize(expr)
+    rebuilt = deserialize(data)
+    assert np.allclose(rebuilt.eval(prices), expr.eval(prices))

--- a/tests/property/test_feature_generation.py
+++ b/tests/property/test_feature_generation.py
@@ -1,0 +1,38 @@
+from hypothesis import assume, given, strategies as st
+import math
+
+from botcopier.scripts.features import _sma, _atr, _bollinger
+
+
+@st.composite
+def value_series(draw):
+    size = draw(st.integers(min_value=1, max_value=50))
+    return draw(
+        st.lists(
+            st.floats(-1e6, 1e6, allow_nan=False, allow_infinity=False),
+            min_size=size,
+            max_size=size,
+        )
+    )
+
+
+@given(value_series(), st.integers(1, 50))
+def test_sma_within_bounds(values, window):
+    sma = _sma(values, window)
+    assert math.isfinite(sma)
+    assert min(values) <= sma <= max(values)
+
+
+@given(value_series(), st.integers(1, 50))
+def test_atr_non_negative(values, window):
+    assume(len(values) > 1)
+    atr = _atr(values, window)
+    assert math.isfinite(atr)
+    assert atr >= 0
+
+
+@given(value_series(), st.integers(1, 50))
+def test_bollinger_order(values, window):
+    upper, mid, lower = _bollinger(values, window)
+    assert upper >= mid >= lower
+    assert math.isfinite(upper) and math.isfinite(mid) and math.isfinite(lower)

--- a/tests/property/test_order_execution.py
+++ b/tests/property/test_order_execution.py
@@ -1,0 +1,17 @@
+import numpy as np
+from hypothesis import given, strategies as st
+
+from botcopier.strategy.dsl import Constant, Position, StopLoss
+from tests.property.strategies import price_series
+
+
+@given(price_series(), st.floats(0.0, 5.0, allow_nan=False, allow_infinity=False))
+def test_stop_loss_resets_on_large_drop(prices, limit):
+    expr = StopLoss(Position(Constant(1.0)), limit)
+    positions = expr.eval(prices)
+    returns = np.diff(prices, prepend=prices[0])
+    for pos, ret in zip(positions, returns):
+        if ret < -abs(limit):
+            assert pos == 0.0
+        else:
+            assert pos == 1.0

--- a/tests/test_active_validator.py
+++ b/tests/test_active_validator.py
@@ -9,21 +9,15 @@ from scripts.active_validator import ActiveValidator
 def test_retrain_on_metric_decay():
     calls: list[str] = []
 
-    def retrain():
-        calls.append("retrained")
-
-    validator = ActiveValidator(threshold=0.8, retrain_cb=retrain)
+    validator = ActiveValidator(threshold=0.8, retrain_cb=lambda: calls.append("retrained"), window=2)
     truth = [1, 0, 1, 1]
     good = [1, 0, 1, 1]
     bad = [0, 0, 1, 1]  # accuracy 0.75
 
-    m1 = validator.evaluate(good, truth)
-    assert m1 == 1.0
-    m2 = validator.evaluate(bad, truth)
-    assert m2 == 0.75
-    assert calls == ["retrained"]
-    m3 = validator.evaluate(good, truth)
-    assert m3 == 1.0
+    validator.evaluate(good, truth)
+    validator.evaluate(bad, truth)  # rolling avg 0.875 -> no retrain
+    assert calls == []
+    validator.evaluate(bad, truth)  # rolling avg 0.75 -> retrain
     assert calls == ["retrained"]
 
 
@@ -36,3 +30,20 @@ def test_no_retrain_when_metrics_good():
     metric = validator.evaluate(preds, truth)
     assert metric == 0.5
     assert calls == []
+
+
+def test_demote_after_persistent_failures():
+    calls: list[str] = []
+
+    validator = ActiveValidator(
+        threshold=0.9,
+        retrain_cb=lambda: calls.append("retrain"),
+        demote_cb=lambda: calls.append("demote"),
+        window=3,
+        patience=2,
+    )
+    truth = [1, 1, 1]
+    bad = [0, 0, 0]
+    validator.evaluate(bad, truth)
+    validator.evaluate(bad, truth)
+    assert calls == ["retrain", "retrain", "demote"]


### PR DESCRIPTION
## Summary
- implement rolling window validation with demotion handling
- add Hypothesis property tests for feature generation, DSL parsing, and order execution
- add chaos tests simulating network and data outages

## Testing
- `pytest tests/property/test_feature_generation.py tests/property/test_dsl_parsing.py tests/property/test_order_execution.py tests/chaos/test_fault_injection.py tests/test_active_validator.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c71adcf2b0832fb540e7a8107fc256