### PR TITLE
Add multi-symbol attention model and pipeline integration

### DIFF
--- a/botcopier/models/schema.py
+++ b/botcopier/models/schema.py
@@ -43,6 +43,14 @@ class ModelParams(BaseModel):
     regime_gating: dict[str, Any] | None = Field(
         default=None, description="Serialised gating network parameters"
     )
+    attention_weights: dict[str, list[float]] = Field(
+        default_factory=dict,
+        description="Learned neighbour attention weights per symbol",
+    )
+    neighbor_order: dict[str, list[str]] = Field(
+        default_factory=dict,
+        description="Ordered neighbour symbols used by attention modules",
+    )
     version: Literal[1] = 1
 
     model_config = ConfigDict(extra="allow")


### PR DESCRIPTION
## Summary
- add a SymbolContextAttention module that aggregates symbol neighbour context with multi-head attention
- register a new fit_multi_symbol_attention builder, extend ModelParams, and wire pipeline support for --model-type=multi_symbol with symbol graph metadata
- add a synthetic regression test covering accuracy gains from the multi-symbol attention head

## Testing
- pytest tests/test_deep_models.py *(skipped: numpy dependency unavailable)*
- pytest tests/test_train_target_clone_features.py::test_neighbor_correlation_features *(fails: numpy dependency unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68cb3be32124832fb4dceb17932a8739