### PR TITLE
Add hashed settings handling and schema validation

### DIFF
--- a/botcopier/cli/__init__.py
+++ b/botcopier/cli/__init__.py
@@ -187,7 +187,7 @@ def train(
     }
     if data_cfg.data is None or data_cfg.out is None:
         raise typer.BadParameter("data_dir and out_dir must be provided")
-    save_params(data_cfg, train_cfg, exec_cfg)
+    config_hash = save_params(data_cfg, train_cfg, exec_cfg)
     train_pipeline(
         Path(data_cfg.data),
         Path(data_cfg.out),
@@ -199,6 +199,7 @@ def train(
         hrp_allocation=train_cfg.hrp_allocation,
         strategy_search=train_cfg.strategy_search,
         reuse_controller=train_cfg.reuse_controller,
+        config_hash=config_hash,
     )
 
 

--- a/botcopier/config/__init__.py
+++ b/botcopier/config/__init__.py
@@ -4,6 +4,7 @@ from .settings import (
     DataConfig,
     ExecutionConfig,
     TrainingConfig,
+    compute_settings_hash,
     load_settings,
     save_params,
 )
@@ -12,6 +13,7 @@ __all__ = [
     "DataConfig",
     "TrainingConfig",
     "ExecutionConfig",
+    "compute_settings_hash",
     "load_settings",
     "save_params",
 ]

--- a/botcopier/config/settings.py
+++ b/botcopier/config/settings.py
@@ -3,6 +3,7 @@ from config.settings import (
     DataConfig,
     TrainingConfig,
     ExecutionConfig,
+    compute_settings_hash,
     load_settings,
     save_params,
 )
@@ -11,6 +12,7 @@ __all__ = [
     "DataConfig",
     "TrainingConfig",
     "ExecutionConfig",
+    "compute_settings_hash",
     "load_settings",
     "save_params",
 ]

--- a/botcopier/models/schema.py
+++ b/botcopier/models/schema.py
@@ -30,6 +30,9 @@ class ModelParams(BaseModel):
     feature_names: list[str] = Field(default_factory=list)
     feature_metadata: list[FeatureMetadata] = Field(default_factory=list)
     data_hashes: dict[str, str] = Field(default_factory=dict)
+    config_hash: str | None = Field(
+        default=None, description="SHA256 hash of the configuration used"
+    )
     version: Literal[1] = 1
 
     model_config = ConfigDict(extra="allow")

--- a/tests/test_feature_schema.py
+++ b/tests/test_feature_schema.py
@@ -1,8 +1,11 @@
-import pandas as pd
-import pandera as pa
 import pytest
 
+np = pytest.importorskip("numpy")
+pd = pytest.importorskip("pandas")
+pa = pytest.importorskip("pandera")
+
 from botcopier.data.feature_schema import FeatureSchema
+from botcopier.training.pipeline import predict_expected_value
 
 
 def test_type_violation():
@@ -15,3 +18,16 @@ def test_range_violation():
     df = pd.DataFrame({"atr": [1.0], "sl_dist_atr": [-1.0]})
     with pytest.raises(pa.errors.SchemaErrors):
         FeatureSchema.validate(df, lazy=True)
+
+
+def test_predict_expected_value_schema_violation():
+    model = {
+        "feature_names": ["atr"],
+        "feature_mean": [0.0],
+        "feature_std": [1.0],
+        "coefficients": [1.0],
+        "intercept": 0.0,
+    }
+    X = np.array([[-1.0]])  # atr must be >= 0
+    with pytest.raises(pa.errors.SchemaErrors):
+        predict_expected_value(model, X)

--- a/tests/test_indicator_discovery_training.py
+++ b/tests/test_indicator_discovery_training.py
@@ -96,11 +96,18 @@ def test_discovered_indicators_used_in_training(monkeypatch, tmp_path):
             rows.append(f"{label},{wr},{ap}\n")
         train_csv.write_text("".join(rows))
         out_dir = tmp_path / "out"
-        train_pipeline(train_csv, out_dir, model_json=model, cluster_correlation=1.0)
+        train_pipeline(
+            train_csv,
+            out_dir,
+            model_json=model,
+            cluster_correlation=1.0,
+            config_hash="abc123",
+        )
         model_trained = json.loads((out_dir / "model.json").read_text())
         assert any(f.startswith("sym_") for f in model_trained["feature_names"])
         assert model_trained["symbolic_indicators"]["formulas"] == [
             "add(win_rate,avg_profit)"
         ]
+        assert model_trained["config_hash"] == "abc123"
 
     asyncio.run(_run())

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -3,10 +3,19 @@
 from pathlib import Path
 
 import pytest
+
+pytest.importorskip("pydantic")
 from pydantic import ValidationError
 from jsonschema import ValidationError as JSONValidationError
 
-from botcopier.config.settings import load_settings
+from botcopier.config.settings import (
+    DataConfig,
+    ExecutionConfig,
+    TrainingConfig,
+    compute_settings_hash,
+    load_settings,
+    save_params,
+)
 
 
 def test_load_settings_valid(tmp_path: Path) -> None:
@@ -37,3 +46,30 @@ data:
     )
     with pytest.raises((ValidationError, JSONValidationError)):
         load_settings(path=cfg)
+
+
+def test_load_settings_missing_section(tmp_path: Path) -> None:
+    cfg = tmp_path / "params.yaml"
+    cfg.write_text(
+        """
+training:
+  batch_size: 8
+data: null
+"""
+    )
+    with pytest.raises(TypeError):
+        load_settings(path=cfg)
+
+
+def test_save_params_persists_and_hash(tmp_path: Path) -> None:
+    cfg_path = tmp_path / "params.yaml"
+    data_cfg = DataConfig(csv=Path("trades.csv"))
+    train_cfg = TrainingConfig(batch_size=64, model=Path("model.json"))
+    exec_cfg = ExecutionConfig(use_gpu=True)
+
+    digest = save_params(data_cfg, train_cfg, exec_cfg, path=cfg_path)
+    data_loaded, train_loaded, exec_loaded = load_settings(path=cfg_path)
+    assert data_loaded.csv == Path("trades.csv")
+    assert train_loaded.batch_size == 64
+    assert exec_loaded.use_gpu is True
+    assert digest == compute_settings_hash(data_cfg, train_cfg, exec_cfg)


### PR DESCRIPTION
## Summary
- serialize resolved Data/Training/Execution settings, compute a stable configuration hash, and harden load_settings against non-mapping sections
- propagate the configuration hash through the CLI into the training pipeline, embed it in model.json metadata, and run Pandera schema validation before prediction endpoints
- extend the test suite to cover configuration persistence, CLI hash wiring, and schema enforcement with dependency-aware skips

## Testing
- pytest tests/test_settings.py
- pytest tests/test_feature_schema.py
- pytest tests/test_cli_commands.py
- pytest tests/test_indicator_discovery_training.py

------
https://chatgpt.com/codex/tasks/task_e_68c8c99ec690832fba8c40861ede5355