### PR TITLE
Refactor feature configuration to avoid global state

### DIFF
--- a/botcopier/data/loading.py
+++ b/botcopier/data/loading.py
@@ -13,7 +13,11 @@ import pandas as pd
 from opentelemetry import trace
 
 from botcopier.exceptions import DataError
-from botcopier.features.augmentation import _augment_dataframe, _augment_dtw_dataframe
+from botcopier.features.engineering import (
+    FeatureConfig,
+    _augment_dataframe,
+    _augment_dtw_dataframe,
+)
 
 from ..scripts.data_validation import validate_logs
 
@@ -122,6 +126,7 @@ def _load_logs_impl(
     mmap_threshold: int = 50 * 1024 * 1024,
     depth_file: Path | None = None,
     dask: bool = False,
+    feature_config: FeatureConfig | None = None,
 ) -> Tuple[Iterable[pd.DataFrame] | pd.DataFrame, list[str], dict[str, str]]:
     """Load trade logs from ``trades_raw.csv``.
 
@@ -299,9 +304,9 @@ def _load_logs_impl(
 
         if augment_ratio > 0:
             if dtw_augment:
-                df = _augment_dtw_dataframe(df, augment_ratio)
+                df = _augment_dtw_dataframe(df, augment_ratio, config=feature_config)
             else:
-                df = _augment_dataframe(df, augment_ratio)
+                df = _augment_dataframe(df, augment_ratio, config=feature_config)
 
         return df, feature_cols
 

--- a/botcopier/features/__init__.py
+++ b/botcopier/features/__init__.py
@@ -1,7 +1,14 @@
 """Convenience exports for feature utilities."""
 from .anomaly import _clip_apply, _clip_train_features, _score_anomalies
-from .augmentation import _augment_dataframe, _augment_dtw_dataframe
-from .technical import _extract_features, _neutralize_against_market_index
+from .engineering import (
+    FeatureConfig,
+    _augment_dataframe,
+    _augment_dtw_dataframe,
+    _extract_features,
+    clear_cache,
+    configure_cache,
+)
+from .technical import _neutralize_against_market_index
 from .indicator_discovery import evolve_indicators
 
 __all__ = [
@@ -12,5 +19,8 @@ __all__ = [
     "_score_anomalies",
     "_extract_features",
     "_neutralize_against_market_index",
+    "FeatureConfig",
+    "configure_cache",
+    "clear_cache",
     "evolve_indicators",
 ]

--- a/botcopier/scripts/cluster_regimes.py
+++ b/botcopier/scripts/cluster_regimes.py
@@ -23,7 +23,11 @@ except Exception:  # pragma: no cover - optional
 
 # Reuse data loading and feature extraction from training script
 from botcopier.data.loading import _load_calendar, _load_logs
-from botcopier.features.engineering import _extract_features
+from botcopier.features.engineering import (
+    FeatureConfig,
+    _extract_features,
+    configure_cache,
+)
 
 
 def cluster_features(
@@ -36,12 +40,14 @@ def cluster_features(
     event_window: float = 60.0,
 ) -> None:
     """Cluster feature vectors and write model to ``out_file``."""
-    rows_df, _, _ = _load_logs(data_dir)
+    feature_config = configure_cache(FeatureConfig())
+    rows_df, _, _ = _load_logs(data_dir, feature_config=feature_config)
     feats, *_ = _extract_features(
         rows_df.to_dict("records"),
         corr_map=corr_map,
         calendar_events=calendar_events,
         event_window=event_window,
+        config=feature_config,
     )
     if not feats:
         raise ValueError("No features found for clustering")

--- a/botcopier/scripts/detect_regime.py
+++ b/botcopier/scripts/detect_regime.py
@@ -22,7 +22,11 @@ except Exception:  # pragma: no cover - optional
     hdbscan = None
 
 from botcopier.data.loading import _load_calendar, _load_logs
-from botcopier.features.engineering import _extract_features
+from botcopier.features.engineering import (
+    FeatureConfig,
+    _extract_features,
+    configure_cache,
+)
 
 
 def detect_regimes(
@@ -53,12 +57,14 @@ def detect_regimes(
         regime information and gating weights are merged into this file so
         that downstream utilities can embed them into generated strategies.
     """
-    rows_df, _, _ = _load_logs(data_dir)
+    feature_config = configure_cache(FeatureConfig())
+    rows_df, _, _ = _load_logs(data_dir, feature_config=feature_config)
     feats, *_ = _extract_features(
         rows_df.to_dict("records"),
         corr_map=corr_map,
         calendar_events=calendar_events,
         event_window=event_window,
+        config=feature_config,
     )
     if not feats:
         raise ValueError("No features found for clustering")

--- a/botcopier/training/pipeline.py
+++ b/botcopier/training/pipeline.py
@@ -1364,8 +1364,12 @@ def train(
                 [float(threshold_grid_param)], dtype=float
             )
     set_seed(random_seed)
-    configure_cache(
-        FeatureConfig(cache_dir=cache_dir, enabled_features=set(features or []))
+    feature_config = configure_cache(
+        FeatureConfig(
+            cache_dir=cache_dir,
+            enabled_features=set(features or []),
+            n_jobs=n_jobs,
+        )
     )
     memory = Memory(str(cache_dir) if cache_dir else None, verbose=0)
     _classification_metrics_cached = memory.cache(_classification_metrics)
@@ -1471,6 +1475,7 @@ def train(
         "dask",
     ]
     load_kwargs = {k: kwargs[k] for k in load_keys if k in kwargs}
+    load_kwargs.setdefault("feature_config", feature_config)
     with tracer.start_as_current_span("data_load"):
         logs, feature_names, data_hashes = _load_logs(data_dir, **load_kwargs)
     news_embeddings_df, news_hashes = _load_news_embeddings(data_dir)
@@ -1582,6 +1587,7 @@ def train(
                     news_embeddings=news_embeddings_df,
                     news_embedding_window=news_window_param,
                     news_embedding_horizon=news_horizon_seconds,
+                    config=feature_config,
                     **feature_extra_kwargs,
                 )
             meta_entry = technical_features._FEATURE_METADATA.get("__news_embeddings__")
@@ -1664,6 +1670,7 @@ def train(
                 news_embeddings=news_embeddings_df,
                 news_embedding_window=news_window_param,
                 news_embedding_horizon=news_horizon_seconds,
+                config=feature_config,
                 **feature_extra_kwargs,
             )
         meta_entry = technical_features._FEATURE_METADATA.get("__news_embeddings__")

--- a/tests/test_candlestick_patterns.py
+++ b/tests/test_candlestick_patterns.py
@@ -63,7 +63,8 @@ def _synthetic_rows():
 
 
 def test_pattern_detection_rows():
-    feats, *_ = extract_rows_features(_synthetic_rows())
+    config = fe.configure_cache(fe.FeatureConfig())
+    feats, *_ = extract_rows_features(_synthetic_rows(), config=config)
     assert feats[0]["pattern_hammer"] == 1.0
     assert feats[1]["pattern_doji"] == 1.0
     assert feats[2]["pattern_engulfing"] == 1.0
@@ -71,14 +72,14 @@ def test_pattern_detection_rows():
 
 def test_pattern_detection_dataframe(tmp_path, caplog):
     cache_dir = tmp_path / "cache"
-    configure_cache(FeatureConfig(cache_dir=cache_dir))
-    clear_cache()
+    config = configure_cache(FeatureConfig(cache_dir=cache_dir))
+    clear_cache(config)
     rows = _synthetic_rows()
     df = pd.DataFrame(rows)
     feature_cols = ["price"]
     with caplog.at_level(logging.INFO):
-        df, feature_cols, *_ = _extract_features(df, feature_cols)
-        _extract_features(df, feature_cols)
+        df, feature_cols, *_ = _extract_features(df, feature_cols, config=config)
+        _extract_features(df, feature_cols, config=config)
     assert "cache hit for _extract_features" in caplog.text
     assert "pattern_hammer" in feature_cols
     assert "pattern_doji" in feature_cols

--- a/tests/test_contrastive_encoder.py
+++ b/tests/test_contrastive_encoder.py
@@ -28,8 +28,8 @@ def _write_ticks(dir_path: Path, n: int = 50) -> None:
 
 def test_contrastive_encoder_flow(tmp_path: Path, caplog):
     cache_dir = tmp_path / "cache"
-    configure_cache(FeatureConfig(cache_dir=cache_dir))
-    clear_cache()
+    feature_config = configure_cache(FeatureConfig(cache_dir=cache_dir))
+    clear_cache(feature_config)
     tick_dir = tmp_path / "ticks"
     tick_dir.mkdir()
     _write_ticks(tick_dir)
@@ -42,8 +42,10 @@ def test_contrastive_encoder_flow(tmp_path: Path, caplog):
     # verify feature extraction
     df = pd.DataFrame({f"tick_{i}": [float(i)] for i in range(window)})
     with caplog.at_level(logging.INFO):
-        df2, feats, _, _ = _extract_features(df.copy(), [], tick_encoder=enc_path)
-        _extract_features(df.copy(), [], tick_encoder=enc_path)
+        df2, feats, _, _ = _extract_features(
+            df.copy(), [], tick_encoder=enc_path, config=feature_config
+        )
+        _extract_features(df.copy(), [], tick_encoder=enc_path, config=feature_config)
     assert "cache hit for _extract_features" in caplog.text
     for i in range(dim):
         assert f"enc_{i}" in feats

--- a/tests/test_csd_features.py
+++ b/tests/test_csd_features.py
@@ -16,9 +16,9 @@ def test_csd_features_shapes_and_ranges(tmp_path):
             data.append({"event_time": t, "symbol": sym, "price": p})
     df = pd.DataFrame(data)
 
-    configure_cache(FeatureConfig(enabled_features={"csd"}))
+    config = configure_cache(FeatureConfig(enabled_features={"csd"}))
     feats, cols, _, _ = _extract_features(
-        df.copy(), [], symbol_graph=Path("symbol_graph.json")
+        df.copy(), [], symbol_graph=Path("symbol_graph.json"), config=config
     )
     configure_cache(FeatureConfig())
 

--- a/tests/test_depth_cnn_embeddings.py
+++ b/tests/test_depth_cnn_embeddings.py
@@ -9,7 +9,7 @@ import botcopier.features.technical as technical
 
 
 def test_depth_cnn_deterministic(tmp_path: Path) -> None:
-    fe.configure_cache(fe.FeatureConfig(enabled_features={"orderbook"}))
+    config = fe.configure_cache(fe.FeatureConfig(enabled_features={"orderbook"}))
     df = pd.DataFrame(
         {
             "bid_depth": [np.array([1.0, 2.0, 3.0]), np.array([2.0, 3.0, 4.0])],
@@ -18,7 +18,7 @@ def test_depth_cnn_deterministic(tmp_path: Path) -> None:
             "ask": [1.1, 1.1],
         }
     )
-    df1, feats1, _, _ = technical._extract_features(df.copy(), [])
+    df1, feats1, _, _ = technical._extract_features(df.copy(), [], config=config)
     state = technical._DEPTH_CNN_STATE
     assert state is not None
     model_file = tmp_path / "model.json"
@@ -29,7 +29,9 @@ def test_depth_cnn_deterministic(tmp_path: Path) -> None:
     tech = importlib.import_module("botcopier.features.technical")
     tech._DEPTH_CNN_STATE = None
     saved = json.loads(model_file.read_text())["depth_cnn"]
-    df2, feats2, _, _ = technical._extract_features(df.copy(), [], depth_cnn=saved)
+    df2, feats2, _, _ = technical._extract_features(
+        df.copy(), [], depth_cnn=saved, config=config
+    )
     emb_cols = [c for c in feats1 if c.startswith("depth_cnn_")]
     for col in emb_cols:
         assert np.allclose(df1[col], df2[col])

--- a/tests/test_feature_plugins.py
+++ b/tests/test_feature_plugins.py
@@ -101,13 +101,13 @@ def test_entry_point_plugin(monkeypatch):
     )
 
     # enable plugin via configuration
-    configure_cache(FeatureConfig(enabled_features={"ep"}))
+    config = configure_cache(FeatureConfig(enabled_features={"ep"}))
 
     # replace heavy technical plugin with a no-op for the test
     FEATURE_REGISTRY["technical"] = lambda df, names, **kwargs: (df, names, {}, {})
 
     df = pd.DataFrame({"price": [1.0]})
-    out, cols, *_ = technical._extract_features(df, [])
+    out, cols, *_ = technical._extract_features(df, [], config=config)
     assert "ep" in cols
     assert out["ep"].iloc[0] == 1.0
 
@@ -121,13 +121,13 @@ def test_register_feature_direct():
         names.append("direct")
         return df, names, {}, {}
 
-    configure_cache(FeatureConfig(enabled_features={"direct"}))
+    config = configure_cache(FeatureConfig(enabled_features={"direct"}))
 
     # replace heavy technical plugin with a no-op for the test
     FEATURE_REGISTRY["technical"] = lambda df, names, **kwargs: (df, names, {}, {})
 
     df = pd.DataFrame({"price": [1.0]})
-    out, cols, *_ = technical._extract_features(df, [])
+    out, cols, *_ = technical._extract_features(df, [], config=config)
     assert "direct" in cols
     assert out["direct"].iloc[0] == 2.0
     FEATURE_REGISTRY.pop("direct", None)

--- a/tests/test_n_jobs_deterministic.py
+++ b/tests/test_n_jobs_deterministic.py
@@ -36,8 +36,13 @@ def _sample_df() -> pd.DataFrame:
 def test_extract_features_deterministic_n_jobs() -> None:
     df = _sample_df()
     feature_names: list[str] = []
-    df1, fn1, emb1, gnn1 = _extract_features_impl(df.copy(), feature_names.copy(), n_jobs=1)
-    df2, fn2, emb2, gnn2 = _extract_features_impl(df.copy(), feature_names.copy(), n_jobs=2)
+    config = fe.configure_cache(fe.FeatureConfig())
+    df1, fn1, emb1, gnn1 = _extract_features_impl(
+        df.copy(), feature_names.copy(), n_jobs=1, config=config
+    )
+    df2, fn2, emb2, gnn2 = _extract_features_impl(
+        df.copy(), feature_names.copy(), n_jobs=2, config=config
+    )
     pd.testing.assert_frame_equal(df1, df2)
     assert fn1 == fn2
     assert emb1 == emb2
@@ -47,10 +52,14 @@ def test_extract_features_deterministic_n_jobs() -> None:
 def test_engineering_wrapper_respects_n_jobs() -> None:
     df = _sample_df()
     feature_names: list[str] = []
-    with fe._CONFIG.override(n_jobs=1):
-        df1, fn1, emb1, gnn1 = fe._extract_features(df.copy(), feature_names.copy())
-    with fe._CONFIG.override(n_jobs=2):
-        df2, fn2, emb2, gnn2 = fe._extract_features(df.copy(), feature_names.copy())
+    config1 = fe.configure_cache(fe.FeatureConfig(n_jobs=1))
+    df1, fn1, emb1, gnn1 = fe._extract_features(
+        df.copy(), feature_names.copy(), config=config1
+    )
+    config2 = fe.configure_cache(fe.FeatureConfig(n_jobs=2))
+    df2, fn2, emb2, gnn2 = fe._extract_features(
+        df.copy(), feature_names.copy(), config=config2
+    )
     pd.testing.assert_frame_equal(df1, df2)
     assert fn1 == fn2
     assert emb1 == emb2

--- a/tests/test_orderbook_features.py
+++ b/tests/test_orderbook_features.py
@@ -12,8 +12,8 @@ def test_orderbook_features_shapes_and_ranges():
             "ask_depth": [[4, 5], [3, 6], [2, 7]],
         }
     )
-    configure_cache(FeatureConfig(enabled_features={"orderbook"}))
-    feats, cols, _, _ = _extract_features(df.copy(), [])
+    config = configure_cache(FeatureConfig(enabled_features={"orderbook"}))
+    feats, cols, _, _ = _extract_features(df.copy(), [], config=config)
     configure_cache(FeatureConfig())  # reset for other tests
 
     assert {"depth_microprice", "depth_vol_imbalance", "depth_order_flow_imbalance"} <= set(

--- a/tests/test_strategy_search.py
+++ b/tests/test_strategy_search.py
@@ -127,8 +127,10 @@ class FeatureConfig:
         self.enabled_features = enabled_features
 
 engineering_mod.FeatureConfig = FeatureConfig
-engineering_mod.configure_cache = lambda config: None
-engineering_mod._extract_features = lambda df, names, n_jobs=None: (df, names, None, None)
+engineering_mod.configure_cache = lambda config: config
+engineering_mod._extract_features = (
+    lambda df, names, n_jobs=None, **kwargs: (df, names, None, None)
+)
 engineering_mod._neutralize_against_market_index = lambda df, n_jobs=None: df
 
 augmentation_mod = types.ModuleType("augmentation")

--- a/tests/test_train_target_clone_multi.py
+++ b/tests/test_train_target_clone_multi.py
@@ -19,12 +19,14 @@ def test_multi_horizon_training(tmp_path: Path, caplog) -> None:
     data.write_text("".join(rows))
 
     cache_dir = tmp_path / "cache"
-    configure_cache(FeatureConfig(cache_dir=cache_dir))
-    clear_cache()
-    df, feature_cols, _ = _load_logs(data)
+    feature_config = configure_cache(FeatureConfig(cache_dir=cache_dir))
+    clear_cache(feature_config)
+    df, feature_cols, _ = _load_logs(data, feature_config=feature_config)
     with caplog.at_level(logging.INFO):
-        df, feature_cols, _, _ = _extract_features(df, feature_cols)
-        _extract_features(df, feature_cols)
+        df, feature_cols, _, _ = _extract_features(
+            df, feature_cols, config=feature_config
+        )
+        _extract_features(df, feature_cols, config=feature_config)
     assert "cache hit for _extract_features" in caplog.text
     assert df["label_h5"].notna().all()
     assert df["label_h20"].notna().all()

--- a/tests/test_wavelet_packets.py
+++ b/tests/test_wavelet_packets.py
@@ -102,7 +102,7 @@ def _sample_wavelet_df(rows: int = 48) -> pd.DataFrame:
 
 
 def test_wavelet_packets_features_and_metadata():
-    configure_cache(FeatureConfig(enabled_features={"wavelet_packets"}))
+    config = configure_cache(FeatureConfig(enabled_features={"wavelet_packets"}))
     try:
         df = _sample_wavelet_df()
         feature_names: list[str] = []
@@ -111,6 +111,7 @@ def test_wavelet_packets_features_and_metadata():
             feature_names,
             wavelet_windows=(16, 32),
             wavelet_stats=("mean", "energy"),
+            config=config,
         )
 
         expected_columns = {
@@ -154,6 +155,7 @@ def test_wavelet_packets_features_and_metadata():
             list(feats),
             wavelet_windows=(16, 32),
             wavelet_stats=("mean", "energy"),
+            config=config,
         )
         assert feats_cached == feats
         assert out_cached is out


### PR DESCRIPTION
## Summary
- scope feature caching to `FeatureConfig` instances and plumb the configuration object through `_extract_features` and plugin dispatch
- update the training pipeline, CLI scripts, and data loader to create or reuse a feature configuration and pass it into feature extraction
- adjust feature-related tests to operate on isolated configurations and add coverage ensuring per-config cache isolation

## Testing
- `pytest tests/test_cache_performance.py tests/test_n_jobs_deterministic.py tests/test_feature_plugins.py tests/test_csd_features.py tests/test_orderbook_features.py tests/test_regime_assignment.py tests/test_wavelet_packets.py tests/test_depth_cnn_embeddings.py tests/test_train_target_clone_multi.py tests/test_contrastive_encoder.py` *(fails: missing optional numpy/pandas dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68ccba425d9c832f85ae217db1197510