### PR TITLE
Expand property and pipeline tests

### DIFF
--- a/tests/property/test_dsl_parsing.py
+++ b/tests/property/test_dsl_parsing.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import numpy as np
-from hypothesis import given, strategies as st
+from hypothesis import given, settings, strategies as st
 
 from botcopier.strategy.dsl import (
     Add,
@@ -49,6 +49,7 @@ expr_strategy = st.recursive(
 
 
 @given(expr_strategy, price_series())
+@settings(max_examples=100)
 def test_serialize_roundtrip(expr, prices):
     data = serialize(expr)
     rebuilt = deserialize(data)

--- a/tests/property/test_feature_generation.py
+++ b/tests/property/test_feature_generation.py
@@ -1,4 +1,4 @@
-from hypothesis import assume, given, strategies as st
+from hypothesis import assume, given, settings, strategies as st
 import math
 
 from botcopier.scripts.features import _sma, _atr, _bollinger
@@ -17,6 +17,7 @@ def value_series(draw):
 
 
 @given(value_series(), st.integers(1, 50))
+@settings(max_examples=100)
 def test_sma_within_bounds(values, window):
     sma = _sma(values, window)
     assert math.isfinite(sma)
@@ -24,6 +25,7 @@ def test_sma_within_bounds(values, window):
 
 
 @given(value_series(), st.integers(1, 50))
+@settings(max_examples=100)
 def test_atr_non_negative(values, window):
     assume(len(values) > 1)
     atr = _atr(values, window)
@@ -32,6 +34,7 @@ def test_atr_non_negative(values, window):
 
 
 @given(value_series(), st.integers(1, 50))
+@settings(max_examples=100)
 def test_bollinger_order(values, window):
     upper, mid, lower = _bollinger(values, window)
     assert upper >= mid >= lower

--- a/tests/property/test_order_execution.py
+++ b/tests/property/test_order_execution.py
@@ -1,11 +1,12 @@
 import numpy as np
-from hypothesis import given, strategies as st
+from hypothesis import given, settings, strategies as st
 
 from botcopier.strategy.dsl import Constant, Position, StopLoss
 from tests.property.strategies import price_series
 
 
 @given(price_series(), st.floats(0.0, 5.0, allow_nan=False, allow_infinity=False))
+@settings(max_examples=100)
 def test_stop_loss_resets_on_large_drop(prices, limit):
     expr = StopLoss(Position(Constant(1.0)), limit)
     positions = expr.eval(prices)

--- a/tests/test_full_pipeline.py
+++ b/tests/test_full_pipeline.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import pytest
 
 from botcopier.training.pipeline import train
+from scripts.promote_strategy import promote
 
 
 @pytest.mark.integration
@@ -34,3 +35,38 @@ def test_full_pipeline(tmp_path: Path) -> None:
     expected_hash = hashlib.sha256(data_file.read_bytes()).hexdigest()
     key = str(data_file.resolve())
     assert model["data_hashes"][key] == expected_hash
+
+
+@pytest.mark.integration
+def test_train_promote_and_verify(tmp_path: Path) -> None:
+    """Train a strategy then promote and verify it on synthetic data."""
+    data_file = tmp_path / "trades_raw.csv"
+    rows = [
+        "label,price,volume,spread,hour,symbol\n",
+        "1,1.0,100,1.0,0,EURUSD\n",
+        "0,1.1,110,1.1,1,EURUSD\n",
+        "1,1.2,120,1.2,2,EURUSD\n",
+        "0,1.3,130,1.3,3,EURUSD\n",
+    ]
+    data_file.write_text("".join(rows))
+
+    shadow = tmp_path / "shadow" / "modelA"
+    train(data_file, shadow, n_splits=2, cv_gap=1, param_grid=[{}])
+
+    # Synthetic performance metrics for promotion
+    (shadow / "oos.csv").write_text("0.1\n0.2\n-0.1\n")
+    (shadow / "orders.csv").write_text("market\nmarket\nmarket\n")
+
+    live = tmp_path / "live"
+    metrics_dir = tmp_path / "metrics"
+    registry = tmp_path / "models" / "active.json"
+
+    promote(shadow.parent, live, metrics_dir, registry, max_drawdown=0.5, max_risk=1.0)
+
+    promoted = live / "modelA"
+    assert promoted.exists()
+
+    report = json.loads((metrics_dir / "risk.json").read_text())
+    assert "modelA" in report
+    reg = json.loads(registry.read_text())
+    assert reg["modelA"] == str(promoted)


### PR DESCRIPTION
## Summary
- stress feature generation, DSL parsing, and order execution invariants with Hypothesis
- add end-to-end training and promotion test over synthetic data

## Testing
- `pytest tests/property/test_feature_generation.py tests/property/test_dsl_parsing.py tests/property/test_order_execution.py tests/test_full_pipeline.py tests/chaos/test_fault_injection.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c74fb28a38832fb8f4b79d60f2108a