### PR TITLE
Add time-decay sample weighting with CLI controls

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -85,6 +85,8 @@ class TrainingConfig(BaseSettings):
     random_seed: int = 0
     online_model: str = "sgd"
     grad_clip: float = 1.0
+    half_life_days: float = 0.0
+    vol_weight: bool = False
     eval_hooks: List[str] = []
     hrp_allocation: bool = False
     strategy_search: bool = False

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -355,6 +355,16 @@
           "title": "Grad Clip",
           "type": "number"
         },
+        "half_life_days": {
+          "default": 0.0,
+          "title": "Half Life Days",
+          "type": "number"
+        },
+        "vol_weight": {
+          "default": false,
+          "title": "Vol Weight",
+          "type": "boolean"
+        },
         "eval_hooks": {
           "default": [],
           "items": {

--- a/tests/test_train_target_clone_half_life.py
+++ b/tests/test_train_target_clone_half_life.py
@@ -1,5 +1,7 @@
 import json
 
+import pytest
+
 from botcopier.training.pipeline import train
 
 
@@ -14,6 +16,9 @@ def test_half_life_recorded(tmp_path):
     train(data, out_dir, half_life_days=1.0)
     model = json.loads((out_dir / "model.json").read_text())
     assert model["half_life_days"] == 1.0
+    stats = model.get("sample_weight_stats")
+    assert stats is not None
+    assert stats["mean"] == pytest.approx(1.0)
 
 
 def test_decay_weighting_changes_coefficients(tmp_path):
@@ -37,3 +42,31 @@ def test_decay_weighting_changes_coefficients(tmp_path):
         "asian"
     ]["coefficients"]
     assert any(abs(a - b) > 1e-6 for a, b in zip(coeffs1, coeffs2))
+
+
+def test_vol_weighting_changes_coefficients(tmp_path):
+    data = tmp_path / "trades_raw.csv"
+    rows = [
+        "event_time,price,profit\n",
+        "2024-01-01,0.0,1.0\n",
+        "2024-01-02,1.0,-1.0\n",
+        "2024-01-03,2.0,5.0\n",
+        "2024-01-04,3.0,-0.5\n",
+    ]
+    data.write_text("".join(rows))
+
+    base_out = tmp_path / "base"
+    train(data, base_out)
+    coeffs_base = json.loads((base_out / "model.json").read_text())["session_models"][
+        "asian"
+    ]["coefficients"]
+
+    vol_out = tmp_path / "vol"
+    train(data, vol_out, vol_weight=True)
+    model_vol = json.loads((vol_out / "model.json").read_text())
+    coeffs_vol = model_vol["session_models"]["asian"]["coefficients"]
+    assert any(abs(a - b) > 1e-6 for a, b in zip(coeffs_base, coeffs_vol))
+
+    stats = model_vol.get("sample_weight_stats")
+    assert stats is not None
+    assert stats["mean"] == pytest.approx(1.0)


### PR DESCRIPTION
## Summary
- compute sample weights from profits with optional time-decay and volatility scaling, then normalise before fitting
- log sample-weight statistics, persist them in model metadata, and expose CLI/config flags for half-life and volatility weighting
- handle very small datasets more defensively and add tests covering the new weighting behaviour

## Testing
- pytest tests/test_train_target_clone_half_life.py -q

------
https://chatgpt.com/codex/tasks/task_e_68c8817ab2e8832fb7bbfbf0884a1969