### PR TITLE
Refactor training script into package modules

### DIFF
--- a/botcopier/scripts/cluster_regimes.py
+++ b/botcopier/scripts/cluster_regimes.py
@@ -22,7 +22,7 @@ except Exception:  # pragma: no cover - optional
     hdbscan = None
 
 # Reuse data loading and feature extraction from training script
-from botcopier.data.loading import _load_logs
+from botcopier.data.loading import _load_calendar, _load_logs
 from botcopier.features.technical import _extract_features
 
 

--- a/botcopier/scripts/detect_regime.py
+++ b/botcopier/scripts/detect_regime.py
@@ -21,7 +21,8 @@ try:  # optional dependency
 except Exception:  # pragma: no cover - optional
     hdbscan = None
 
-from train_target_clone import _load_logs, _load_calendar  # type: ignore
+from botcopier.data.loading import _load_calendar, _load_logs
+
 try:
     from scripts.features import _extract_features  # type: ignore
 except Exception:
@@ -138,16 +139,25 @@ def main() -> None:
         help="clustering algorithm",
     )
     p.add_argument("--model-json", type=Path, default=Path("model.json"))
-    p.add_argument("--assignments", type=Path, help="CSV file to write per-sample regime IDs")
-    p.add_argument("--corr-symbols", help="comma separated correlated symbol pairs e.g. EURUSD:USDCHF")
-    p.add_argument("--calendar-file", help="CSV file with columns time,impact[,id] for events")
-    p.add_argument("--event-window", type=float, default=60.0, help="minutes around events to flag")
+    p.add_argument(
+        "--assignments", type=Path, help="CSV file to write per-sample regime IDs"
+    )
+    p.add_argument(
+        "--corr-symbols",
+        help="comma separated correlated symbol pairs e.g. EURUSD:USDCHF",
+    )
+    p.add_argument(
+        "--calendar-file", help="CSV file with columns time,impact[,id] for events"
+    )
+    p.add_argument(
+        "--event-window", type=float, default=60.0, help="minutes around events to flag"
+    )
     args = p.parse_args()
     if args.corr_symbols:
         corr_map = {}
-        for p_sym in args.corr_symbols.split(','):
-            if ':' in p_sym:
-                base, peer = p_sym.split(':', 1)
+        for p_sym in args.corr_symbols.split(","):
+            if ":" in p_sym:
+                base, peer = p_sym.split(":", 1)
                 corr_map.setdefault(base, []).append(peer)
     else:
         corr_map = None

--- a/botcopier/scripts/replay_decisions.py
+++ b/botcopier/scripts/replay_decisions.py
@@ -40,13 +40,8 @@ except Exception:  # pragma: no cover
     torch = None  # type: ignore
     _HAS_TORCH = False
 
-try:
-    from train_target_clone import TabTransformer, detect_resources
-except Exception:  # pragma: no cover - script executed within package
-    from botcopier.training.pipeline import (  # type: ignore
-        TabTransformer,
-        detect_resources,
-    )
+from botcopier.models.registry import TabTransformer
+from botcopier.training.pipeline import detect_resources
 
 try:  # optional graph embedding support
     from graph_dataset import GraphDataset, compute_gnn_embeddings
@@ -59,11 +54,13 @@ except Exception:  # pragma: no cover
 
 try:  # optional stable-baselines3 dependency
     import stable_baselines3 as sb3  # type: ignore
+
     from botcopier.rl.options import (
         OptionTradeEnv,
         default_skills,
         evaluate_option_policy,
     )
+
     _HAS_SB3 = True
 except Exception:  # pragma: no cover - optional dependency
     sb3 = None  # type: ignore
@@ -378,7 +375,9 @@ def main() -> int:
             states = df[state_cols].to_numpy(dtype=float)
             acts = df.get("action", pd.Series([0] * len(df))).to_numpy(dtype=int)
             rewards = np.ones(len(df), dtype=float)
-            opt_stats = replay_option_policy(states, acts, rewards, model, args.model.parent)
+            opt_stats = replay_option_policy(
+                states, acts, rewards, model, args.model.parent
+            )
             print(f"Option total reward: {opt_stats['total_reward']:.2f}")
         except Exception:
             pass

--- a/tests/test_hyperparam_log.py
+++ b/tests/test_hyperparam_log.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import pandas as pd
 import pytest
 
-from train_target_clone import run_optuna
+from botcopier.training.pipeline import run_optuna
 
 
 def test_hyperparam_csv_contains_best_trial(tmp_path: Path):

--- a/train_target_clone.py
+++ b/train_target_clone.py
@@ -1,194 +1,25 @@
-"""Simplified training script used for unit tests.
+"""CLI wrapper for the simplified training pipeline.
 
-This module implements a tiny Optuna optimisation loop.  The real project
-contains a much more sophisticated training pipeline, but for the purposes of
-the unit tests we only need something that exercises a couple of pieces of
-infrastructure:
-
-* Hyper-parameter trials are logged to ``hyperparams.csv`` using an Optuna
-  callback.
-* ``model.json`` records where this log lives via ``metadata.hyperparam_log``
-  and stores information about the best trial for later inspection.
-
-The ``TabTransformer`` class and ``detect_resources`` function are stubs that
-exist solely so imports from other modules (or historical code) do not fail.
+This script exists for historical compatibility.  The implementation
+moved into the :mod:`botcopier` package and is re-exported here so that
+older entry points continue to function.
 """
-
 from __future__ import annotations
 
 import argparse
-import json
-import os
-from pathlib import Path
-from typing import Callable
 
-import numpy as np
-import optuna
-import pandas as pd
+from botcopier.models.registry import TabTransformer
+from botcopier.training.pipeline import detect_resources, run_optuna
+
+__all__ = ["run_optuna", "TabTransformer", "detect_resources"]
 
 
-class TabTransformer:
-    """Stubbed model class.
-
-    The real implementation lives elsewhere.  Only the methods required by old
-    imports are present here.
-    """
-
-    def __init__(self, *args, **kwargs):
-        pass
-
-    def load_state_dict(self, *args, **kwargs):
-        pass
-
-    def eval(self):
-        pass
-
-    def __call__(self, x):
-        return x
-
-
-def detect_resources() -> dict:
-    """Return dummy resource information.
-
-    In the full project this performs hardware introspection.  For tests we
-    simply indicate that the training should run in a light-weight mode.
-    """
-
-    return {"lite_mode": True}
-
-
-# ---------------------------------------------------------------------------
-# Optuna helpers
-# ---------------------------------------------------------------------------
-
-
-def _trial_logger(
-    csv_path: Path,
-) -> Callable[[optuna.study.Study, optuna.trial.FrozenTrial], None]:
-    """Return a callback that appends trial information to ``csv_path``.
-
-    Each row contains the trial number, suggested parameters, the objective
-    values and the random seed stored in ``trial.user_attrs``.
-    """
-
-    def _callback(study: optuna.study.Study, trial: optuna.trial.FrozenTrial) -> None:
-        row = {
-            "trial": trial.number,
-            **trial.params,
-            "seed": trial.user_attrs.get("seed"),
-            "profit": trial.values[0],
-            "sharpe": trial.values[1],
-            "max_drawdown": trial.values[2],
-        }
-        df = pd.DataFrame([row])
-        df.to_csv(csv_path, mode="a", header=not csv_path.exists(), index=False)
-
-    return _callback
-
-
-def _objective_factory(
-    max_drawdown: float | None, var_limit: float | None
-) -> Callable[[optuna.trial.Trial], tuple[float, float, float]]:
-    """Return a multi-objective that includes risk penalties.
-
-    The returned objective yields ``(profit, sharpe, max_drawdown)`` so the
-    study can simultaneously optimise for risk and return.
-    """
-
-    def _objective(trial: optuna.trial.Trial) -> tuple[float, float, float]:
-        seed = trial.suggest_int("seed", 0, 9999)
-        trial.set_user_attr("seed", seed)
-        x = trial.suggest_float("x", -10.0, 10.0)
-        rng = np.random.default_rng(seed)
-        noise = rng.normal()
-        risk = abs(x) / 10.0
-        trial.set_user_attr("max_drawdown", risk)
-        trial.set_user_attr("var_95", risk)
-        profit = -((x - 2) ** 2) + noise
-        if max_drawdown is not None and risk > max_drawdown:
-            profit -= risk - max_drawdown
-        if var_limit is not None and risk > var_limit:
-            profit -= risk - var_limit
-        sharpe = profit / (risk + 1e-6)
-        return profit, sharpe, risk
-
-    return _objective
-
-
-def run_optuna(
-    n_trials: int = 10,
-    csv_path: Path | str = "hyperparams.csv",
-    model_json_path: Path | str = "model.json",
-    *,
-    max_drawdown: float | None = None,
-    var_limit: float | None = None,
-) -> optuna.study.Study:
-    """Run a small Optuna study and record trial information.
-
-    Parameters
-    ----------
-    n_trials:
-        Number of optimisation trials to run.
-    csv_path:
-        Location where the hyper-parameter log will be written.
-    model_json_path:
-        Where to write the resulting ``model.json`` summary.
-    """
-
-    csv_path = Path(csv_path)
-    model_json_path = Path(model_json_path)
-
-    sampler = optuna.samplers.RandomSampler(seed=0)
-    study = optuna.create_study(
-        directions=["maximize", "maximize", "minimize"], sampler=sampler
-    )
-    objective = _objective_factory(max_drawdown, var_limit)
-    study.optimize(objective, n_trials=n_trials, callbacks=[_trial_logger(csv_path)])
-
-    def _select_trial() -> optuna.trial.FrozenTrial:
-        candidates = [t for t in study.best_trials]
-        if max_drawdown is not None:
-            candidates = [t for t in candidates if t.values[2] <= max_drawdown]
-        if var_limit is not None:
-            candidates = [
-                t
-                for t in candidates
-                if t.user_attrs.get("var_95", t.values[2]) <= var_limit
-            ]
-        if not candidates:
-            candidates = list(study.best_trials)
-        return max(candidates, key=lambda t: (t.values[0], t.values[1]))
-
-    best = _select_trial()
-    relative_csv = os.path.relpath(csv_path, model_json_path.parent)
-    risk = best.user_attrs.get("max_drawdown", 0.0)
-    model_data = {
-        "metadata": {
-            "hyperparam_log": relative_csv,
-            "selected_trial": {
-                "number": best.number,
-                "profit": best.values[0],
-                "sharpe": best.values[1],
-                "max_drawdown": best.values[2],
-            },
-        },
-        "risk_params": {"max_drawdown": max_drawdown, "var_limit": var_limit},
-        "risk_metrics": {
-            "max_drawdown": risk,
-            "var_95": best.user_attrs.get("var_95", risk),
-        },
-    }
-    model_json_path.write_text(json.dumps(model_data))
-
-    return study
-
-
-if __name__ == "__main__":  # pragma: no cover - manual execution entry point
-    p = argparse.ArgumentParser()
-    p.add_argument("--max-drawdown", type=float, default=None)
-    p.add_argument("--var-limit", type=float, default=None)
-    p.add_argument("--trials", type=int, default=10)
-    args = p.parse_args()
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--max-drawdown", type=float, default=None)
+    parser.add_argument("--var-limit", type=float, default=None)
+    parser.add_argument("--trials", type=int, default=10)
+    args = parser.parse_args()
     run_optuna(
         n_trials=args.trials,
         max_drawdown=args.max_drawdown,


### PR DESCRIPTION
## Summary
- expose Optuna-based hyperparameter study via `botcopier.training.pipeline.run_optuna`
- add calendar CSV loader utility and update scripts to use package imports
- slim `train_target_clone.py` to a CLI wrapper re-exporting package functions

## Testing
- `pre-commit run --files botcopier/data/loading.py botcopier/scripts/cluster_regimes.py botcopier/scripts/detect_regime.py botcopier/scripts/online_trainer.py botcopier/scripts/replay_decisions.py botcopier/training/pipeline.py tests/test_hyperparam_log.py train_target_clone.py` *(failed: Module has no attribute "signal" [attr-defined])* 
- `pytest tests/test_hyperparam_log.py tests/test_detect_resources.py` *(failed: No module named 'pandera')*

------
https://chatgpt.com/codex/tasks/task_e_68c75dba1248832f9c8925f6a31974b5