### PR TITLE
Add tests for logging setup and metrics endpoints

### DIFF
--- a/tests/test_logging_utils.py
+++ b/tests/test_logging_utils.py
@@ -1,0 +1,73 @@
+"""Tests for the :mod:`logging_utils` helpers."""
+
+from __future__ import annotations
+
+import io
+import json
+import logging
+
+import pytest
+
+from logging_utils import setup_logging
+
+
+@pytest.fixture(autouse=True)
+def _reset_logging_state() -> None:
+    """Ensure each test starts with a clean root logger configuration."""
+
+    root = logging.getLogger()
+    root.handlers.clear()
+    if hasattr(root, "_botcopier_configured"):
+        delattr(root, "_botcopier_configured")
+    yield
+    root.handlers.clear()
+    if hasattr(root, "_botcopier_configured"):
+        delattr(root, "_botcopier_configured")
+
+
+def _stream_handler() -> logging.StreamHandler:
+    root = logging.getLogger()
+    for handler in root.handlers:
+        if isinstance(handler, logging.StreamHandler):
+            return handler
+    raise AssertionError("stream handler was not configured")
+
+
+def test_setup_logging_uses_json_formatter_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """JSON formatting should be enabled when structured logs are requested."""
+
+    stream = io.StringIO()
+    monkeypatch.setenv("BOTCOPIER_JSON_LOGS", "1")
+
+    logger = setup_logging("botcopier.tests")
+    handler = _stream_handler()
+    handler.setStream(stream)
+
+    logger.info("structured log", extra={"foo": "bar"})
+    handler.flush()
+
+    payload = json.loads(stream.getvalue())
+    assert payload["message"] == "structured log"
+    assert payload["foo"] == "bar"
+    assert payload["logger"] == "botcopier.tests"
+    assert payload["level"] == "INFO"
+
+
+def test_setup_logging_supports_plain_formatter(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Setting ``BOTCOPIER_LOG_FORMAT`` should enable text logging."""
+
+    stream = io.StringIO()
+    monkeypatch.delenv("BOTCOPIER_JSON_LOGS", raising=False)
+    monkeypatch.setenv("BOTCOPIER_LOG_FORMAT", "plain")
+
+    logger = setup_logging("botcopier.tests")
+    handler = _stream_handler()
+    handler.setStream(stream)
+
+    logger.warning("plain text entry")
+    handler.flush()
+
+    log_line = stream.getvalue()
+    assert "plain text entry" in log_line
+    with pytest.raises(json.JSONDecodeError):
+        json.loads(log_line)

--- a/tests/test_metrics_endpoints.py
+++ b/tests/test_metrics_endpoints.py
@@ -11,7 +11,6 @@ try:  # optional dependency in minimal environments
     from fastapi.testclient import TestClient
 except ModuleNotFoundError:  # pragma: no cover - fastapi not installed
     TestClient = None  # type: ignore[assignment]
-    pytestmark = pytest.mark.skip(reason="fastapi is not installed")
 
 from botcopier.metrics import ERROR_COUNTER, TRADE_COUNTER, start_metrics_server
 from botcopier.scripts import bandit_router
@@ -45,6 +44,7 @@ def test_metrics_server_exposes_counters():
     assert "botcopier_errors_total" in payload
 
 
+@pytest.mark.skipif(TestClient is None, reason="fastapi is not installed")
 def test_bandit_router_metrics_endpoint(tmp_path):
     state_file = tmp_path / "state.json"
     router = bandit_router.BanditRouter(models=1, method="thompson", state_file=str(state_file))


### PR DESCRIPTION
## Summary
- add tests that assert JSON and plain-text logging formats from `setup_logging`
- adjust the metrics endpoint test to skip only when FastAPI is missing so the Prometheus server checks still run

## Testing
- pytest tests/test_logging_utils.py -q
- pytest tests/test_metrics_endpoints.py -q


------
https://chatgpt.com/codex/tasks/task_e_68ca378d7d68832f940adc1cbb78897f