### PR TITLE
Add plugin registries for metrics and evaluation hooks

### DIFF
--- a/docs/eval_hooks.md
+++ b/docs/eval_hooks.md
@@ -21,3 +21,14 @@ botcopier evaluate preds.csv trades.csv --eval-hooks precision,sharpe
 
 Each hook receives the same context object, allowing them to share results.
 They are executed sequentially in the order provided.
+
+Third-party packages can expose hooks via the `botcopier.eval_hooks` entry
+point group:
+
+```
+[project.entry-points."botcopier.eval_hooks"]
+precision_plus = "my_pkg.hooks:precision_plus"
+```
+
+When listed on the CLI the hook will be discovered and executed alongside the
+built-in ones.

--- a/docs/feature_plugins.md
+++ b/docs/feature_plugins.md
@@ -35,3 +35,52 @@ custom = "my_pkg.my_module:my_features"
 BotCopier will automatically discover such plugins when they are enabled.
 Enable a plugin by passing ``--feature custom`` on the CLI or by listing it
 under ``training.features`` in a configuration file.
+
+## Metric plugins
+
+Classification metrics share the same ergonomics. Implement a callable that
+accepts ``(y_true, probas, profits=None)`` and register it via
+``metrics.registry.register_metric``:
+
+```python
+from metrics.registry import register_metric
+
+@register_metric("fancy")
+def fancy_metric(y_true, probas, profits=None):
+    return 42.0
+```
+
+Expose the metric from a third-party package with an entry point:
+
+```
+[project.entry-points."botcopier.metrics"]
+fancy = "my_pkg.metrics:fancy_metric"
+```
+
+Metrics can be selected when training with ``--metric fancy`` or by setting
+``training.metrics`` in a configuration file.
+
+## Evaluation hooks
+
+Evaluation hooks extend the JSON payload returned by the ``evaluate`` command.
+They are simple callables that receive a mutable context dictionary. Register
+hooks with ``botcopier.eval.hooks.register_hook`` or publish them via the
+``botcopier.eval_hooks`` entry point group:
+
+```python
+from botcopier.eval import hooks
+
+@hooks.register_hook("alpha")
+def add_alpha(ctx):
+    ctx.setdefault("stats", {})["alpha"] = 1.0
+```
+
+Or from a plugin package:
+
+```
+[project.entry-points."botcopier.eval_hooks"]
+alpha = "my_pkg.hooks:add_alpha"
+```
+
+Enable hooks on the CLI with ``--eval-hooks alpha`` or set ``training.eval_hooks``
+in configuration.

--- a/metrics/__init__.py
+++ b/metrics/__init__.py
@@ -1,10 +1,11 @@
 """Metric utilities exposed for convenience."""
-from .registry import get_metrics, register_metric
+from .registry import get_metrics, load_plugins, register_metric
 from .aggregator import add_metric, get_aggregated_metrics, reset_metrics
 
 __all__ = [
     "get_metrics",
     "register_metric",
+    "load_plugins",
     "add_metric",
     "get_aggregated_metrics",
     "reset_metrics",

--- a/metrics/registry.py
+++ b/metrics/registry.py
@@ -1,16 +1,59 @@
-"""Simple metric registry for classification metrics."""
+"""Simple plugin-style registry for classification metrics."""
 from __future__ import annotations
 
-from typing import Callable, Dict, Sequence
+from collections.abc import Callable, Iterable
+from importlib.metadata import entry_points
+from typing import Dict, Sequence
 
 MetricFn = Callable[[object, object, object | None], object]
 
 _REGISTRY: Dict[str, MetricFn] = {}
 
 
-def register_metric(name: str, fn: MetricFn) -> None:
-    """Register a metric callable under ``name``."""
-    _REGISTRY[name] = fn
+def register_metric(name: str, fn: MetricFn | None = None):
+    """Register ``fn`` under ``name`` in the metric registry.
+
+    The function can be used either directly::
+
+        def my_metric(y_true, probas, profits=None):
+            ...
+
+        register_metric("custom", my_metric)
+
+    or as a decorator::
+
+        @register_metric("custom")
+        def my_metric(y_true, probas, profits=None):
+            ...
+    """
+
+    def _register(func: MetricFn) -> MetricFn:
+        _REGISTRY[name] = func
+        return func
+
+    if fn is None:
+        return _register
+    return _register(fn)
+
+
+def load_plugins(names: Iterable[str] | None = None) -> None:
+    """Discover and load metric plugins exposed via entry points."""
+
+    try:
+        eps = entry_points(group="botcopier.metrics")
+    except TypeError:  # pragma: no cover - compatibility with Python <3.10
+        eps = entry_points().get("botcopier.metrics", [])
+
+    for ep in eps:
+        if names is not None and ep.name not in names:
+            continue
+        if ep.name in _REGISTRY:
+            continue
+        try:
+            fn = ep.load()
+        except Exception:  # pragma: no cover - third party plugin failure
+            continue
+        register_metric(ep.name, fn)
 
 
 def get_metrics(selected: Sequence[str] | None = None) -> Dict[str, MetricFn]:
@@ -22,3 +65,6 @@ def get_metrics(selected: Sequence[str] | None = None) -> Dict[str, MetricFn]:
     if selected is None:
         return dict(_REGISTRY)
     return {name: _REGISTRY[name] for name in selected if name in _REGISTRY}
+
+
+__all__ = ["register_metric", "load_plugins", "get_metrics", "MetricFn"]

--- a/tests/test_eval_hooks.py
+++ b/tests/test_eval_hooks.py
@@ -1,3 +1,8 @@
+import sys
+import types
+
+from importlib.metadata import EntryPoint
+
 from botcopier.eval import hooks
 
 
@@ -23,3 +28,34 @@ def test_hooks_run_in_order_and_share_context():
         assert ctx["value"] == [1, 2]
     finally:
         hooks._REGISTRY = original
+
+
+def test_entry_point_hook_executes(monkeypatch):
+    original = hooks._REGISTRY.copy()
+    try:
+        module = types.ModuleType("thirdparty_eval_hook")
+
+        def plugin(ctx):
+            ctx.setdefault("stats", {})["thirdparty"] = 99
+
+        module.plugin = plugin
+        sys.modules["thirdparty_eval_hook"] = module
+
+        ep = EntryPoint(
+            name="thirdparty",
+            value="thirdparty_eval_hook:plugin",
+            group="botcopier.eval_hooks",
+        )
+        monkeypatch.setattr(
+            hooks,
+            "entry_points",
+            lambda group=None: [ep] if group == "botcopier.eval_hooks" else [],
+        )
+
+        hooks.load_entry_point_hooks(["thirdparty"])
+        ctx = {"stats": {}}
+        hooks.dispatch_hooks(["thirdparty"], ctx)
+        assert ctx["stats"]["thirdparty"] == 99
+    finally:
+        hooks._REGISTRY = original
+        sys.modules.pop("thirdparty_eval_hook", None)

--- a/tests/test_metric_plugins.py
+++ b/tests/test_metric_plugins.py
@@ -1,0 +1,74 @@
+import sys
+import types
+
+from importlib.metadata import EntryPoint
+
+# stub optional dependencies required by evaluation import
+pyarrow = types.ModuleType("pyarrow")
+
+
+class _ArrowField:
+    def __init__(self, name: str):
+        self.name = name
+
+
+def _make_type():  # pragma: no cover - trivial stub
+    return object()
+
+
+pyarrow.int32 = _make_type  # type: ignore[attr-defined]
+pyarrow.float64 = _make_type  # type: ignore[attr-defined]
+pyarrow.string = _make_type  # type: ignore[attr-defined]
+
+
+def _schema(fields):  # pragma: no cover - trivial stub
+    return [_ArrowField(name) for name, *_ in fields]
+
+
+pyarrow.schema = _schema  # type: ignore[attr-defined]
+pyarrow.Schema = list  # type: ignore[attr-defined]
+sys.modules.setdefault("pyarrow", pyarrow)
+pydantic = types.ModuleType("pydantic")
+
+
+class _BaseModel:  # pragma: no cover - minimal stub
+    def model_dump(self, *args, **kwargs):
+        return {}
+
+
+pydantic.BaseModel = _BaseModel  # type: ignore[attr-defined]
+sys.modules.setdefault("pydantic", pydantic)
+
+from botcopier.scripts import evaluation
+import metrics.registry as metric_registry
+
+
+def test_entry_point_metric(monkeypatch):
+    original = metric_registry._REGISTRY.copy()
+    try:
+        module = types.ModuleType("thirdparty_metric_mod")
+
+        def metric(y_true, probas, profits=None):  # type: ignore[unused-arg]
+            return "plugin"
+
+        module.metric = metric
+        sys.modules["thirdparty_metric_mod"] = module
+
+        ep = EntryPoint(
+            name="plugin_metric",
+            value="thirdparty_metric_mod:metric",
+            group="botcopier.metrics",
+        )
+        monkeypatch.setattr(
+            metric_registry,
+            "entry_points",
+            lambda group=None: [ep] if group == "botcopier.metrics" else [],
+        )
+
+        result = evaluation._classification_metrics(
+            [], [], None, selected=["plugin_metric"]
+        )
+        assert result["plugin_metric"] == "plugin"
+    finally:
+        metric_registry._REGISTRY = original
+        sys.modules.pop("thirdparty_metric_mod", None)


### PR DESCRIPTION
## Summary
- extend the metric registry with decorator support and entry-point discovery
- load evaluation metrics and hooks selected via config/CLI and document plugin authoring
- add tests covering third-party hook and metric execution paths

## Testing
- pytest tests/test_feature_plugins.py tests/test_eval_hooks.py tests/test_metric_plugins.py -q

------
https://chatgpt.com/codex/tasks/task_e_68c83488c808832fa3c47609d9228793