### PR TITLE
docs: expand tutorials and diagrams

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.x'
-      - run: pip install mkdocs mkdocstrings[python]
+      - run: pip install mkdocs mkdocstrings[python] pymdown-extensions plantuml-markdown
       - run: mkdocs build --site-dir site
       - uses: actions/upload-pages-artifact@v1
         with:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,22 +1,95 @@
 # System Architecture
 
-The system consists of modular components for ingesting data, training models and deploying strategies.
+BotCopier is organised as a set of cooperating services that ingest market
+data, produce enriched features, train candidate models, and finally deploy the
+most promising strategy. The following diagrams provide both high-level and
+operational views using Mermaid and PlantUML so the topology can be explored in
+multiple notations.
+
+## High-level Pipeline (Mermaid)
 
 ```mermaid
 flowchart TB
-    logs[Log Ingestion] --> collector[OTel Collector]
-    collector --> pipeline[Processing Pipeline]
-    pipeline --> registry[(Model Registry)]
-    registry --> deploy[Strategy Deployment]
+    subgraph ingest[Data Ingestion]
+        logs[Exchange Logs]
+        metrics[Metrics Stream]
+    end
+    subgraph enrich[Feature Engineering]
+        cache[Feature Cache]
+        registry[(Feature Registry)]
+    end
+    subgraph train[Training & Evaluation]
+        trainer[AutoML Controller]
+        scoring[Risk & Metric Scoring]
+    end
+    subgraph deploy[Deployment]
+        registryModels[(Model Registry)]
+        orchestrator[Strategy Orchestrator]
+        traders[Live Trading Bots]
+    end
+
+    logs --> ingest
+    metrics --> ingest
+    ingest --> enrich
+    enrich --> train
+    train --> registryModels
+    registryModels --> orchestrator --> traders
 ```
 
-## Deployment Topology
+## Observability and Feedback Loops (Mermaid)
 
 ```mermaid
 flowchart LR
-    registry[(Model Registry)] --> service[Deployment Service]
-    service --> trader[Trading Bot]
-    service --> monitor[Monitoring]
+    subgraph observability[Observability Stack]
+        prom[Prometheus Metrics]
+        otel[OpenTelemetry Collector]
+        grafana[Grafana Dashboards]
+    end
+    trader[Trading Bot] --> prom
+    trader --> otel
+    otel --> grafana
+    prom --> grafana
+    grafana -->|Alerts| oncall[On-call Rotation]
+    oncall -->|Feedback| trainer[AutoML Controller]
 ```
 
-See the [Data Flow](data_flow.md) page for a step-by-step walkthrough from ingestion to deployment.
+These feedback loops ensure that human operators can intervene quickly if a
+strategy drifts away from acceptable behaviour. The [Data Flow](data_flow.md)
+page provides an even more detailed walkthrough from ingestion to deployment.
+
+## Deployment Topology (PlantUML)
+
+```plantuml
+@startuml
+skinparam componentStyle rectangle
+actor Trader
+actor Analyst
+
+rectangle "Inference Plane" {
+  component "REST API" as Rest
+  component "gRPC Stream" as Grpc
+  component "Prediction Router" as Router
+}
+
+rectangle "Control Plane" {
+  component "Model Registry" as Registry
+  component "Pipeline Scheduler" as Scheduler
+  component "Feature Store" as FeatureStore
+}
+
+Trader --> Router
+Router --> Rest
+Router --> Grpc
+Rest --> Registry
+Grpc --> Registry
+Scheduler --> Registry
+Scheduler --> FeatureStore
+Analyst --> Scheduler
+FeatureStore --> Router : feature snapshots
+@enduml
+```
+
+This diagram highlights the control plane components that coordinate model
+lifecycle management separately from the low-latency inference services. The
+PlantUML and Mermaid variants use the same naming so teams familiar with either
+notation can collaborate without friction.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,14 +1,55 @@
 # Contributing
 
-Thank you for your interest in improving BotCopier.
+Thank you for your interest in improving BotCopier. This guide explains how to
+set up a development environment, follow the project standards, and validate
+changes before opening a pull request.
+
+## Development Workflow
+
+1. Fork the repository and create a feature branch.
+2. Install the development dependencies described in
+   [Getting Started](getting_started.md).
+3. Keep the documentation up to date. When you add a new module or CLI command,
+   document it and expose the API using the mkdocstrings directives in
+   ``docs/api.md``.
+
+## Coding Standards
+
+* Review the [coding standards](coding_standards.md) document for naming,
+  structure, and typing expectations.
+* Prefer small, focused commits with descriptive messages.
+* Run ``ruff`` or ``flake8`` locally if you have them installed; the CI will
+  enforce linting on every push.
+
+## Testing Checklist
 
 Before submitting a pull request:
 
-1. Review the [coding standards](coding_standards.md).
-2. Run all [tests](testing.md) and ensure they pass.
-3. Use `pre-commit` to apply formatting and static analysis:
+1. Run the automated tests:
+   ```bash
+   pytest
+   ```
+2. Execute representative smoke tests against the sample data to ensure the
+   pipeline still succeeds end-to-end:
+   ```bash
+   python -m botcopier.training.pipeline /tmp/botcopier-sample ./artifacts --trials 2
+   ```
+3. Build the documentation and ensure no warnings are emitted:
+   ```bash
+   mkdocs build
+   ```
+4. Use ``pre-commit`` to apply formatting and static analysis:
    ```bash
    pre-commit run --all-files
    ```
 
-Please open an issue for major changes so we can discuss the approach.
+## Opening a Pull Request
+
+* Provide a concise summary of the change, referencing any related issues.
+* Include screenshots or terminal output when altering dashboards or CLI
+  behaviour.
+* Double-check that ``.github/workflows/docs.yml`` succeeds locally if your
+  changes touch the documentation configuration.
+
+Please open an issue for major changes so we can discuss the approach and align
+on deliverables before large investments of time.

--- a/docs/end_to_end_pipeline.md
+++ b/docs/end_to_end_pipeline.md
@@ -1,0 +1,89 @@
+# End-to-End Pipeline Tutorial
+
+This tutorial walks through the entire BotCopier pipeline using the bundled
+sample data. You will load raw trades, engineer features, train a model, and
+publish the resulting artefacts.
+
+## Prerequisites
+
+* A working environment configured according to
+  [Getting Started](getting_started.md).
+* Sample data copied into ``/tmp/botcopier-sample`` as described below.
+
+## 1. Prepare the Data Directory
+
+The training pipeline expects a directory containing ``trades_raw.csv`` (and
+optionally ``depth_raw.csv``). Copy the sample CSV provided with the repository:
+
+```bash
+mkdir -p /tmp/botcopier-sample
+cp tests/fixtures/trades_small.csv /tmp/botcopier-sample/trades_raw.csv
+```
+
+## 2. Run the Training Pipeline
+
+Invoke the pipeline with an output directory for artefacts:
+
+```bash
+python -m botcopier.training.pipeline /tmp/botcopier-sample ./tutorial-run \
+  --model-type logreg \
+  --metrics accuracy f1 sharpe \
+  --random-seed 7 \
+  --trials 5
+```
+
+Key artefacts produced in ``./tutorial-run``:
+
+* ``model.json`` – serialised model parameters registered for deployment.
+* ``metrics.json`` – summary of evaluation metrics requested via ``--metrics``.
+* ``model_card.md`` – human-readable description of the experiment.
+* ``dependencies.txt`` – frozen Python environment used during the run.
+
+## 3. Inspect Feature Engineering Outputs
+
+Intermediate feature sets are cached under ``./tutorial-run/cache`` when a cache
+backend is configured. The tutorial run uses the in-memory cache, but you can
+persist features by exporting the ``TRAINING_CACHE_DIR`` environment variable:
+
+```bash
+export TRAINING_CACHE_DIR=./tutorial-run/cache
+python -m botcopier.training.pipeline /tmp/botcopier-sample ./tutorial-run --reuse-controller
+```
+
+With caching enabled subsequent runs reuse feature computations and focus on
+model search.
+
+## 4. Promote the Model to the Registry
+
+Successful runs automatically write the model artefacts into the registry path
+configured by ``TRAINING_MODEL`` (defaults to ``model.json`` in the output
+folder). To promote the model to a shared registry, copy the artefact into the
+``models/`` directory or publish it to your remote storage bucket:
+
+```bash
+cp ./tutorial-run/model.json models/tutorial_logreg.json
+```
+
+Update ``params.yaml`` or environment variables to point inference services to
+this artefact.
+
+## 5. Verify the Deployment Pipeline
+
+Run the lightweight inference smoke test to ensure the exported model can be
+loaded:
+
+```bash
+python -m botcopier.models.registry --list
+python -m botcopier.models.registry --load models/tutorial_logreg.json
+```
+
+These commands use the API definitions referenced in ``docs/api.md``, ensuring
+mkdocstrings-generated documentation stays aligned with the actual code.
+
+## Troubleshooting Tips
+
+* Use ``--profile`` to enable cProfile if you need performance diagnostics.
+* Set ``--trace`` and ``--trace-exporter=jaeger`` to integrate with the
+  OpenTelemetry collector defined in ``docs/otel-collector.yaml``.
+* Increase ``--trials`` for a more exhaustive Optuna search when working with
+  larger datasets.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -1,29 +1,71 @@
 # Getting Started
 
-Follow these steps to set up the BotCopier project locally.
+Follow these steps to set up the BotCopier project locally and run a complete
+pipeline against the bundled sample data.
+
+## Prerequisites
+
+* Python 3.9 or newer.
+* A virtual environment (``venv`` or ``conda``) is strongly recommended.
+* Optional: Docker if you plan to run the observability stack defined in
+  ``docs/docker-compose.yml``.
 
 ## Installation
+
 1. Clone the repository and change into the directory.
-2. Install dependencies:
+2. Create and activate a virtual environment.
+3. Install dependencies:
    ```bash
    pip install -r requirements.txt
    ```
-   Training runs snapshot the environment to `dependencies.txt` in their output
+4. Install the documentation toolchain (needed for MkDocs builds):
+   ```bash
+   pip install "mkdocs>=1.5" "mkdocstrings[python]" "pymdown-extensions"
+   ```
+   Training runs snapshot the environment to ``dependencies.txt`` in their output
    directories. Reinstall from this file to reproduce the exact package
    versions:
    ```bash
    pip install -r dependencies.txt
    ```
 
+## Using the Sample Data
+
+A compact CSV sample is provided at ``tests/fixtures/trades_small.csv``. Create a
+working directory with the expected filenames:
+
+```bash
+mkdir -p /tmp/botcopier-sample
+cp tests/fixtures/trades_small.csv /tmp/botcopier-sample/trades_raw.csv
+```
+
+You can now execute the training pipeline end-to-end:
+
+```bash
+python -m botcopier.training.pipeline /tmp/botcopier-sample ./artifacts \
+  --model-type logreg \
+  --metrics accuracy f1 \
+  --random-seed 123
+```
+
+The pipeline writes model checkpoints, evaluation metrics, and a model card into
+``./artifacts``. Inspect ``artifacts/model_card.md`` for a human readable
+summary of the run.
+
 ## Documentation
+
 Build the documentation locally with:
 ```bash
 mkdocs serve
 ```
-This launches a local server with live reload.
+This launches a local server with live reload. To produce the static site that
+is uploaded in CI, run ``mkdocs build``.
 
 ## Running Tests
+
 Execute the test suite to ensure everything is working:
 ```bash
 pytest
 ```
+Consider running ``pytest -m slow`` periodically to exercise the more
+computationally expensive integration tests.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,8 +17,11 @@ nav:
       - Feature Plugins: feature_plugins.md
   - Tutorials:
       - Data Loading and Feature Engineering: data_loading_tutorial.md
+      - End-to-End Pipeline: end_to_end_pipeline.md
 markdown_extensions:
   - admonition
   - pymdownx.superfences
+  - plantuml_markdown:
+      server: https://www.plantuml.com/plantuml
 plugins:
   - mkdocstrings


### PR DESCRIPTION
## Summary
- expand the architecture guide with additional Mermaid and PlantUML diagrams to visualise the system
- enrich the getting started and contributing guides and add a new end-to-end pipeline tutorial using sample data
- update MkDocs configuration and docs CI workflow to support PlantUML rendering

## Testing
- mkdocs build

------
https://chatgpt.com/codex/tasks/task_e_68c83cc7fd38832fbe90317afaf2e87d