### PR TITLE
Add shared memory streaming and metrics server with restart logic

### DIFF
--- a/metrics/server.py
+++ b/metrics/server.py
@@ -1,0 +1,41 @@
+"""Lightweight HTTP server exposing aggregated metrics."""
+
+from __future__ import annotations
+
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Tuple
+
+from .aggregator import get_aggregated_metrics
+
+
+class _MetricsHandler(BaseHTTPRequestHandler):
+    def do_GET(self) -> None:  # pragma: no cover - trivial
+        if self.path.rstrip("/") == "/metrics":
+            payload = json.dumps(get_aggregated_metrics()).encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+    def log_message(self, format: str, *args) -> None:  # pragma: no cover - silence
+        return
+
+
+def start_http_server(host: str = "127.0.0.1", port: int = 8000) -> Tuple[HTTPServer, threading.Thread]:
+    """Start an HTTP server exposing metrics.
+
+    Returns the server instance and the thread on which it is serving so it can
+    later be shutdown cleanly.
+    """
+
+    server = HTTPServer((host, port), _MetricsHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server, thread
+

--- a/scripts/strategy_orchestrator.py
+++ b/scripts/strategy_orchestrator.py
@@ -1,30 +1,34 @@
 """Orchestrate running multiple strategies in isolated processes.
 
-Each strategy is executed in its own ``multiprocessing.Process`` and receives
-market data via a ``multiprocessing.Queue``. Metrics produced by the strategies
-are funnelled back through another queue and recorded with
-:mod:`metrics.aggregator`.
+This module dispatches market data to strategy functions running in
+subprocesses.  Data can be shared via ``multiprocessing.Queue`` or a
+``multiprocessing.shared_memory.ShareableList`` for zero-copy
+broadcasting.  Metrics produced by strategies are funnelled back
+through a queue and recorded with :mod:`metrics.aggregator`.
 
-The orchestrator can be imported and the :func:`run_strategies` function used in
-unit tests. When executed as a script it expects strategy specifications in the
-form ``module:function`` and a path to a JSON lines file containing market data
-entries.
+An optional HTTP server exposes the aggregated metrics so that external
+systems can monitor strategy performance while the orchestrator is
+running.
 """
+
 from __future__ import annotations
 
 import argparse
 import importlib
 import json
+import threading
 from multiprocessing import Process, Queue
-from typing import Callable, Dict, Iterable, Any, Tuple
+from multiprocessing.shared_memory import ShareableList
+from typing import Any, Callable, Dict, Iterable, Tuple
 
 from metrics.aggregator import add_metric, get_aggregated_metrics
+from metrics.server import start_http_server
 
 
 StrategyFn = Callable[[Any], Any]
 
 
-def _strategy_worker(strategy_id: str, fn: StrategyFn, data_q: Queue, metric_q: Queue) -> None:
+def _strategy_worker_queue(strategy_id: str, fn: StrategyFn, data_q: Queue, metric_q: Queue) -> None:
     """Consume market data from ``data_q`` and push metrics to ``metric_q``."""
     for item in iter(data_q.get, None):
         try:
@@ -36,7 +40,33 @@ def _strategy_worker(strategy_id: str, fn: StrategyFn, data_q: Queue, metric_q: 
     metric_q.put((strategy_id, None))  # signal completion
 
 
-def run_strategies(strategies: Dict[str, StrategyFn], market_data: Iterable[Any]) -> Dict[str, list]:
+def _strategy_worker_shm(strategy_id: str, fn: StrategyFn, shm_name: str, length: int, metric_q: Queue) -> None:
+    """Read market data from shared memory and report metrics."""
+    sl = ShareableList(name=shm_name)
+    try:
+        for i in range(length):
+            item = json.loads(sl[i])
+            try:
+                metric = fn(item)
+                if metric is not None:
+                    metric_q.put((strategy_id, metric))
+            except Exception as exc:  # pragma: no cover - defensive
+                metric_q.put((strategy_id, {"error": str(exc)}))
+    finally:
+        sl.shm.close()
+    metric_q.put((strategy_id, None))
+
+
+def run_strategies(
+    strategies: Dict[str, StrategyFn],
+    market_data: Iterable[Any],
+    *,
+    use_shm: bool = False,
+    max_restarts: int = 0,
+    serve_metrics: bool = False,
+    metrics_host: str = "127.0.0.1",
+    metrics_port: int = 8000,
+) -> Dict[str, list]:
     """Run ``strategies`` concurrently over ``market_data``.
 
     Parameters
@@ -45,38 +75,89 @@ def run_strategies(strategies: Dict[str, StrategyFn], market_data: Iterable[Any]
         Mapping of strategy identifiers to callables.
     market_data:
         Iterable of market data items to broadcast to all strategies.
-    Returns
-    -------
-    dict
-        Aggregated metrics keyed by strategy identifier.
+    use_shm:
+        If ``True`` market data is placed in a
+        :class:`~multiprocessing.shared_memory.ShareableList` and read by
+        workers. Otherwise a ``multiprocessing.Queue`` is used.
+    max_restarts:
+        Number of times a crashing strategy will be restarted.
+    serve_metrics:
+        If ``True`` expose aggregated metrics via an HTTP endpoint for
+        monitoring.
+    metrics_host / metrics_port:
+        Address for the metrics HTTP server when ``serve_metrics`` is
+        enabled.
     """
-    data_queues: Dict[str, Queue] = {sid: Queue() for sid in strategies}
+
+    server = None
+    server_thread: threading.Thread | None = None
+    if serve_metrics:
+        server, server_thread = start_http_server(metrics_host, metrics_port)
+
     metric_q: Queue = Queue()
-    procs: list[Process] = []
+    procs: Dict[str, Process] = {}
+    restarts: Dict[str, int] = {sid: 0 for sid in strategies}
 
-    for sid, fn in strategies.items():
-        p = Process(target=_strategy_worker, args=(sid, fn, data_queues[sid], metric_q))
-        p.start()
-        procs.append(p)
+    if use_shm:
+        data_list = [json.dumps(item) for item in market_data]
+        sl = ShareableList(data_list)
 
-    # Broadcast market data to each strategy
-    for item in market_data:
-        for q in data_queues.values():
-            q.put(item)
-    for q in data_queues.values():
-        q.put(None)  # terminate signal
+        def start_proc(sid: str, fn: StrategyFn) -> None:
+            p = Process(target=_strategy_worker_shm, args=(sid, fn, sl.shm.name, len(sl), metric_q))
+            p.start()
+            procs[sid] = p
 
-    finished = 0
+        for sid, fn in strategies.items():
+            start_proc(sid, fn)
+    else:
+        data_queues: Dict[str, Queue] = {}
+
+        def start_proc(sid: str, fn: StrategyFn) -> None:
+            q = Queue()
+            data_queues[sid] = q
+            p = Process(target=_strategy_worker_queue, args=(sid, fn, q, metric_q))
+            p.start()
+            procs[sid] = p
+            for item in market_data:
+                q.put(item)
+            q.put(None)
+
+        for sid, fn in strategies.items():
+            start_proc(sid, fn)
+
+    finished: Dict[str, bool] = {sid: False for sid in strategies}
     total = len(strategies)
-    while finished < total:
-        sid, metric = metric_q.get()
+    while sum(finished.values()) < total:
+        try:
+            sid, metric = metric_q.get(timeout=0.1)
+        except Exception:
+            # Check for crashed processes with no sentinel
+            for sid, p in procs.items():
+                if not finished[sid] and not p.is_alive():
+                    if p.exitcode and restarts[sid] < max_restarts:
+                        restarts[sid] += 1
+                        start_proc(sid, strategies[sid])
+                    else:
+                        finished[sid] = True
+            continue
         if metric is None:
-            finished += 1
+            p = procs[sid]
+            p.join()
+            if p.exitcode and restarts[sid] < max_restarts:
+                restarts[sid] += 1
+                start_proc(sid, strategies[sid])
+            else:
+                finished[sid] = True
         else:
             add_metric(sid, metric)
 
-    for p in procs:
-        p.join()
+    if serve_metrics and server and server_thread:
+        server.shutdown()
+        server_thread.join()
+
+    if use_shm:
+        sl.shm.close()
+        sl.shm.unlink()
 
     return get_aggregated_metrics()
 
@@ -93,15 +174,25 @@ def main(argv: list[str] | None = None) -> None:
     parser = argparse.ArgumentParser(description="Run strategies concurrently")
     parser.add_argument("strategies", nargs="+", help="Strategy specs in module:function form")
     parser.add_argument("--data", required=True, help="Path to JSON lines market data file")
+    parser.add_argument("--use-shm", action="store_true", help="Stream market data via shared memory")
+    parser.add_argument("--serve-metrics", action="store_true", help="Expose metrics via an HTTP endpoint")
+    parser.add_argument("--metrics-port", type=int, default=8000, help="Port for the metrics HTTP server")
     args = parser.parse_args(argv)
 
     strategies = dict(_parse_strategy(spec) for spec in args.strategies)
     with open(args.data, "r", encoding="utf-8") as fh:
         market_data = [json.loads(line) for line in fh]
 
-    aggregated = run_strategies(strategies, market_data)
+    aggregated = run_strategies(
+        strategies,
+        market_data,
+        use_shm=args.use_shm,
+        serve_metrics=args.serve_metrics,
+        metrics_port=args.metrics_port,
+    )
     print(json.dumps(aggregated, indent=2))
 
 
 if __name__ == "__main__":  # pragma: no cover - CLI entry
     main()
+

--- a/tests/test_strategy_orchestrator.py
+++ b/tests/test_strategy_orchestrator.py
@@ -1,9 +1,16 @@
 import importlib.util
+import json
+import multiprocessing
+import os
 import pathlib
 import sys
 import time
+import urllib.request
+
+import pytest
 
 from metrics.aggregator import get_aggregated_metrics, reset_metrics
+from metrics.server import start_http_server
 
 # Import the orchestrator directly from file to avoid package name clashes
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
@@ -16,7 +23,8 @@ spec.loader.exec_module(module)  # type: ignore[attr-defined]
 run_strategies = module.run_strategies
 
 
-def test_multiple_strategies_run_concurrently():
+@pytest.mark.parametrize("use_shm", [False, True])
+def test_multiple_strategies_run_concurrently(use_shm):
     reset_metrics()
 
     def strat_a(data):
@@ -30,7 +38,7 @@ def test_multiple_strategies_run_concurrently():
     market_data = [1, 2]
 
     start = time.time()
-    run_strategies({"A": strat_a, "B": strat_b}, market_data)
+    run_strategies({"A": strat_a, "B": strat_b}, market_data, use_shm=use_shm)
     duration = time.time() - start
 
     aggregated = get_aggregated_metrics()
@@ -38,3 +46,35 @@ def test_multiple_strategies_run_concurrently():
     assert len(aggregated["B"]) == len(market_data)
     # Two strategies with 0.2s per item would take >0.8s sequentially
     assert duration < 0.7
+
+
+def test_strategy_restarts_on_crash():
+    reset_metrics()
+    flag = multiprocessing.Value("i", 1)
+
+    def strat(data, flag=flag):
+        if flag.value:
+            flag.value = 0
+            os._exit(1)
+        return {"c": data}
+
+    market_data = [1, 2]
+    run_strategies({"C": strat}, market_data, max_restarts=1)
+    aggregated = get_aggregated_metrics()
+    assert len(aggregated["C"]) == len(market_data)
+
+
+def test_metrics_http_endpoint():
+    reset_metrics()
+
+    def strat(data):
+        return {"m": data}
+
+    server, thread = start_http_server(port=0)
+    port = server.server_address[1]
+    run_strategies({"M": strat}, [1])
+    resp = urllib.request.urlopen(f"http://127.0.0.1:{port}/metrics")
+    body = json.load(resp)
+    assert "M" in body
+    server.shutdown()
+    thread.join()


### PR DESCRIPTION
## Summary
- stream market data to strategies via multiprocessing queues or shared memory
- expose aggregated metrics through lightweight HTTP server
- restart crashed strategy processes and test for concurrent execution

## Testing
- `pytest tests/test_strategy_orchestrator.py::test_multiple_strategies_run_concurrently -q`
- `pytest tests/test_strategy_orchestrator.py::test_strategy_restarts_on_crash -q`
- `pytest tests/test_strategy_orchestrator.py::test_metrics_http_endpoint -q`


------
https://chatgpt.com/codex/tasks/task_e_68c72134d990832f998a78e03a86edb5