### PR TITLE
Vectorize feature engineering and evaluation workflows

### DIFF
--- a/botcopier/features/engineering.py
+++ b/botcopier/features/engineering.py
@@ -6,8 +6,20 @@ from contextlib import contextmanager
 from dataclasses import dataclass, field
 from functools import wraps
 from pathlib import Path
+from typing import Iterable, Sequence, TYPE_CHECKING
 
-from joblib import Memory
+from joblib import Memory, Parallel, delayed
+
+try:  # optional polars dependency
+    import polars as pl  # type: ignore
+
+    _HAS_POLARS = True
+except Exception:  # pragma: no cover - optional import
+    pl = None  # type: ignore
+    _HAS_POLARS = False
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    import pandas as pd
 
 from ..scripts.features import KALMAN_DEFAULT_PARAMS
 from . import anomaly as _anomaly
@@ -22,6 +34,7 @@ class FeatureConfig:
     cache_dir: Path | str | None = None
     kalman_params: dict = field(default_factory=lambda: KALMAN_DEFAULT_PARAMS.copy())
     enabled_features: set[str] = field(default_factory=set)
+    n_jobs: int | None = None
 
     def is_enabled(self, flag: str) -> bool:
         return flag in self.enabled_features
@@ -44,6 +57,142 @@ class FeatureConfig:
 _CONFIG = FeatureConfig()
 _MEMORY = Memory(None, verbose=0)
 _FEATURE_RESULTS: dict[int, tuple] = {}
+
+
+def _resolve_n_jobs(n_jobs: int | None) -> int:
+    """Return an effective ``n_jobs`` respecting global configuration."""
+
+    configured = _CONFIG.n_jobs if _CONFIG.n_jobs is not None else 1
+    effective = n_jobs if n_jobs is not None else configured
+    if not effective or effective <= 1:
+        return 1
+    return int(effective)
+
+
+def _clone_frame(df):
+    """Create a shallow copy of ``df`` preserving the backend."""
+
+    clone = getattr(df, "clone", None)
+    if callable(clone):  # polars offers ``clone``
+        return clone()
+    copy = getattr(df, "copy", None)
+    if callable(copy):
+        try:
+            return copy(deep=False)
+        except TypeError:  # pragma: no cover - some backends lack ``deep`` keyword
+            return copy()
+    return df
+
+
+def _to_pandas_with_converter(df):
+    """Return ``df`` as pandas along with a converter to the original type."""
+
+    try:
+        import pandas as pd  # type: ignore
+    except Exception as exc:  # pragma: no cover - optional dependency missing
+        raise ImportError("pandas is required for feature engineering") from exc
+
+    if _HAS_POLARS and pl is not None and isinstance(df, pl.DataFrame):
+        return df.to_pandas(), pl.from_pandas  # type: ignore[arg-type]
+    if isinstance(df, pd.DataFrame):
+        return df, lambda data: data
+    # Fallback: attempt to coerce via pandas constructor
+    return pd.DataFrame(df), lambda data: data
+
+
+def _merge_feature_frames(
+    base_df,
+    feature_names: Sequence[str],
+    plugin_results: Sequence[tuple[str, object, Sequence[str]]],
+):
+    """Merge plugin outputs with ``base_df`` using vectorised dataframe ops."""
+
+    if not plugin_results:
+        return base_df, list(feature_names)
+
+    import pandas as pd  # type: ignore
+
+    base_pdf, to_original = _to_pandas_with_converter(base_df)
+    frames: list[pd.DataFrame] = [base_pdf]
+    feature_sequences: list[Sequence[str]] = []
+    for _, plugin_df, plugin_features in plugin_results:
+        plugin_pdf, _ = _to_pandas_with_converter(plugin_df)
+        frames.append(plugin_pdf)
+        feature_sequences.append(plugin_features)
+
+    merged_pdf = pd.concat(frames, axis=1)
+    merged_pdf = merged_pdf.loc[:, ~merged_pdf.columns.duplicated(keep="last")]
+
+    seen = set(feature_names)
+    merged_features = list(feature_names)
+    for names in feature_sequences:
+        for name in names:
+            if name not in seen:
+                merged_features.append(name)
+                seen.add(name)
+
+    return to_original(merged_pdf), merged_features
+
+
+def _apply_parallel_plugins(
+    df,
+    feature_names: Sequence[str],
+    plugin_names: Sequence[str],
+    *,
+    kwargs: dict,
+    n_jobs: int | None = None,
+    calendar_executed: bool = False,
+):
+    """Execute ``plugin_names`` possibly in parallel and merge their outputs."""
+
+    if not plugin_names:
+        return df, list(feature_names), {}, {}
+
+    from .registry import FEATURE_REGISTRY
+
+    effective_jobs = _resolve_n_jobs(n_jobs)
+    tasks: list[tuple[str, object, dict]] = []
+    for name in plugin_names:
+        func = FEATURE_REGISTRY.get(name)
+        if func is None:
+            continue
+        plugin_kwargs = dict(kwargs)
+        if name == "technical" and calendar_executed:
+            plugin_kwargs["calendar_features"] = False
+        tasks.append((name, func, plugin_kwargs))
+
+    if not tasks:
+        return df, list(feature_names), {}, {}
+
+    def _execute(task: tuple[str, object, dict]):
+        name, func, plugin_kwargs = task
+        local_df = _clone_frame(df)
+        local_features = list(feature_names)
+        result_df, result_features, emb, gnn = func(
+            local_df, local_features, **plugin_kwargs
+        )
+        return name, result_df, result_features, emb or {}, gnn or {}
+
+    if effective_jobs <= 1 or len(tasks) == 1:
+        results = [_execute(task) for task in tasks]
+    else:
+        results = Parallel(n_jobs=effective_jobs, prefer="threads")(
+            delayed(_execute)(task) for task in tasks
+        )
+
+    merged_df, merged_features = _merge_feature_frames(
+        df,
+        feature_names,
+        [(name, res_df, res_features) for name, res_df, res_features, _, _ in results],
+    )
+
+    embeddings: dict[str, list[float]] = {}
+    gnn_state: dict[str, list[list[float]]] = {}
+    for _, _, _, emb, gnn in results:
+        embeddings.update(emb)
+        gnn_state.update(gnn)
+
+    return merged_df, merged_features, embeddings, gnn_state
 
 
 def configure_cache(config: FeatureConfig) -> None:
@@ -94,7 +243,9 @@ def _augment_dtw_dataframe(*args, **kwargs):
 
 
 def _extract_features(*args, **kwargs):
-    return _technical._extract_features(*args, **kwargs)
+    call_kwargs = dict(kwargs)
+    call_kwargs.setdefault("n_jobs", _CONFIG.n_jobs)
+    return _technical._extract_features(*args, **call_kwargs)
 
 
 def _neutralize_against_market_index(*args, **kwargs):

--- a/tests/performance/test_benchmarks.py
+++ b/tests/performance/test_benchmarks.py
@@ -1,7 +1,14 @@
 from pathlib import Path
 
+import numpy as np
+import pandas as pd
+import pytest
+
+pytest.importorskip("pytest_benchmark")
+
 from botcopier.data.loading import _load_logs
 from botcopier.features.engineering import _extract_features
+from botcopier.scripts.evaluation import evaluate
 
 
 def test_load_logs_benchmark(benchmark):
@@ -15,3 +22,40 @@ def test_feature_engineering_benchmark(benchmark):
     data_file = Path("tests/fixtures/trades_small.csv")
     df, feature_cols, _ = _load_logs(data_file)
     benchmark(lambda: _extract_features(df.copy(), feature_names=list(feature_cols)))
+
+
+def test_evaluation_benchmark(benchmark, tmp_path):
+    """Benchmark evaluation pipeline on small synthetic data."""
+
+    preds = pd.DataFrame(
+        {
+            "timestamp": ["2024.01.01 00:00:00", "2024.01.01 00:02:00"],
+            "symbol": ["EURUSD", "EURUSD"],
+            "direction": [1, -1],
+            "lots": [0.1, 0.2],
+            "probability": [0.7, 0.4],
+            "value": [1.2, -0.5],
+            "log_variance": [np.log(0.1), np.log(0.2)],
+            "executed_model_idx": [0, 1],
+            "decision_id": [1, 2],
+        }
+    )
+    trades = pd.DataFrame(
+        {
+            "event_time": ["2024.01.01 00:00:10", "2024.01.01 00:02:30"],
+            "action": ["OPEN", "OPEN"],
+            "order_type": ["0", "1"],
+            "symbol": ["EURUSD", "EURUSD"],
+            "lots": [0.1, 0.2],
+            "ticket": ["1", "2"],
+            "executed_model_idx": [0, 1],
+            "decision_id": [1, 2],
+            "profit": [1.0, -0.6],
+        }
+    )
+    pred_file = tmp_path / "preds.csv"
+    trades_file = tmp_path / "trades.csv"
+    preds.to_csv(pred_file, sep=";", index=False)
+    trades.to_csv(trades_file, sep=";", index=False)
+
+    benchmark(lambda: evaluate(pred_file, trades_file, window=60))


### PR DESCRIPTION
## Summary
- add `n_jobs` support and parallel plugin helpers to the feature engineering config while keeping cache management intact
- adapt technical feature extraction to reuse the new helpers for optional plugins and maintain deterministic results
- refactor evaluation metrics to operate on merged data frames, enabling vectorised computation and additional regression benchmarks

## Testing
- pytest tests/test_n_jobs_deterministic.py
- pytest tests/test_evaluate.py
- pytest tests/performance/test_benchmarks.py -k evaluation

------
https://chatgpt.com/codex/tasks/task_e_68c8ba69d054832f8e08d57da2238028