### PR TITLE
Add AutoML controller reuse flag and convergence tests

### DIFF
--- a/botcopier/cli/__init__.py
+++ b/botcopier/cli/__init__.py
@@ -147,6 +147,9 @@ def train(
     strategy_search: bool = typer.Option(
         False, help="Run neural strategy search instead of standard training"
     ),
+    reuse_controller: bool = typer.Option(
+        False, help="Reuse previously learned AutoML controller policy",
+    ),
 ) -> None:
     """Train a model from trade logs."""
     data_cfg, train_cfg, exec_cfg = _cfg(ctx)
@@ -174,6 +177,8 @@ def train(
         train_cfg = train_cfg.model_copy(update={"hrp_allocation": hrp_allocation})
     if strategy_search:
         train_cfg = train_cfg.model_copy(update={"strategy_search": strategy_search})
+    if reuse_controller:
+        train_cfg = train_cfg.model_copy(update={"reuse_controller": reuse_controller})
     ctx.obj["config"] = {
         "data": data_cfg,
         "training": train_cfg,
@@ -191,6 +196,7 @@ def train(
         random_seed=train_cfg.random_seed,
         hrp_allocation=train_cfg.hrp_allocation,
         strategy_search=train_cfg.strategy_search,
+        reuse_controller=train_cfg.reuse_controller,
     )
 
 

--- a/botcopier/training/pipeline.py
+++ b/botcopier/training/pipeline.py
@@ -316,6 +316,7 @@ def train(
     """Train a model selected from the registry."""
     chosen_action: tuple[tuple[str, ...], str] | None = None
     if controller is not None:
+        controller.model_path = out_dir / "model.json"
         if not reuse_controller:
             controller.reset()
         chosen_action, _ = controller.sample_action()

--- a/tests/test_automl_controller.py
+++ b/tests/test_automl_controller.py
@@ -1,44 +1,42 @@
 import json
+import random
 from pathlib import Path
 
 from automl.controller import AutoMLController
 
 
-def test_automl_controller_converges(tmp_path):
-    features = ["f1", "f2"]
-    models = {"linear": 1, "tree": 2}
-
-    model_file = tmp_path / "model.json"
-    controller = AutoMLController(features, models, model_path=model_file)
-
-    profit_map = {
-        (("f1",), "linear"): 1.0,
-        (("f2",), "linear"): 1.2,
-        (("f1", "f2"), "linear"): 1.5,
-        (("f1",), "tree"): 1.1,
-        (("f2",), "tree"): 1.3,
-        (("f1", "f2"), "tree"): 1.7,
+def _toy_env(action):
+    rewards = {
+        (("f1",), "m1"): 0.1,
+        (("f1",), "m2"): 0.2,
+        (("f2",), "m1"): 0.05,
+        (("f2",), "m2"): 0.15,
+        (("f1", "f2"), "m1"): 0.25,
+        (("f1", "f2"), "m2"): 0.5,
     }
+    return rewards[action]
 
-    def env(action):
-        subset, model = action
-        return profit_map[(tuple(subset), model)]
 
-    controller.train(env, episodes=200, alpha=0.2, penalty=0.1)
-
+def test_controller_converges(tmp_path: Path) -> None:
+    random.seed(0)
+    controller = AutoMLController(
+        ["f1", "f2"], {"m1": 1, "m2": 2}, model_path=tmp_path / "model.json"
+    )
+    controller.train(_toy_env, episodes=500, alpha=0.2, penalty=0.01)
     best = controller.select_best()
-    assert best == (("f1", "f2"), "tree")
+    assert best == (("f1", "f2"), "m2")
+    data = json.loads((tmp_path / "model.json").read_text())
+    sec = data["automl_controller"]["best_action"]
+    assert sec == {"features": ["f1", "f2"], "model": "m2"}
 
-    data = json.loads(model_file.read_text())
-    assert data["automl_controller"]["best_action"] == {
-        "features": ["f1", "f2"],
-        "model": "tree",
-    }
 
-    # Ensure the policy is persisted and reused on a fresh instance
-    warm = AutoMLController(features, models, model_path=model_file)
-    assert warm.select_best() == (("f1", "f2"), "tree")
-
-    # When reuse is disabled the policy should reset
-    cold = AutoMLController(features, models, model_path=model_file, reuse=False)
-    assert cold.select_best() != (("f1", "f2"), "tree")
+def test_controller_reuse(tmp_path: Path) -> None:
+    random.seed(0)
+    path = tmp_path / "model.json"
+    controller = AutoMLController(["f1", "f2"], {"m1": 1, "m2": 2}, model_path=path)
+    controller.train(_toy_env, episodes=200, alpha=0.2, penalty=0.01)
+    best = controller.select_best()
+    reused = AutoMLController(["f1", "f2"], {"m1": 1, "m2": 2}, model_path=path, reuse=True)
+    assert reused.select_best() == best
+    fresh = AutoMLController(["f1", "f2"], {"m1": 1, "m2": 2}, model_path=path, reuse=False)
+    assert fresh.select_best() != best


### PR DESCRIPTION
## Summary
- expose `--reuse-controller` CLI flag and propagate to training pipeline
- ensure controller choices persist via `model.json` and reward profit minus complexity
- add tests demonstrating AutoML controller convergence and policy reuse

## Testing
- `pytest tests/test_automl_controller.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy', 'grpc', 'nats', 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_e_68c771bd52dc832fbd78fcd4c2734fff