### PR TITLE
Enhance evaluation metrics and threshold optimisation

### DIFF
--- a/tests/test_target_clone_cross_validation.py
+++ b/tests/test_target_clone_cross_validation.py
@@ -20,11 +20,22 @@ def test_cross_validation_metrics_written(tmp_path: Path) -> None:
     out_dir = tmp_path / "out"
     train(data, out_dir)
     model = json.loads((out_dir / "model.json").read_text())
+    assert "cv_metrics" in model
+    assert "threshold" in model
     assert "cv_accuracy" in model and "cv_profit" in model
     assert "conformal_lower" in model and "conformal_upper" in model
+    cv_metrics = model["cv_metrics"]
+    assert cv_metrics["threshold_objective"] == "profit"
+    assert cv_metrics["threshold"] == pytest.approx(model["threshold"])
+    assert "brier_score" in cv_metrics
+    assert "sharpe_ratio" in cv_metrics
     for params in model["session_models"].values():
         assert params["cv_metrics"]
         assert "conformal_lower" in params and "conformal_upper" in params
+        assert params["threshold"] == pytest.approx(model["threshold"])
+        assert "metrics" in params
+        assert params["metrics"]["threshold"] == pytest.approx(model["threshold"])
+        assert "brier_score" in params["metrics"]
         for fm in params["cv_metrics"]:
             assert "accuracy" in fm and "profit" in fm
 

--- a/tests/test_train_target_clone_validation.py
+++ b/tests/test_train_target_clone_validation.py
@@ -69,6 +69,8 @@ def test_threshold_selected_by_profit(tmp_path: Path) -> None:
     model = json.loads((out_dir / "model.json").read_text())
     params = model["session_models"]["asian"]
     assert params["threshold"] == pytest.approx(0.0)
+    assert model["threshold"] == pytest.approx(params["threshold"])
+    assert model["cv_metrics"]["threshold"] == pytest.approx(params["threshold"])
     assert params["metrics"]["profit"] == pytest.approx(1.5)
     assert "sharpe_ratio" in params["metrics"]
     assert "sortino_ratio" in params["metrics"]


### PR DESCRIPTION
## Summary
- compute Sharpe/Sortino ratios, max drawdown and net VaR directly in the evaluation pipeline alongside calibration metrics
- extend cross-validation to grid-search decision thresholds, persist aggregated metrics/thresholds in model.json and expose predict_expected_value
- update regression tests to assert recorded metrics and threshold settings

## Testing
- pytest tests/test_evaluate.py tests/test_evaluation_module.py tests/test_target_clone_cross_validation.py

------
https://chatgpt.com/codex/tasks/task_e_68c896b24b38832f866579cb1cb02cf3