### PR TITLE
Refactor training pipeline modules

### DIFF
--- a/automl/controller.py
+++ b/automl/controller.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from typing import Callable, Dict, Iterable, List, Tuple
 
 try:  # pragma: no cover - registry may not be present in tests
-    from models.registry import _REGISTRY as _MODEL_REGISTRY  # type: ignore
+    from botcopier.models.registry import MODEL_REGISTRY as _MODEL_REGISTRY
 except Exception:  # pragma: no cover - best effort
     _MODEL_REGISTRY = {}
 
@@ -31,7 +31,7 @@ class AutoMLController:
         Mapping of model name to an integer representing its relative
         complexity. Higher values imply greater complexity penalty.  If
         ``None`` all models currently registered in
-        :mod:`models.registry` are used with a default complexity of 1.
+        :mod:`botcopier.models.registry` are used with a default complexity of 1.
     model_path:
         File used to persist the controller's policy and best action.
     reuse:

--- a/botcopier/scripts/cluster_regimes.py
+++ b/botcopier/scripts/cluster_regimes.py
@@ -23,7 +23,7 @@ except Exception:  # pragma: no cover - optional
 
 # Reuse data loading and feature extraction from training script
 from botcopier.data.loading import _load_calendar, _load_logs
-from botcopier.features.technical import _extract_features
+from botcopier.features.engineering import _extract_features
 
 
 def cluster_features(

--- a/botcopier/scripts/model_fitting.py
+++ b/botcopier/scripts/model_fitting.py
@@ -18,7 +18,7 @@ from sklearn.metrics import accuracy_score, f1_score, roc_auc_score
 from sklearn.model_selection import TimeSeriesSplit
 from sklearn.preprocessing import StandardScaler
 
-from models.registry import get_model, register_model
+from botcopier.models.registry import get_model, register_model
 
 # Optional model libraries and hyperparameter search
 try:  # pragma: no cover - optional dependency

--- a/botcopier/scripts/train_target_clone.py
+++ b/botcopier/scripts/train_target_clone.py
@@ -21,7 +21,8 @@ except Exception:  # pragma: no cover - optional dependency
     ray = None  # type: ignore
     _HAS_RAY = False
 
-from botcopier.training.pipeline import MODEL_REGISTRY, train
+from botcopier.models.registry import MODEL_REGISTRY
+from botcopier.training.pipeline import train
 
 
 def main() -> None:

--- a/botcopier/training/pipeline.py
+++ b/botcopier/training/pipeline.py
@@ -84,10 +84,11 @@ from botcopier.exceptions import TrainingPipelineError
 from botcopier.data.feature_schema import FeatureSchema
 from botcopier.data.loading import _load_logs
 from botcopier.features.anomaly import _clip_train_features
-from botcopier.features.engineering import FeatureConfig, configure_cache
-from botcopier.features.technical import (
+from botcopier.features.engineering import (
+    FeatureConfig,
     _extract_features,
     _neutralize_against_market_index,
+    configure_cache,
 )
 from botcopier.models.registry import MODEL_REGISTRY, get_model, load_params
 from botcopier.models.schema import FeatureMetadata, ModelParams

--- a/models/registry.py
+++ b/models/registry.py
@@ -1,32 +1,7 @@
 from __future__ import annotations
 
-from typing import Callable, Dict
+from botcopier.models.registry import MODEL_REGISTRY, get_model, register_model
 
-_REGISTRY: Dict[str, Callable] = {}
+_REGISTRY = MODEL_REGISTRY
 
-
-def register_model(name: str, builder: Callable) -> None:
-    """Register a model builder under ``name``.
-
-    Parameters
-    ----------
-    name:
-        Identifier for the model.
-    builder:
-        Callable that returns a fitted model when invoked.
-    """
-    _REGISTRY[name] = builder
-
-
-def get_model(name: str) -> Callable:
-    """Retrieve a registered model builder by ``name``.
-
-    Raises
-    ------
-    KeyError
-        If ``name`` is not present in the registry.
-    """
-    try:
-        return _REGISTRY[name]
-    except KeyError as e:  # pragma: no cover - defensive
-        raise KeyError(f"Model '{name}' is not registered") from e
+__all__ = ["register_model", "get_model", "_REGISTRY"]

--- a/tests/test_candlestick_patterns.py
+++ b/tests/test_candlestick_patterns.py
@@ -5,7 +5,7 @@ import pandas as pd
 
 import botcopier.features.engineering as fe
 from botcopier.features.engineering import FeatureConfig, clear_cache, configure_cache
-from botcopier.features.technical import _extract_features
+from botcopier.features.engineering import _extract_features
 from botcopier.features.engineering import _extract_features as extract_rows_features
 
 

--- a/tests/test_contrastive_encoder.py
+++ b/tests/test_contrastive_encoder.py
@@ -12,7 +12,7 @@ from botcopier.features.engineering import (
     configure_cache,
     train,
 )
-from botcopier.features.technical import _extract_features
+from botcopier.features.engineering import _extract_features
 from scripts.pretrain_contrastive import train as pretrain_encoder
 from scripts.replay_decisions import _recompute
 

--- a/tests/test_dask_determinism.py
+++ b/tests/test_dask_determinism.py
@@ -2,7 +2,7 @@ from pathlib import Path
 import numpy as np
 
 from botcopier.data.loading import _load_logs
-from botcopier.features.technical import _extract_features
+from botcopier.features.engineering import _extract_features
 
 
 def test_pandas_dask_equivalence():

--- a/tests/test_data_contract.py
+++ b/tests/test_data_contract.py
@@ -6,7 +6,7 @@ import pandas as pd
 import yaml
 
 from botcopier.data.loading import _load_logs
-from botcopier.features.technical import _extract_features
+from botcopier.features.engineering import _extract_features
 from botcopier.training.pipeline import train
 
 

--- a/tests/test_regime_assignment.py
+++ b/tests/test_regime_assignment.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import botcopier.features.engineering as fe
 from botcopier.data.loading import _load_logs
 from botcopier.features.engineering import FeatureConfig, clear_cache, configure_cache
-from botcopier.features.technical import _extract_features
+from botcopier.features.engineering import _extract_features
 from botcopier.training.pipeline import train
 
 

--- a/tests/test_train_target_clone_multi.py
+++ b/tests/test_train_target_clone_multi.py
@@ -7,7 +7,7 @@ import numpy as np
 import botcopier.features.engineering as fe
 from botcopier.data.loading import _load_logs
 from botcopier.features.engineering import FeatureConfig, clear_cache, configure_cache
-from botcopier.features.technical import _extract_features
+from botcopier.features.engineering import _extract_features
 from botcopier.training.pipeline import train
 
 


### PR DESCRIPTION
## Summary
- align the training pipeline, CLI wrappers, and AutoML controller with the package-level feature extraction helpers and model registry
- collapse the legacy `models.registry` shim into a thin compatibility layer over `botcopier.models.registry`
- update tests to import `_extract_features` from the new package module hierarchy

## Testing
- pytest tests/test_data_contract.py::test_data_contract -q *(fails: numpy not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c99da2277c832fa29e7befbea505d6