### PR TITLE
Add deep model implementations and inference support

### DIFF
--- a/botcopier/training/pipeline.py
+++ b/botcopier/training/pipeline.py
@@ -643,6 +643,12 @@ def train(
             "patience",
             "mixed_precision",
         },
+        "moe": {
+            "epochs",
+            "lr",
+            "n_experts",
+            "dropout",
+        },
     }
     extra_model_params = {
         key: kwargs[key]

--- a/tests/test_deep_models.py
+++ b/tests/test_deep_models.py
@@ -1,0 +1,80 @@
+import pytest
+
+np = pytest.importorskip("numpy")
+torch = pytest.importorskip("torch")
+
+from botcopier.models.deep import TemporalConvNet
+from botcopier.models.registry import (
+    TabTransformer,
+    fit_tab_transformer,
+    fit_temporal_cnn,
+)
+
+
+def test_tabtransformer_forward_and_accuracy():
+    rng = np.random.default_rng(0)
+    X = rng.normal(size=(128, 4))
+    y = (X[:, 0] + 0.5 * X[:, 1] > 0).astype(float)
+
+    torch.manual_seed(0)
+    model = TabTransformer(num_features=4)
+    batch = torch.tensor(X, dtype=torch.float32)
+    logits = model(batch)
+    assert logits.shape == (X.shape[0],)
+
+    meta, predict = fit_tab_transformer(
+        X,
+        y,
+        epochs=12,
+        batch_size=32,
+        lr=5e-3,
+        dropout=0.0,
+        mixed_precision=False,
+    )
+    preds = predict(X)
+    acc = ((preds >= 0.5).astype(float) == y).mean()
+    assert acc > 0.75
+
+    arch = meta.get("architecture", {})
+    assert arch.get("type") == "TabTransformer"
+    assert arch.get("num_features") == 4
+    assert arch.get("window") == 1
+    assert "state_dict" in meta and meta["state_dict"]
+
+
+def test_temporal_convnet_forward_and_accuracy():
+    rng = np.random.default_rng(1)
+    seq = rng.normal(size=(96, 5, 3))
+    y = (seq[:, :, 0].mean(axis=1) > 0).astype(float)
+
+    torch.manual_seed(0)
+    net = TemporalConvNet(3, [4, 4])
+    inp = torch.tensor(seq.transpose(0, 2, 1), dtype=torch.float32)
+    out = net(inp)
+    assert out.shape == (seq.shape[0], 4, seq.shape[1])
+
+    meta, predict = fit_temporal_cnn(
+        seq,
+        y,
+        epochs=15,
+        batch_size=24,
+        lr=5e-3,
+        dropout=0.0,
+        channels=(8, 8),
+        mixed_precision=False,
+    )
+    preds = predict(seq)
+    acc = ((preds >= 0.5).astype(float) == y).mean()
+    assert acc > 0.7
+
+    arch = meta.get("architecture", {})
+    assert arch.get("type") == "TemporalConvNet"
+    assert arch.get("num_features") == 3
+    assert arch.get("window") == 5
+    assert "state_dict" in meta and meta["state_dict"]
+
+
+__all__ = [
+    "test_tabtransformer_forward_and_accuracy",
+    "test_temporal_convnet_forward_and_accuracy",
+]


### PR DESCRIPTION
## Summary
- extend TabTransformer and TemporalConvNet implementations and add a MixtureOfExperts head with validation logic
- persist architecture/state metadata in model registry and expose MixtureOfExperts during inference and CLI usage
- add focused tests covering neural architectures and MixtureOfExperts metadata expectations

## Testing
- `pytest tests/test_deep_models.py tests/test_moe_model.py tests/test_train_transformer.py tests/test_model_explain.py` *(skipped: optional dependencies such as numpy/torch are unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c9d69936c0832fa05fbccc487d2eb3