### PR TITLE
Refactor training wrapper exports to package modules

### DIFF
--- a/botcopier/scripts/detect_regime.py
+++ b/botcopier/scripts/detect_regime.py
@@ -22,11 +22,7 @@ except Exception:  # pragma: no cover - optional
     hdbscan = None
 
 from botcopier.data.loading import _load_calendar, _load_logs
-
-try:
-    from scripts.features import _extract_features  # type: ignore
-except Exception:
-    from features import _extract_features  # type: ignore
+from botcopier.features.engineering import _extract_features
 
 
 def detect_regimes(

--- a/tests/test_candlestick_patterns.py
+++ b/tests/test_candlestick_patterns.py
@@ -6,7 +6,7 @@ import pandas as pd
 import botcopier.features.engineering as fe
 from botcopier.features.engineering import FeatureConfig, clear_cache, configure_cache
 from botcopier.features.technical import _extract_features
-from scripts.features import _extract_features as extract_rows_features
+from botcopier.features.engineering import _extract_features as extract_rows_features
 
 
 def _synthetic_rows():

--- a/tests/test_end_to_end_pipeline.py
+++ b/tests/test_end_to_end_pipeline.py
@@ -2,7 +2,7 @@ from datetime import datetime
 
 from sklearn.feature_extraction import DictVectorizer
 
-from scripts.features import _extract_features
+from botcopier.features.engineering import _extract_features
 from scripts.model_fitting import fit_logistic_regression
 from scripts.evaluation import evaluate_model
 

--- a/tests/test_features_module.py
+++ b/tests/test_features_module.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from scripts.features import _extract_features
+from botcopier.features.engineering import _extract_features
 
 
 def test_extract_features_basic():

--- a/train_target_clone.py
+++ b/train_target_clone.py
@@ -2,16 +2,27 @@
 
 This script exists for historical compatibility.  The implementation
 moved into the :mod:`botcopier` package and is re-exported here so that
-older entry points continue to function.
+older entry points continue to function.  To preserve the legacy public
+API we re-export the training helpers that previously lived directly in
+this module.
 """
 from __future__ import annotations
 
 import argparse
 
+from botcopier.data.loading import _load_logs
+from botcopier.features.engineering import _extract_features
 from botcopier.models.registry import TabTransformer
-from botcopier.training.pipeline import detect_resources, run_optuna
+from botcopier.training.pipeline import detect_resources, run_optuna, train
 
-__all__ = ["run_optuna", "TabTransformer", "detect_resources"]
+__all__ = [
+    "train",
+    "_load_logs",
+    "_extract_features",
+    "run_optuna",
+    "TabTransformer",
+    "detect_resources",
+]
 
 
 if __name__ == "__main__":  # pragma: no cover - CLI entry


### PR DESCRIPTION
## Summary
- re-export training helpers from the legacy `train_target_clone` CLI so code depending on the old module path still works
- update the detect_regime utility to pull feature extraction from the `botcopier` package modules
- switch unit tests to import `_extract_features` from `botcopier.features.engineering`

## Testing
- `pytest tests/test_features_module.py::test_extract_features_basic` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68c84b0dd1fc832fa308dc52286d8799