### PR TITLE
Add sequential drift logging and tests

### DIFF
--- a/tests/test_sequential_drift.py
+++ b/tests/test_sequential_drift.py
@@ -1,4 +1,4 @@
-from scripts.sequential_drift import PageHinkley
+from scripts.sequential_drift import PageHinkley, CusumDetector
 
 
 def test_page_hinkley_detects_expected_change():
@@ -10,4 +10,15 @@ def test_page_hinkley_detects_expected_change():
             alarm = i
             break
     assert alarm == 11
+
+
+def test_cusum_detects_expected_change():
+    detector = CusumDetector(threshold=0.5)
+    data = [0.0] * 5 + [1.0] * 5
+    alarm = None
+    for i, v in enumerate(data):
+        if detector.update(v):
+            alarm = i
+            break
+    assert alarm == 5
 


### PR DESCRIPTION
## Summary
- support Page-Hinkley and CUSUM drift tests in online trainer
- log sequential drift events with model hashes
- add tests for sequential detectors and drift logging

## Testing
- `pytest tests/test_sequential_drift.py`
- `pytest tests/test_sequential_drift.py tests/test_online_trainer.py::test_sequential_drift_records_hash` *(fails: ModuleNotFoundError: No module named 'pandera')*

------
https://chatgpt.com/codex/tasks/task_e_68c7a1d4a678832f870d9e6268be4bc7