### PR TITLE
Enhance online trainer drift handling and streaming tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,8 @@ ALLOWED = {
     "test_benchmarks.py",
     "test_nats_publisher_async.py",
     "test_online_trainer_async.py",
+    "test_online_trainer.py",
+    "test_online_trainer_live_ticks.py",
     "property",
     "test_invariants.py",
     "optional",

--- a/tests/test_online_trainer_live_ticks.py
+++ b/tests/test_online_trainer_live_ticks.py
@@ -1,8 +1,10 @@
 import asyncio
+import json
 
 import pandas as pd
 
 from botcopier.scripts.online_trainer import OnlineTrainer
+from scripts.sequential_drift import PageHinkley
 
 
 class DummyController:
@@ -45,3 +47,43 @@ def test_tick_stream_buffer_and_adaptive_refit(tmp_path):
     assert len(df) >= 64
     assert controller.sampled
     assert trainer.model_type == "confidence_weighted"
+
+
+async def _drift_stream():
+    for _ in range(6):
+        yield {"feat": -0.5, "y": 0}
+        yield {"feat": 0.5, "y": 1}
+    for _ in range(8):
+        yield {"feat": 3.0, "y": 1}
+    for i in range(12):
+        yield {"feat": 2.5 + 0.1 * (i % 3), "y": i % 2}
+
+
+def test_live_tick_drift_retrain_and_recalibration(tmp_path):
+    ring_path = tmp_path / "ticks.ring"
+    model_path = tmp_path / "model.json"
+    buffer_path = tmp_path / "data/live_ticks.parquet"
+    trainer = OnlineTrainer(
+        model_path=model_path,
+        batch_size=4,
+        tick_buffer_path=buffer_path,
+    )
+    trainer.drift_detector = PageHinkley(delta=0.0, threshold=0.05, min_samples=5)
+    trainer.drift_baseline_min = 6
+    trainer.drift_recent_min = 4
+    trainer.psi_threshold = 0.01
+    trainer.ks_threshold = 0.01
+    asyncio.run(trainer.consume_ticks(_drift_stream(), ring_path))
+    assert buffer_path.exists()
+    df = pd.read_parquet(buffer_path)
+    assert not df.empty
+    assert trainer.drift_events >= 1
+    assert trainer.drift_event_log
+    assert any(evt.get("type") in {"sequential", "feature"} for evt in trainer.drift_event_log)
+    assert trainer.calibrator is not None
+    assert trainer.calibration_metadata.get("samples", 0) >= trainer.calibration_min_samples
+    assert len(trainer.calib_scores) == trainer.calibration_metadata.get("samples")
+    data = json.loads(model_path.read_text())
+    assert data.get("online_drift_events")
+    calib = data.get("calibration")
+    assert calib and calib.get("samples", 0) == trainer.calibration_metadata.get("samples")


### PR DESCRIPTION
## Summary
- guard the detect_resources import and add helper utilities so partial_fit can run before drift monitoring
- rework the update loop to refit batches after drift, refresh calibration buffers, and persist streaming ticks from CSV/Flight feeds
- expand live tick tests to cover drift driven retraining and enable the online trainer test modules in conftest

## Testing
- `pytest tests/test_online_trainer.py tests/test_online_trainer_live_ticks.py`


------
https://chatgpt.com/codex/tasks/task_e_68c9eb48b004832f9da9645363349f7d