### PR TITLE
Integrate optuna study with full training pipeline

### DIFF
--- a/tests/test_hyperparam_log.py
+++ b/tests/test_hyperparam_log.py
@@ -1,26 +1,73 @@
 import json
 from pathlib import Path
 
-import pandas as pd
 import pytest
+
+np = pytest.importorskip("numpy")
+pd = pytest.importorskip("pandas")
+pytest.importorskip("optuna")
 
 from botcopier.training.pipeline import run_optuna
 
 
 def test_hyperparam_csv_contains_best_trial(tmp_path: Path):
-    csv_path = tmp_path / "hyperparams.csv"
-    model_path = tmp_path / "model.json"
+    rng = np.random.default_rng(42)
+    X = rng.normal(size=(48, 4))
+    weights = np.array([0.8, -0.5, 0.3, 0.2])
+    logits = X @ weights + rng.normal(scale=0.2, size=X.shape[0])
+    y = (logits > 0).astype(int)
+    profits = np.where(y == 1, rng.uniform(0.5, 1.5, size=y.size), rng.uniform(-1.0, 0.2, size=y.size))
+    df = pd.DataFrame(X, columns=["feat1", "feat2", "feat3", "feat4"])
+    df["label"] = y
+    df["profit"] = profits
+    data_file = tmp_path / "trades.csv"
+    df.to_csv(data_file, index=False)
 
-    study = run_optuna(n_trials=5, csv_path=csv_path, model_json_path=model_path)
+    out_dir = tmp_path / "study"
+    csv_path = out_dir / "hyperparams.csv"
+    model_path = out_dir / "model.json"
+
+    study = run_optuna(
+        n_trials=3,
+        csv_path=csv_path,
+        model_json_path=model_path,
+        settings_overrides={"data_dir": data_file, "out_dir": out_dir},
+        model_types=["logreg"],
+        feature_flags={"vol_weight": [False, True]},
+        train_kwargs={"n_splits": 2, "cv_gap": 1},
+    )
 
     assert csv_path.exists(), "hyperparams.csv should be created"
+    assert model_path.exists(), "Final model should be written"
 
     data = json.loads(model_path.read_text())
-    assert data["metadata"]["hyperparam_log"] == "hyperparams.csv"
+    metadata = data.get("metadata", {})
+    assert metadata["hyperparam_log"] == "hyperparams.csv"
+    assert "selected_trial" in metadata
+    selected = metadata["selected_trial"]
 
     df = pd.read_csv(csv_path)
-    selected = data["metadata"]["selected_trial"]
     best_row = df[df["trial"] == selected["number"]].iloc[0]
     assert best_row["profit"] == pytest.approx(selected["profit"])
     assert best_row["sharpe"] == pytest.approx(selected["sharpe"])
     assert best_row["max_drawdown"] == pytest.approx(selected["max_drawdown"])
+    assert best_row["var_95"] == pytest.approx(selected["var_95"])
+
+    search_params = selected.get("search_params", {})
+    assert "seed" in search_params
+    assert search_params.get("model_type", "logreg") == "logreg"
+    assert "vol_weight" in search_params
+
+    risk_metrics = data.get("risk_metrics", {})
+    assert risk_metrics.get("max_drawdown") == pytest.approx(selected["max_drawdown"])
+    assert risk_metrics.get("var_95") == pytest.approx(selected["var_95"])
+
+    hyperopt = metadata.get("hyperparameter_optimization", {})
+    assert hyperopt.get("n_trials") == len(
+        [t for t in study.trials if t.state.name == "COMPLETE"]
+    )
+    best_meta = hyperopt.get("best_trial", {})
+    assert best_meta.get("number") == selected["number"]
+    assert "artifact_dir" in best_meta
+    artifact_dir = out_dir / best_meta["artifact_dir"]
+    assert artifact_dir.exists()

--- a/train_target_clone.py
+++ b/train_target_clone.py
@@ -9,6 +9,7 @@ this module.
 from __future__ import annotations
 
 import argparse
+from pathlib import Path
 
 from botcopier.data.loading import _load_logs
 from botcopier.features.engineering import _extract_features
@@ -26,13 +27,111 @@ __all__ = [
 
 
 if __name__ == "__main__":  # pragma: no cover - CLI entry
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(description="Run Optuna hyperparameter search")
+    parser.add_argument("--data-dir", type=Path, help="Path to training data directory")
+    parser.add_argument(
+        "--out-dir",
+        type=Path,
+        help="Directory where study outputs and the final model will be written",
+    )
+    parser.add_argument(
+        "--config",
+        type=Path,
+        default=Path("params.yaml"),
+        help="Path to configuration file (default: params.yaml)",
+    )
+    parser.add_argument(
+        "--model-type",
+        dest="model_type",
+        help="Base model type to use for training (default from configuration)",
+    )
+    parser.add_argument(
+        "--search-model",
+        dest="search_models",
+        action="append",
+        help="Model type to include in the Optuna search space (repeatable)",
+    )
+    parser.add_argument(
+        "--feature",
+        dest="features",
+        action="append",
+        help="Feature name to enable (repeatable)",
+    )
+    parser.add_argument(
+        "--regime-feature",
+        dest="regime_features",
+        action="append",
+        help="Regime feature name to enable (repeatable)",
+    )
+    parser.add_argument(
+        "--vol-weight",
+        dest="vol_weight",
+        action="store_true",
+        help="Enable volatility weighting when training",
+    )
+    parser.add_argument(
+        "--no-vol-weight",
+        dest="vol_weight",
+        action="store_false",
+        help="Disable volatility weighting",
+    )
+    parser.set_defaults(vol_weight=None)
+    parser.add_argument(
+        "--flag",
+        dest="flag_options",
+        action="append",
+        help="Feature flag search in the form name or name=true,false",
+    )
     parser.add_argument("--max-drawdown", type=float, default=None)
     parser.add_argument("--var-limit", type=float, default=None)
     parser.add_argument("--trials", type=int, default=10)
+    parser.add_argument("--study-name", type=str, default=None)
+    parser.add_argument("--storage", type=str, default=None)
     args = parser.parse_args()
+
+    overrides: dict[str, object] = {}
+    if args.data_dir is not None:
+        overrides["data_dir"] = args.data_dir
+    if args.out_dir is not None:
+        overrides["out_dir"] = args.out_dir
+    if args.model_type is not None:
+        overrides["model_type"] = args.model_type
+    if args.features:
+        overrides["features"] = args.features
+    if args.regime_features:
+        overrides["regime_features"] = args.regime_features
+    if args.vol_weight is not None:
+        overrides["vol_weight"] = args.vol_weight
+
+    flag_options: dict[str, list[bool]] = {}
+    for raw in args.flag_options or []:
+        if "=" in raw:
+            name, values = raw.split("=", 1)
+            parsed: list[bool] = []
+            for token in values.split(","):
+                token_norm = token.strip().lower()
+                if token_norm in {"1", "true", "yes", "on"}:
+                    parsed.append(True)
+                elif token_norm in {"0", "false", "no", "off"}:
+                    parsed.append(False)
+            if parsed:
+                flag_options[name.strip()] = parsed
+        else:
+            flag_options[raw.strip()] = [False, True]
+
+    csv_path = args.out_dir / "hyperparams.csv" if args.out_dir else "hyperparams.csv"
+    model_path = args.out_dir / "model.json" if args.out_dir else "model.json"
+
     run_optuna(
         n_trials=args.trials,
         max_drawdown=args.max_drawdown,
         var_limit=args.var_limit,
+        study_name=args.study_name,
+        storage=args.storage,
+        csv_path=csv_path,
+        model_json_path=model_path,
+        settings_overrides=overrides or None,
+        config_path=args.config,
+        model_types=args.search_models,
+        feature_flags=flag_options or None,
     )


### PR DESCRIPTION
## Summary
- refactor run_optuna to execute the full training pipeline per trial, capture metrics, and persist the best configuration metadata
- add CLI support for passing data paths, model choices, and feature flag search options to the optuna runner
- update the hyperparameter log test to use a synthetic dataset and verify recorded metrics and metadata

## Testing
- `python -m pytest tests/test_hyperparam_log.py` *(skipped: optuna not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68cadbe45e68832f944a71bde8130a67