### PR TITLE
Improve gRPC predict service robustness

### DIFF
--- a/botcopier/scripts/grpc_predict_server.py
+++ b/botcopier/scripts/grpc_predict_server.py
@@ -6,7 +6,10 @@ from __future__ import annotations
 import argparse
 import asyncio
 import json
+import logging
 import math
+import signal
+from contextlib import suppress
 from pathlib import Path
 from typing import List
 
@@ -19,28 +22,98 @@ sys.path.append(str(PROTO_DIR))
 import predict_pb2  # type: ignore
 import predict_pb2_grpc  # type: ignore
 
+from botcopier.exceptions import ModelError, ServiceError
+
 BASE_DIR = Path(__file__).resolve().parent.parent
 DEFAULT_MODEL_PATH = BASE_DIR / "model.json"
 
+MODEL: dict = {"entry_coefficients": [], "entry_intercept": 0.0}
+COEFFS: List[float] = []
+INTERCEPT: float = 0.0
+
+logger = logging.getLogger(__name__)
+
 
 def _load_model(path: Path) -> dict:
+    """Load a JSON model specification from ``path``."""
+
     try:
         with path.open("r", encoding="utf-8") as fh:
-            return json.load(fh)
-    except FileNotFoundError:
-        return {"feature_names": [], "entry_coefficients": [], "entry_intercept": 0.0}
+            model = json.load(fh)
+    except FileNotFoundError as exc:  # pragma: no cover - defensive guard
+        raise ModelError(f"Model file not found: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise ModelError(f"Model file is not valid JSON: {path}") from exc
+    except OSError as exc:  # pragma: no cover - defensive guard
+        raise ModelError(f"Unable to read model file: {path}") from exc
+
+    if not isinstance(model, dict):
+        raise ModelError(f"Model payload must be a JSON object: {path}")
+    return model
 
 
-MODEL = _load_model(DEFAULT_MODEL_PATH)
-COEFFS: List[float] = [float(x) for x in MODEL.get("entry_coefficients", [])]
-INTERCEPT: float = float(MODEL.get("entry_intercept", 0.0))
+def _reload_model(path: Path) -> None:
+    """Refresh global model parameters from ``path``."""
+
+    global MODEL, COEFFS, INTERCEPT
+    model = _load_model(path)
+    MODEL = model
+    COEFFS = [float(x) for x in model.get("entry_coefficients", [])]
+    INTERCEPT = float(model.get("entry_intercept", 0.0))
+    logger.info(
+        "model_loaded",
+        extra={
+            "context": {
+                "coefficients": len(COEFFS),
+                "intercept": INTERCEPT,
+                "path": str(path),
+            }
+        },
+    )
 
 
 def _predict_one(features: List[float]) -> float:
+    """Compute the logistic score for ``features``."""
+
     if len(features) != len(COEFFS):
-        raise ValueError("feature length mismatch")
+        raise ServiceError("feature length mismatch")
     score = sum(c * f for c, f in zip(COEFFS, features)) + INTERCEPT
     return 1.0 / (1.0 + math.exp(-score))
+
+
+def _build_server(host: str, port: int) -> grpc.Server:
+    server = grpc.server()
+    predict_pb2_grpc.add_PredictServiceServicer_to_server(_PredictService(), server)
+    server.add_insecure_port(f"{host}:{port}")
+    return server
+
+
+class _ServerManager:
+    """Async context manager ensuring the gRPC server is stopped."""
+
+    def __init__(self, host: str, port: int) -> None:
+        self._host = host
+        self._port = port
+        self.server: grpc.Server | None = None
+        self.stopped = False
+
+    async def __aenter__(self) -> grpc.Server:
+        server = _build_server(self._host, self._port)
+        await server.start()
+        logger.info(
+            "server_started",
+            extra={"context": {"host": self._host, "port": self._port}},
+        )
+        self.server = server
+        return server
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        if self.server and not self.stopped:
+            await self.server.stop(None)
+        logger.info(
+            "server_stopped",
+            extra={"context": {"host": self._host, "port": self._port}},
+        )
 
 
 class _PredictService(predict_pb2_grpc.PredictServiceServicer):
@@ -48,21 +121,83 @@ class _PredictService(predict_pb2_grpc.PredictServiceServicer):
         try:
             pred = _predict_one(list(request.features))
             return predict_pb2.PredictResponse(prediction=pred)
-        except ValueError as exc:
+        except ServiceError as exc:
+            logger.exception(
+                "prediction_failed",
+                extra={
+                    "context": {
+                        "feature_count": len(request.features),
+                        "error": str(exc),
+                    }
+                },
+            )
             await context.abort(grpc.StatusCode.INVALID_ARGUMENT, str(exc))
+        except Exception as exc:  # pragma: no cover - defensive guard
+            logger.exception(
+                "prediction_internal_error",
+                extra={
+                    "context": {
+                        "feature_count": len(request.features),
+                        "error": str(exc),
+                    }
+                },
+            )
+            await context.abort(grpc.StatusCode.INTERNAL, "internal error")
 
 
 async def create_server(host: str, port: int) -> grpc.Server:
-    server = grpc.server()
-    predict_pb2_grpc.add_PredictServiceServicer_to_server(_PredictService(), server)
-    server.add_insecure_port(f"{host}:{port}")
+    server = _build_server(host, port)
     await server.start()
+    logger.info(
+        "server_started",
+        extra={"context": {"host": host, "port": port}},
+    )
     return server
 
 
-async def serve(host: str, port: int) -> None:
-    server = await create_server(host, port)
-    await server.wait_for_termination()
+async def serve(
+    host: str,
+    port: int,
+    *,
+    shutdown_event: asyncio.Event | None = None,
+) -> None:
+    loop = asyncio.get_running_loop()
+    stop_event = shutdown_event or asyncio.Event()
+    registered: list[signal.Signals] = []
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        try:
+            loop.add_signal_handler(sig, stop_event.set)
+            registered.append(sig)
+        except NotImplementedError:  # pragma: no cover - platform specific
+            continue
+
+    manager = _ServerManager(host, port)
+    try:
+        async with manager as server:
+            wait_task = asyncio.create_task(server.wait_for_termination())
+            stop_task = asyncio.create_task(stop_event.wait())
+            try:
+                done, _ = await asyncio.wait(
+                    {wait_task, stop_task}, return_when=asyncio.FIRST_COMPLETED
+                )
+                if stop_task in done and not wait_task.done():
+                    logger.info(
+                        "shutdown_requested",
+                        extra={"context": {"host": host, "port": port}},
+                    )
+                    await server.stop(None)
+                    manager.stopped = True
+                await wait_task
+                manager.stopped = True
+            finally:
+                for task in (wait_task, stop_task):
+                    if not task.done():
+                        task.cancel()
+                        with suppress(asyncio.CancelledError):
+                            await task
+    finally:
+        for sig in registered:
+            loop.remove_signal_handler(sig)
 
 
 async def async_main() -> None:
@@ -72,10 +207,13 @@ async def async_main() -> None:
     parser.add_argument("--model", type=Path, default=DEFAULT_MODEL_PATH)
     args = parser.parse_args()
 
-    global MODEL, COEFFS, INTERCEPT
-    MODEL = _load_model(args.model)
-    COEFFS = [float(x) for x in MODEL.get("entry_coefficients", [])]
-    INTERCEPT = float(MODEL.get("entry_intercept", 0.0))
+    try:
+        _reload_model(args.model)
+    except ModelError:
+        logger.exception(
+            "model_load_failed", extra={"context": {"path": str(args.model)}}
+        )
+        raise SystemExit(1) from None
 
     await serve(args.host, args.port)
 

--- a/tests/test_grpc_predict_server.py
+++ b/tests/test_grpc_predict_server.py
@@ -1,9 +1,14 @@
 import asyncio
+import logging
 import math
+import socket
 from pathlib import Path
 import sys
 
-import grpc
+import pytest
+
+grpc_mod = pytest.importorskip("grpc")
+from grpc import aio as grpc_aio
 
 # Import generated proto modules
 PROTO_DIR = Path(__file__).resolve().parents[1] / "proto"
@@ -14,6 +19,14 @@ import predict_pb2_grpc  # type: ignore
 from botcopier.scripts import grpc_predict_server as gps
 
 
+def _free_port() -> int:
+    sock = socket.socket()
+    sock.bind(("127.0.0.1", 0))
+    port = sock.getsockname()[1]
+    sock.close()
+    return port
+
+
 def test_grpc_round_trip():
     model = {"entry_coefficients": [0.5, -0.25], "entry_intercept": 0.1}
     gps.MODEL = model
@@ -21,8 +34,9 @@ def test_grpc_round_trip():
     gps.INTERCEPT = 0.1
 
     async def _run() -> None:
-        server = await gps.create_server("127.0.0.1", 50070)
-        async with grpc.aio.insecure_channel("127.0.0.1:50070") as channel:
+        port = _free_port()
+        server = await gps.create_server("127.0.0.1", port)
+        async with grpc_aio.insecure_channel(f"127.0.0.1:{port}") as channel:
             stub = predict_pb2_grpc.PredictServiceStub(channel)
             req = predict_pb2.PredictRequest(features=[1.0, 2.0])
             resp = await stub.Predict(req)
@@ -31,3 +45,62 @@ def test_grpc_round_trip():
         assert math.isclose(resp.prediction, expected)
 
     asyncio.run(_run())
+
+
+@pytest.mark.asyncio
+async def test_grpc_invalid_features_logged(caplog):
+    gps.COEFFS = [0.5, -0.25]
+    gps.INTERCEPT = 0.0
+    caplog.set_level(logging.ERROR)
+
+    port = _free_port()
+    server = await gps.create_server("127.0.0.1", port)
+    try:
+        async with grpc_aio.insecure_channel(f"127.0.0.1:{port}") as channel:
+            stub = predict_pb2_grpc.PredictServiceStub(channel)
+            with pytest.raises(grpc_aio.AioRpcError) as excinfo:
+                await stub.Predict(predict_pb2.PredictRequest(features=[1.0]))
+        assert excinfo.value.code() == grpc_mod.StatusCode.INVALID_ARGUMENT
+    finally:
+        await server.stop(None)
+
+    messages = " ".join(record.getMessage() for record in caplog.records)
+    assert "prediction_failed" in messages
+
+
+@pytest.mark.asyncio
+async def test_serve_shutdown_event_triggers_stop(monkeypatch):
+    shutdown_event = asyncio.Event()
+
+    class DummyServer:
+        def __init__(self) -> None:
+            self._terminated = asyncio.Event()
+            self.stop_called = False
+            self.wait_called = False
+
+        def add_insecure_port(self, address: str) -> None:  # pragma: no cover - helper
+            self.address = address
+
+        async def start(self) -> None:
+            return None
+
+        async def wait_for_termination(self) -> None:
+            self.wait_called = True
+            await self._terminated.wait()
+
+        async def stop(self, grace) -> None:
+            self.stop_called = True
+            self._terminated.set()
+
+    dummy = DummyServer()
+    monkeypatch.setattr(gps, "_build_server", lambda host, port: dummy)
+
+    serve_task = asyncio.create_task(
+        gps.serve("127.0.0.1", 50072, shutdown_event=shutdown_event)
+    )
+    await asyncio.sleep(0.05)
+    shutdown_event.set()
+    await asyncio.wait_for(serve_task, timeout=1.0)
+
+    assert dummy.stop_called
+    assert dummy.wait_called


### PR DESCRIPTION
## Summary
- Refactored the gRPC prediction service to load models safely, emit structured logging, and wrap prediction errors in custom exceptions while managing the server lifecycle with a context manager and signal-aware shutdown.
- Added asynchronous tests that validate logging on invalid feature input and ensure the service stops cleanly when a shutdown event is triggered, using dynamically allocated ports and a dummy server stub.

## Testing
- ⚠️ `pytest tests/test_grpc_predict_server.py` *(skipped: grpc dependency not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c839bdd674832fb2fb11d06e87e7b9