### PR TITLE
Centralize config loading and add schema validation

### DIFF
--- a/botcopier/scripts/evaluation.py
+++ b/botcopier/scripts/evaluation.py
@@ -34,7 +34,10 @@ except Exception:  # pragma: no cover
     ) = brier_score_loss = roc_auc_score = _missing  # type: ignore
 
 from botcopier.exceptions import DataError, ServiceError
+from botcopier.utils.validation import validate_columns
 from metrics.registry import get_metrics, register_metric
+from schemas.decisions import DECISION_SCHEMA
+from schemas.trades import TRADE_SCHEMA
 
 logger = logging.getLogger(__name__)
 
@@ -68,6 +71,13 @@ def _load_predictions(pred_file: Path) -> pd.DataFrame:
             "decision_id",
         ]
         return pd.DataFrame(columns=cols)
+
+    validate_columns(
+        df,
+        DECISION_SCHEMA,
+        required={"timestamp", "probability"},
+        name="predictions",
+    )
 
     ts_col = next((c for c in ["timestamp", "time"] if c in df.columns), df.columns[0])
     sym_col = "symbol" if "symbol" in df.columns else None
@@ -161,6 +171,21 @@ def _load_actual_trades(log_file: Path) -> pd.DataFrame:
             "profit",
         ]
         return pd.DataFrame(columns=cols)
+
+    validate_columns(
+        df,
+        TRADE_SCHEMA,
+        required={
+            "event_time",
+            "action",
+            "ticket",
+            "symbol",
+            "order_type",
+            "lots",
+            "profit",
+        },
+        name="trade log",
+    )
 
     ts_col = next(
         (c for c in ["event_time", "time_event"] if c in df.columns), df.columns[0]

--- a/botcopier/utils/validation.py
+++ b/botcopier/utils/validation.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from typing import Iterable
+
+import pandas as pd
+import pyarrow as pa
+
+from botcopier.exceptions import DataError
+
+
+def validate_columns(
+    df: pd.DataFrame,
+    schema: pa.Schema,
+    *,
+    required: Iterable[str] | None = None,
+    name: str = "artifact",
+) -> None:
+    """Validate that ``df`` contains the ``required`` columns.
+
+    Parameters
+    ----------
+    df:
+        DataFrame to validate.
+    schema:
+        Arrow schema providing the full set of expected columns.
+    required:
+        Iterable of field names that must be present.  Defaults to all fields in
+        ``schema``.
+    name:
+        Human readable name of the data source used in error messages.
+    """
+
+    required_set = set(required) if required is not None else {f.name for f in schema}
+    missing = [col for col in required_set if col not in df.columns]
+    if missing:
+        raise DataError(
+            f"{name} missing required columns: {', '.join(sorted(missing))}",
+        )
+
+
+__all__ = ["validate_columns"]

--- a/tests/test_schema_validation.py
+++ b/tests/test_schema_validation.py
@@ -1,0 +1,29 @@
+import csv
+from pathlib import Path
+
+import pytest
+
+from botcopier.exceptions import DataError
+from botcopier.scripts.evaluation import evaluate
+
+
+def test_evaluate_missing_prediction_field(tmp_path: Path) -> None:
+    pred = tmp_path / "preds.csv"
+    with open(pred, "w", newline="") as f:
+        writer = csv.writer(f, delimiter=";")
+        writer.writerow(["timestamp", "symbol", "direction", "lots"])
+        writer.writerow(["2024.01.01 00:00:00", "EURUSD", "buy", "0.1"])
+
+    log = tmp_path / "trades.csv"
+    with open(log, "w", newline="") as f:
+        writer = csv.writer(f, delimiter=";")
+        writer.writerow(
+            ["event_time", "action", "ticket", "symbol", "order_type", "lots", "profit"]
+        )
+        writer.writerow(["2024.01.01 00:00:05", "OPEN", "1", "EURUSD", "0", "0.1", "0"])
+        writer.writerow(
+            ["2024.01.01 00:01:00", "CLOSE", "1", "EURUSD", "0", "0.1", "1"]
+        )
+
+    with pytest.raises(DataError):
+        evaluate(pred, log, window=60)


### PR DESCRIPTION
## Summary
- Load shared DataConfig, TrainingConfig, and ExecutionConfig in CLI with a single settings loader
- Validate prediction and trade logs against schema definitions before evaluation
- Add schema validation utility and tests for missing fields

## Testing
- `pre-commit run --files botcopier/cli/__init__.py botcopier/utils/validation.py botcopier/scripts/evaluation.py tests/test_schema_validation.py` *(fails: Found 217 errors in 49 files)*
- `pytest tests/test_cli_commands.py tests/test_evaluate.py tests/test_schema_validation.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c7404846e4832f820cb4345c2926e8