### PR TITLE
Enable streaming RL and persist meta adaptation

### DIFF
--- a/botcopier/scripts/online_trainer.py
+++ b/botcopier/scripts/online_trainer.py
@@ -604,6 +604,7 @@ class OnlineTrainer:
                         self.adapt_log.append(
                             {"old": old_coef.tolist(), "new": new_coef.tolist()}
                         )
+                        self.meta_weights = new_coef.tolist()
                     lr_used = getattr(self.clf, "eta0", self.lr)
                     self.lr_history.append(lr_used)
                     try:

--- a/tests/test_online_trainer_meta.py
+++ b/tests/test_online_trainer_meta.py
@@ -1,0 +1,20 @@
+import json
+from pathlib import Path
+
+from scripts.online_trainer import OnlineTrainer
+
+
+def test_online_trainer_persists_meta(tmp_path):
+    model_path = tmp_path / "model.json"
+    model_path.write_text(json.dumps({"meta": {"weights": [0.0, 0.0]}}))
+    trainer = OnlineTrainer(model_path=model_path, batch_size=2, run_generator=False)
+    batch = [
+        {"f0": 0.1, "f1": 0.2, "y": 1},
+        {"f0": -0.1, "f1": -0.2, "y": 0},
+    ]
+    assert trainer.update(batch)
+    trainer._save()
+    data = json.loads(model_path.read_text())
+    assert "meta" in data and "weights" in data["meta"]
+    assert data["meta"]["weights"] != [0.0, 0.0]
+    assert len(data.get("adaptation_log", [])) >= 1


### PR DESCRIPTION
## Summary
- Stream live tick experiences into the Q-learning trainer with periodic policy updates
- Persist online adaptation by updating meta-weights and logging coefficient changes
- Add regression test ensuring meta weights and adaptation log are saved

## Testing
- `pytest tests/test_meta_pretrain.py tests/test_online_trainer_meta.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c72c2ffd30832f89bc34afb0c04c68