### PR TITLE
Add lazy subset sampling and controller hyperparameters

### DIFF
--- a/automl/controller.py
+++ b/automl/controller.py
@@ -7,8 +7,9 @@ import json
 import math
 import os
 import random
+from collections import OrderedDict
 from pathlib import Path
-from typing import Callable, Dict, Iterable, List, Tuple
+from typing import Callable, Dict, Iterable, List, Sequence, Tuple
 
 try:  # pragma: no cover - registry may not be present in tests
     from botcopier.models.registry import MODEL_REGISTRY as _MODEL_REGISTRY
@@ -46,33 +47,49 @@ class AutoMLController:
         model_path: str | os.PathLike[str] = "model.json",
         *,
         reuse: bool = True,
+        max_subset_size: int | None = None,
+        episode_sample_size: int | None = None,
+        baseline_momentum: float | None = 0.9,
     ) -> None:
         self.features = list(features)
+        if not self.features:
+            raise ValueError("AutoMLController requires at least one feature")
         if models is None:
             models = {name: 1 for name in _MODEL_REGISTRY.keys()}
+        if not models:
+            raise ValueError("AutoMLController requires at least one model")
         self.models = models
         self.model_path = Path(model_path)
-        self.action_space: List[Action] = []
+        self.max_subset_size = (
+            len(self.features) if max_subset_size is None else max_subset_size
+        )
+        if self.max_subset_size < 1:
+            raise ValueError("max_subset_size must be at least 1")
+        self.max_subset_size = min(self.max_subset_size, len(self.features))
+        self.episode_sample_size = episode_sample_size
+        if self.episode_sample_size is not None and self.episode_sample_size < 1:
+            raise ValueError("episode_sample_size must be positive when provided")
+
+        self.baseline_momentum = baseline_momentum
+        if self.baseline_momentum is not None:
+            if self.baseline_momentum <= 0.0:
+                self.baseline_momentum = None
+            elif self.baseline_momentum > 1.0:
+                raise ValueError("baseline_momentum must be between 0 and 1")
+
+        self._known_actions: Dict[str, Action] = {}
+        self._current_actions: List[Action] = []
+        self._current_keys: List[str] = []
         self.last_action: Action | None = None
-        for r in range(1, len(self.features) + 1):
-            for subset in itertools.combinations(self.features, r):
-                for model in self.models:
-                    self.action_space.append((subset, model))
-
-        if not self.action_space:
-            raise ValueError(
-                "AutoMLController requires at least one feature/model combination"
-            )
-
-        # Pre-compute keys for each action so we don't repeatedly encode
-        # actions during gradient updates. ``action_keys`` maintains the
-        # same order as ``action_space``.
-        self.action_keys = [self._key(a) for a in self.action_space]
 
         # policy parameters and reward estimates per action
-        self.theta: Dict[str, float] = {k: 0.0 for k in self.action_keys}
-        self.avg_reward: Dict[str, float] = {k: 0.0 for k in self.action_keys}
-        self.counts: Dict[str, int] = {k: 0 for k in self.action_keys}
+        self.theta: Dict[str, float] = {}
+        self.avg_reward: Dict[str, float] = {}
+        self.counts: Dict[str, int] = {}
+
+        # baseline critic statistics
+        self._baseline: float = 0.0
+        self._baseline_updates: int = 0
 
         if reuse:
             self._load()
@@ -82,11 +99,15 @@ class AutoMLController:
     # ------------------------------------------------------------------
     def reset(self) -> None:
         """Reset the learned policy."""
-        for k in self.action_keys:
-            self.theta[k] = 0.0
-            self.avg_reward[k] = 0.0
-            self.counts[k] = 0
+        self.theta.clear()
+        self.avg_reward.clear()
+        self.counts.clear()
+        self._known_actions.clear()
+        self._current_actions = []
+        self._current_keys = []
         self.last_action = None
+        self._baseline = 0.0
+        self._baseline_updates = 0
 
     def _key(self, action: Action) -> str:
         subset, model = action
@@ -97,6 +118,95 @@ class AutoMLController:
         subset_key, model = key.split("|")
         subset = tuple(filter(None, subset_key.split(",")))
         return subset, model
+
+    def _register_action(self, action: Action) -> str:
+        key = self._key(action)
+        if key not in self._known_actions:
+            self._known_actions[key] = action
+        self.theta.setdefault(key, 0.0)
+        self.avg_reward.setdefault(key, 0.0)
+        self.counts.setdefault(key, 0)
+        return key
+
+    def configure(
+        self,
+        *,
+        max_subset_size: int | None = None,
+        episode_sample_size: int | None = None,
+        baseline_momentum: float | None = None,
+    ) -> None:
+        """Update controller hyperparameters for future episodes."""
+
+        if max_subset_size is not None:
+            if max_subset_size < 1:
+                raise ValueError("max_subset_size must be at least 1")
+            self.max_subset_size = min(max_subset_size, len(self.features))
+        if episode_sample_size is not None:
+            if episode_sample_size < 1:
+                raise ValueError("episode_sample_size must be positive")
+            self.episode_sample_size = episode_sample_size
+        if baseline_momentum is not None:
+            if baseline_momentum <= 0.0:
+                self.baseline_momentum = None
+            elif baseline_momentum > 1.0:
+                raise ValueError("baseline_momentum must be between 0 and 1")
+            else:
+                self.baseline_momentum = baseline_momentum
+        self._current_actions = []
+        self._current_keys = []
+
+    def _iter_subsets(self) -> Iterable[Tuple[str, ...]]:
+        max_r = min(self.max_subset_size, len(self.features))
+        for r in range(1, max_r + 1):
+            yield from itertools.combinations(self.features, r)
+
+    def _random_subset(self) -> Tuple[str, ...]:
+        max_r = min(self.max_subset_size, len(self.features))
+        if max_r <= 0:
+            raise ValueError("AutoMLController requires at least one feature")
+        size = random.randint(1, max_r)
+        if size == 0:
+            return ()
+        return tuple(sorted(random.sample(self.features, size)))
+
+    def _prepare_episode_actions(self, include: Sequence[Action] | None = None) -> None:
+        include = list(include or [])
+        subset_map: Dict[Tuple[str, ...], None] = OrderedDict()
+        for action in include:
+            subset = tuple(sorted(action[0]))
+            subset_map.setdefault(subset, None)
+
+        if self.episode_sample_size is None:
+            for subset in self._iter_subsets():
+                subset_map.setdefault(tuple(subset), None)
+        else:
+            target = max(self.episode_sample_size, len(subset_map))
+            attempts = 0
+            max_attempts = max(100, target * 10)
+            while len(subset_map) < target and attempts < max_attempts:
+                subset_map.setdefault(self._random_subset(), None)
+                attempts += 1
+            if len(subset_map) < target:
+                for subset in self._iter_subsets():
+                    subset_map.setdefault(tuple(subset), None)
+                    if len(subset_map) >= target:
+                        break
+
+        actions: List[Action] = []
+        for subset in subset_map.keys():
+            for model in self.models:
+                action = (subset, model)
+                self._register_action(action)
+                actions.append(action)
+
+        if not actions:
+            raise ValueError(
+                "AutoMLController requires at least one feature/model combination"
+            )
+
+        random.shuffle(actions)
+        self._current_actions = actions
+        self._current_keys = [self._key(action) for action in actions]
 
     # ------------------------------------------------------------------
     # Persistence
@@ -113,18 +223,28 @@ class AutoMLController:
         rewards = sec.get("avg_reward")
         counts = sec.get("counts")
         last_action = sec.get("last_action")
+        baseline = sec.get("baseline")
+        baseline_updates = sec.get("baseline_updates")
+
         if theta:
             for k, v in theta.items():
-                if k in self.theta:
-                    self.theta[k] = float(v)
+                action = self._decode(k)
+                self._register_action(action)
+                self.theta[k] = float(v)
         if rewards:
             for k, v in rewards.items():
-                if k in self.avg_reward:
-                    self.avg_reward[k] = float(v)
+                action = self._decode(k)
+                self._register_action(action)
+                self.avg_reward[k] = float(v)
         if counts:
             for k, v in counts.items():
-                if k in self.counts:
-                    self.counts[k] = int(v)
+                action = self._decode(k)
+                self._register_action(action)
+                self.counts[k] = int(v)
+        if isinstance(baseline, (int, float)):
+            self._baseline = float(baseline)
+        if isinstance(baseline_updates, int):
+            self._baseline_updates = max(0, baseline_updates)
         if last_action and isinstance(last_action, dict):
             subset = tuple(last_action.get("features", ()))
             model = last_action.get("model")
@@ -142,6 +262,9 @@ class AutoMLController:
         sec["policy"] = self.theta
         sec["avg_reward"] = self.avg_reward
         sec["counts"] = self.counts
+        if self.baseline_momentum is not None:
+            sec["baseline"] = self._baseline
+            sec["baseline_updates"] = self._baseline_updates
         if self.last_action is not None:
             sec["last_action"] = {
                 "features": list(self.last_action[0]),
@@ -158,34 +281,53 @@ class AutoMLController:
     # ------------------------------------------------------------------
     # Policy logic
     # ------------------------------------------------------------------
-    def _probs(self) -> List[float]:
-        # ``self.action_keys`` mirrors ``self.action_space`` so weights are
-        # retrieved without recomputing keys.
-        weights = [self.theta[k] for k in self.action_keys]
+    def _probs(self, keys: Sequence[str]) -> List[float]:
+        weights = [self.theta.get(k, 0.0) for k in keys]
         max_w = max(weights)
         exps = [math.exp(w - max_w) for w in weights]
         s = sum(exps)
+        if s == 0.0:
+            return [1.0 / len(keys)] * len(keys)
         return [e / s for e in exps]
 
     def sample_action(self) -> Tuple[Action, List[float]]:
         """Sample an action according to the current policy."""
-        probs = self._probs()
-        action = random.choices(self.action_space, probs)[0]
+        if not self._current_actions:
+            self._prepare_episode_actions()
+        probs = self._probs(self._current_keys)
+        action = random.choices(self._current_actions, probs)[0]
         self.last_action = action
         return action, probs
 
     def update(self, action: Action, reward: float, alpha: float = 0.1) -> None:
         """Update policy parameters for ``action`` with ``reward``."""
-        probs = self._probs()
-        chosen = self.action_space.index(action)
-        for i, k in enumerate(self.action_keys):
+        key = self._register_action(action)
+        if not self._current_actions or key not in self._current_keys:
+            self._prepare_episode_actions(include=[action])
+
+        probs = self._probs(self._current_keys)
+        chosen = self._current_keys.index(key)
+
+        advantage = reward
+        if self.baseline_momentum is not None:
+            advantage = reward - self._baseline
+            if self._baseline_updates == 0:
+                self._baseline = reward
+            else:
+                momentum = self.baseline_momentum
+                if momentum is not None:
+                    self._baseline = momentum * self._baseline + (1 - momentum) * reward
+            self._baseline_updates += 1
+
+        for i, k in enumerate(self._current_keys):
             grad = (1.0 if i == chosen else 0.0) - probs[i]
-            self.theta[k] += alpha * reward * grad
-        k = self.action_keys[chosen]
-        self.counts[k] += 1
-        c = self.counts[k]
-        self.avg_reward[k] += (reward - self.avg_reward[k]) / c
+            self.theta[k] += alpha * advantage * grad
+        self.counts[key] += 1
+        c = self.counts[key]
+        self.avg_reward[key] += (reward - self.avg_reward[key]) / c
         self.last_action = action
+        self._current_actions = []
+        self._current_keys = []
         self._save()
 
     def train(
@@ -198,6 +340,7 @@ class AutoMLController:
     ) -> None:
         """Train the controller in ``env`` for ``episodes`` iterations."""
         for _ in range(episodes):
+            self._prepare_episode_actions()
             action, _ = self.sample_action()
             result = env(action)
             if isinstance(result, tuple):
@@ -217,3 +360,9 @@ class AutoMLController:
             return None
         key = max(self.avg_reward, key=self.avg_reward.get)
         return self._decode(key)
+
+    @property
+    def action_space(self) -> List[Action]:  # pragma: no cover - compatibility shim
+        """Return the set of actions discovered so far."""
+
+        return list(self._known_actions.values())

--- a/botcopier/cli/__init__.py
+++ b/botcopier/cli/__init__.py
@@ -174,6 +174,18 @@ def train(
         False,
         help="Reuse previously learned AutoML controller policy",
     ),
+    controller_max_subset_size: Optional[int] = typer.Option(
+        None,
+        help="Maximum number of features per subset evaluated by the controller",
+    ),
+    controller_episode_sample_size: Optional[int] = typer.Option(
+        None,
+        help="Number of feature subsets sampled per controller episode",
+    ),
+    controller_baseline_momentum: Optional[float] = typer.Option(
+        None,
+        help="Momentum for the controller's reward baseline (set to 0 to disable)",
+    ),
 ) -> None:
     """Train a model from trade logs."""
     data_cfg, train_cfg, exec_cfg = _cfg(ctx)
@@ -207,6 +219,18 @@ def train(
         train_cfg = train_cfg.model_copy(update={"strategy_search": strategy_search})
     if reuse_controller:
         train_cfg = train_cfg.model_copy(update={"reuse_controller": reuse_controller})
+    if controller_max_subset_size is not None:
+        train_cfg = train_cfg.model_copy(
+            update={"controller_max_subset_size": controller_max_subset_size}
+        )
+    if controller_episode_sample_size is not None:
+        train_cfg = train_cfg.model_copy(
+            update={"controller_episode_sample_size": controller_episode_sample_size}
+        )
+    if controller_baseline_momentum is not None:
+        train_cfg = train_cfg.model_copy(
+            update={"controller_baseline_momentum": controller_baseline_momentum}
+        )
     _store_config(ctx, data_cfg, train_cfg, exec_cfg)
     if data_cfg.data is None or data_cfg.out is None:
         raise typer.BadParameter("data_dir and out_dir must be provided")
@@ -223,6 +247,9 @@ def train(
         hrp_allocation=train_cfg.hrp_allocation,
         strategy_search=train_cfg.strategy_search,
         reuse_controller=train_cfg.reuse_controller,
+        controller_max_subset_size=train_cfg.controller_max_subset_size,
+        controller_episode_sample_size=train_cfg.controller_episode_sample_size,
+        controller_baseline_momentum=train_cfg.controller_baseline_momentum,
         regime_features=train_cfg.regime_features,
         config_hash=config_hash,
         config_snapshot=snapshot.as_dict(),

--- a/config/settings.py
+++ b/config/settings.py
@@ -114,6 +114,9 @@ class TrainingConfig(BaseSettings):
     experiment_name: Optional[str] = None
     metrics: List[str] = []
     reuse_controller: bool = False
+    controller_max_subset_size: Optional[int] = None
+    controller_episode_sample_size: Optional[int] = None
+    controller_baseline_momentum: Optional[float] = 0.9
     meta_weights: Optional[Path] = None
 
     model_config = {"env_prefix": "TRAIN_", "extra": "forbid"}

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -428,6 +428,42 @@
           "title": "Reuse Controller",
           "type": "boolean"
         },
+        "controller_max_subset_size": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Controller Max Subset Size"
+        },
+        "controller_episode_sample_size": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Controller Episode Sample Size"
+        },
+        "controller_baseline_momentum": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": 0.9,
+          "title": "Controller Baseline Momentum"
+        },
         "meta_weights": {
           "anyOf": [
             {


### PR DESCRIPTION
## Summary
- add lazy AutoML controller action sampling with configurable subset limits and a baseline critic
- propagate controller hyperparameters through the training pipeline, CLI, and online trainer
- extend configuration schema and add a stress test to bound action growth when many features exist

## Testing
- pytest tests/test_automl_controller.py
- pytest tests/test_online_trainer_live_ticks.py *(fails: ModuleNotFoundError: pandas)*


------
https://chatgpt.com/codex/tasks/task_e_68cae59eb888832f80c219e936340c50