### PR TITLE
Enhance strategy promotion risk checks and logging

### DIFF
--- a/tests/test_promote_strategy.py
+++ b/tests/test_promote_strategy.py
@@ -1,12 +1,19 @@
 import json
 from pathlib import Path
 
-from scripts.promote_strategy import promote
+from scripts import promote_strategy
+
+promote = promote_strategy.promote
 
 
 def _write_returns(path: Path, returns):
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text("\n".join(str(r) for r in returns))
+
+
+def _write_slippage(path: Path, values):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(str(v) for v in values))
 
 
 def test_promote_keeps_failing_model(tmp_path: Path):
@@ -24,6 +31,7 @@ def test_promote_keeps_failing_model(tmp_path: Path):
     assert not (live / "bad").exists()
     data = json.loads((metrics_dir / "risk.json").read_text())
     assert "bad" in data
+    assert data["bad"]["reasons"]
     assert "bad" not in json.loads(registry.read_text())
 
 
@@ -44,6 +52,7 @@ def test_promote_moves_successful_model(tmp_path: Path):
     assert reg["good"] == str(live / "good")
     data = json.loads((metrics_dir / "risk.json").read_text())
     assert "good" in data
+    assert not data["good"]["reasons"]
 
 
 def test_promote_rejects_budget_overuse(tmp_path: Path):
@@ -66,8 +75,11 @@ def test_promote_rejects_budget_overuse(tmp_path: Path):
     )
 
     assert (model).exists()
+    assert not (live / "over_budget").exists()
     report = json.loads((metrics_dir / "risk.json").read_text())
     assert report["over_budget"]["budget_utilisation"] > 1.0
+    assert "budget" in report["over_budget"]["reasons"]
+    assert "over_budget" not in json.loads(registry.read_text())
 
 
 def test_promote_rejects_order_mismatch(tmp_path: Path):
@@ -93,5 +105,35 @@ def test_promote_rejects_order_mismatch(tmp_path: Path):
     )
 
     assert (model).exists()
+    assert not (live / "bad_orders").exists()
     report = json.loads((metrics_dir / "risk.json").read_text())
     assert report["bad_orders"]["order_type_compliance"] < 1.0
+    assert "order_type" in report["bad_orders"]["reasons"]
+    assert "bad_orders" not in json.loads(registry.read_text())
+
+
+def test_promote_logs_additional_metrics(tmp_path: Path):
+    shadow = tmp_path / "shadow"
+    live = tmp_path / "live"
+    metrics_dir = tmp_path / "metrics"
+    registry = tmp_path / "models" / "active.json"
+
+    model = shadow / "metrics_model"
+    _write_returns(model / "oos.csv", [0.1, -0.2, 0.05, -0.4, 0.02])
+    _write_slippage(model / "slippage.csv", [0.1, 0.2, 0.1])
+
+    promote(
+        shadow,
+        live,
+        metrics_dir,
+        registry,
+        max_drawdown=1.0,
+        max_risk=1.0,
+    )
+
+    report = json.loads((metrics_dir / "risk.json").read_text())
+    metrics = report["metrics_model"]
+    assert "var_95" in metrics
+    assert "volatility_spikes" in metrics
+    assert "slippage_mean" in metrics
+    assert "slippage_std" in metrics


### PR DESCRIPTION
## Summary
- compute VaR, volatility spikes, and slippage statistics during strategy evaluation
- record rejection reasons for budget or order-type breaches in metrics/risk.json
- integration tests verify shadow retention for failures and registry updates for successful promotions

## Testing
- `SKIP=mypy pre-commit run --files botcopier/scripts/evaluation.py scripts/promote_strategy.py tests/test_promote_strategy.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68c71eef0204832f9f5103fce4c577e7