### PR TITLE
Add risk metrics and dataset lineage

### DIFF
--- a/tests/test_full_pipeline.py
+++ b/tests/test_full_pipeline.py
@@ -35,6 +35,8 @@ def test_full_pipeline(tmp_path: Path) -> None:
     expected_hash = hashlib.sha256(data_file.read_bytes()).hexdigest()
     key = str(data_file.resolve())
     assert model["data_hashes"][key] == expected_hash
+    assert "risk_metrics" in model
+    assert set(model["risk_metrics"].keys()) >= {"max_drawdown", "var_95"}
 
 
 @pytest.mark.integration

--- a/tests/test_promote_strategy.py
+++ b/tests/test_promote_strategy.py
@@ -161,6 +161,8 @@ def test_promote_logs_additional_metrics(tmp_path: Path):
     report = json.loads((metrics_dir / "risk.json").read_text())
     metrics = report["metrics_model"]
     assert "var_95" in metrics
+    assert "sharpe_ratio" in metrics
+    assert "sortino_ratio" in metrics
     assert "volatility_spikes" in metrics
     assert "slippage_mean" in metrics
     assert "slippage_std" in metrics


### PR DESCRIPTION
## Summary
- compute Sharpe, Sortino, max drawdown and 95% VaR metrics with bootstrap confidence intervals
- hash training datasets and persist risk metrics in `model.json`
- test evaluation metrics persistence and dataset lineage

## Testing
- `pytest tests/test_evaluation_module.py::test_evaluate_model tests/test_evaluation_module.py::test_bootstrap_interval_shrinks tests/test_full_pipeline.py::test_full_pipeline tests/test_promote_strategy.py::test_promote_logs_additional_metrics -q`

------
https://chatgpt.com/codex/tasks/task_e_68c7a443b104832fbdb97cb0efc59487