### PR TITLE
Add ensemble voting model with thresholded inference

### DIFF
--- a/botcopier/training/pipeline.py
+++ b/botcopier/training/pipeline.py
@@ -1751,6 +1751,9 @@ def train(
         model["threshold"] = float(selected_threshold)
         model["decision_threshold"] = float(selected_threshold)
         model["threshold_objective"] = threshold_objective
+        ensemble_cfg = model.get("ensemble")
+        if isinstance(ensemble_cfg, dict):
+            ensemble_cfg.setdefault("threshold", float(selected_threshold))
         model["cv_accuracy"] = metrics.get("accuracy", 0.0)
         model["cv_profit"] = metrics.get("profit", 0.0)
         model["conformal_lower"] = 0.0

--- a/tests/test_ensemble_performance.py
+++ b/tests/test_ensemble_performance.py
@@ -1,0 +1,65 @@
+import pytest
+
+np = pytest.importorskip("numpy")
+
+from botcopier.models.registry import get_model
+from botcopier.scripts.evaluation import search_decision_threshold
+
+
+def test_ensemble_voting_improves_profit() -> None:
+    rng = np.random.default_rng(0)
+    n_linear = 200
+    n_xor = 200
+
+    X_linear = rng.normal(size=(n_linear, 2))
+    y_linear = (X_linear[:, 0] > 0).astype(float)
+    profits_linear = np.where(y_linear == 1.0, 2.0, -1.0)
+
+    X_xor = rng.integers(0, 2, size=(n_xor, 2)).astype(float)
+    y_xor = (X_xor[:, 0] != X_xor[:, 1]).astype(float)
+    profits_xor = np.where(y_xor == 1.0, 2.0, -1.0)
+
+    X = np.vstack([X_linear, X_xor])
+    y = np.concatenate([y_linear, y_xor])
+    profits = np.concatenate([profits_linear, profits_xor])
+
+    perm = rng.permutation(X.shape[0])
+    X = X[perm]
+    y = y[perm]
+    profits = profits[perm]
+
+    split = int(0.8 * X.shape[0])
+    X_train, X_val = X[:split], X[split:]
+    y_train, y_val = y[:split], y[split:]
+    profits_val = profits[split:]
+
+    _, log_predict = get_model("logreg")(X_train, y_train)
+    log_probs = log_predict(X_val)
+    _, log_metrics = search_decision_threshold(
+        y_val, log_probs, profits_val, objective="profit"
+    )
+    log_profit = log_metrics.get("profit", 0.0)
+
+    _, gb_predict = get_model("gradient_boosting")(
+        X_train, y_train, random_state=0, max_depth=2
+    )
+    gb_probs = gb_predict(X_val)
+    _, gb_metrics = search_decision_threshold(
+        y_val, gb_probs, profits_val, objective="profit"
+    )
+    gb_profit = gb_metrics.get("profit", 0.0)
+
+    _, ens_predict = get_model("ensemble_voting")(
+        X_train,
+        y_train,
+        random_state=0,
+        gb_params={"max_depth": 2},
+    )
+    ens_probs = ens_predict(X_val)
+    _, ens_metrics = search_decision_threshold(
+        y_val, ens_probs, profits_val, objective="profit"
+    )
+    ens_profit = ens_metrics.get("profit", 0.0)
+
+    assert ens_profit >= log_profit
+    assert ens_profit >= gb_profit

--- a/tests/test_grpc_predict_server.py
+++ b/tests/test_grpc_predict_server.py
@@ -28,10 +28,12 @@ def _free_port() -> int:
 
 
 def test_grpc_round_trip():
-    model = {"entry_coefficients": [0.5, -0.25], "entry_intercept": 0.1}
-    gps.MODEL = model
-    gps.COEFFS = [0.5, -0.25]
-    gps.INTERCEPT = 0.1
+    model = {
+        "entry_coefficients": [0.5, -0.25],
+        "entry_intercept": 0.1,
+        "threshold": 0.0,
+    }
+    gps._configure_runtime(model)
 
     async def _run() -> None:
         port = _free_port()
@@ -49,8 +51,9 @@ def test_grpc_round_trip():
 
 @pytest.mark.asyncio
 async def test_grpc_invalid_features_logged(caplog):
-    gps.COEFFS = [0.5, -0.25]
-    gps.INTERCEPT = 0.0
+    gps._configure_runtime(
+        {"entry_coefficients": [0.5, -0.25], "entry_intercept": 0.0, "threshold": 0.0}
+    )
     caplog.set_level(logging.ERROR)
 
     port = _free_port()

--- a/tests/test_ood_detection.py
+++ b/tests/test_ood_detection.py
@@ -1,15 +1,24 @@
-import numpy as np
+import pytest
+
+np = pytest.importorskip("numpy")
 from botcopier.scripts import serve_model as sm
 
 
 def test_mahalanobis_ood_flag():
     """Samples far from training mean should be flagged as OOD."""
-    sm.MODEL = {"entry_coefficients": [1.0, 1.0], "entry_intercept": 0.0}
-    sm.FEATURE_NAMES = ["f1", "f2"]
-    sm.FEATURE_METADATA = []
-    sm.OOD_MEAN = np.zeros(2)
-    sm.OOD_INV = np.eye(2)
-    sm.OOD_THRESHOLD = 1.0
+    sm._configure_model(
+        {
+            "entry_coefficients": [1.0, 1.0],
+            "entry_intercept": 0.0,
+            "feature_names": ["f1", "f2"],
+            "threshold": 0.0,
+            "ood": {
+                "mean": [0.0, 0.0],
+                "covariance": [[1.0, 0.0], [0.0, 1.0]],
+                "threshold": 1.0,
+            },
+        }
+    )
     sm.OOD_COUNTER._value.set(0)
     pred = sm._predict_one([10.0, 10.0])
     assert pred == 0.0


### PR DESCRIPTION
## Summary
- add reusable logistic metadata extraction and register gradient boosting and voting ensemble builders
- load ensemble definitions during inference, averaging estimator outputs and applying the stored decision threshold
- persist ensemble thresholds from training and extend tests to cover new behaviour and profit improvements

## Testing
- pytest tests/test_grpc_predict_server.py tests/test_ood_detection.py tests/test_ensemble_performance.py (skipped)


------
https://chatgpt.com/codex/tasks/task_e_68c9f2c8a384832fa72de2ab5b873144