### PR TITLE
Ensure feature configs are explicit per invocation

### DIFF
--- a/botcopier/features/engineering.py
+++ b/botcopier/features/engineering.py
@@ -116,9 +116,6 @@ class FeatureConfig:
                 self.refresh()
 
 
-_DEFAULT_FEATURE_CONFIG = FeatureConfig()
-
-
 def _resolve_n_jobs(config: FeatureConfig, n_jobs: int | None) -> int:
     """Return an effective ``n_jobs`` respecting the provided configuration."""
 
@@ -306,22 +303,21 @@ def configure_cache(config: FeatureConfig | None = None) -> FeatureConfig:
     return cfg
 
 
-def clear_cache(config: FeatureConfig | None = None) -> None:
+def clear_cache(config: FeatureConfig) -> None:
     """Remove cached feature computations bound to ``config``."""
 
-    cfg = config or _DEFAULT_FEATURE_CONFIG
-    cfg.clear()
+    config.clear()
     _technical._FEATURE_METADATA.clear()
 
 
 def _augment_dataframe(*args, config: FeatureConfig | None = None, **kwargs):
-    cfg = config or _DEFAULT_FEATURE_CONFIG
+    cfg = config or FeatureConfig()
     func = cfg.cache_function("_augment_dataframe", _augmentation._augment_dataframe_impl)
     return func(*args, **kwargs)
 
 
 def _augment_dtw_dataframe(*args, config: FeatureConfig | None = None, **kwargs):
-    cfg = config or _DEFAULT_FEATURE_CONFIG
+    cfg = config or FeatureConfig()
     func = cfg.cache_function(
         "_augment_dtw_dataframe", _augmentation._augment_dtw_dataframe_impl
     )
@@ -330,7 +326,7 @@ def _augment_dtw_dataframe(*args, config: FeatureConfig | None = None, **kwargs)
 
 def _extract_features(*args, **kwargs):
     config = kwargs.pop("config", None)
-    cfg = config or _DEFAULT_FEATURE_CONFIG
+    cfg = config or FeatureConfig()
     call_kwargs = dict(kwargs)
     call_kwargs.setdefault("n_jobs", cfg.n_jobs)
     return _technical._extract_features(*args, config=cfg, **call_kwargs)
@@ -350,9 +346,6 @@ def _clip_apply(*args, **kwargs):
 
 def _score_anomalies(*args, **kwargs):
     return _anomaly._score_anomalies(*args, **kwargs)
-
-
-configure_cache(_DEFAULT_FEATURE_CONFIG)
 
 
 def train(*args, **kwargs):

--- a/docs/data_loading_tutorial.md
+++ b/docs/data_loading_tutorial.md
@@ -5,11 +5,12 @@ This tutorial demonstrates how to load trade logs and derive features.
 ```python
 >>> from pathlib import Path
 >>> from botcopier.data.loading import _load_logs
->>> from botcopier.features.engineering import _extract_features
->>> df, feature_cols, _ = _load_logs(Path('tests/fixtures/trades_small.csv'))
+>>> from botcopier.features.engineering import FeatureConfig, _extract_features, configure_cache
+>>> feature_config = configure_cache(FeatureConfig())
+>>> df, feature_cols, _ = _load_logs(Path('tests/fixtures/trades_small.csv'), feature_config=feature_config)
 >>> bool(len(df))
 True
->>> _, cols, *_ = _extract_features(df, feature_names=list(feature_cols))
+>>> _, cols, *_ = _extract_features(df, feature_names=list(feature_cols), config=feature_config)
 >>> set(cols) == set(feature_cols)
 True
 >>>

--- a/tests/performance/test_benchmarks.py
+++ b/tests/performance/test_benchmarks.py
@@ -7,21 +7,30 @@ import pytest
 pytest.importorskip("pytest_benchmark")
 
 from botcopier.data.loading import _load_logs
-from botcopier.features.engineering import _extract_features
+from botcopier.features.engineering import (
+    FeatureConfig,
+    _extract_features,
+    configure_cache,
+)
 from botcopier.scripts.evaluation import evaluate
 
 
 def test_load_logs_benchmark(benchmark):
     """Benchmark the log loading routine."""
     data_file = Path("tests/fixtures/trades_small.csv")
-    benchmark(lambda: _load_logs(data_file))
+    benchmark(lambda: _load_logs(data_file, feature_config=configure_cache(FeatureConfig())))
 
 
 def test_feature_engineering_benchmark(benchmark):
     """Benchmark feature extraction."""
     data_file = Path("tests/fixtures/trades_small.csv")
-    df, feature_cols, _ = _load_logs(data_file)
-    benchmark(lambda: _extract_features(df.copy(), feature_names=list(feature_cols)))
+    config = configure_cache(FeatureConfig())
+    df, feature_cols, _ = _load_logs(data_file, feature_config=config)
+    benchmark(
+        lambda: _extract_features(
+            df.copy(), feature_names=list(feature_cols), config=configure_cache(FeatureConfig())
+        )
+    )
 
 
 def test_evaluation_benchmark(benchmark, tmp_path):

--- a/tests/test_cache_performance.py
+++ b/tests/test_cache_performance.py
@@ -42,7 +42,8 @@ def test_feature_cache_speed(tmp_path):
     )
     t2 = perf_counter() - start
 
-    configure_cache(FeatureConfig())
+    reset_config = configure_cache(FeatureConfig())
+    assert reset_config.cache_dir is None
 
     assert f1.equals(f2)
     assert c1 == c2
@@ -81,3 +82,4 @@ def test_feature_config_isolation(tmp_path):
     assert any(col.startswith("csd_") for col in cols_csd)
     assert not any(col.startswith("csd_") for col in cols_default)
     assert set(feats_default.columns) == set(cols_default)
+    assert config_default.enabled_features == set()

--- a/tests/test_cross_symbol_correlations.py
+++ b/tests/test_cross_symbol_correlations.py
@@ -3,7 +3,11 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 
-from botcopier.features.engineering import _extract_features
+from botcopier.features.engineering import (
+    FeatureConfig,
+    _extract_features,
+    configure_cache,
+)
 
 
 def test_cross_symbol_correlations(tmp_path: Path) -> None:
@@ -16,11 +20,13 @@ def test_cross_symbol_correlations(tmp_path: Path) -> None:
     )
     feature_cols = ["price"]
     sg_path = Path("symbol_graph.json")
+    config = configure_cache(FeatureConfig())
     df, feature_cols, _, _ = _extract_features(
         data.copy(),
         feature_cols,
         symbol_graph=sg_path,
         neighbor_corr_windows=[3],
+        config=config,
     )
     corr_cols = ["corr_EURUSD_USDCHF_w3", "corr_USDCHF_EURUSD_w3"]
     for col in corr_cols:

--- a/tests/test_dask_determinism.py
+++ b/tests/test_dask_determinism.py
@@ -2,16 +2,24 @@ from pathlib import Path
 import numpy as np
 
 from botcopier.data.loading import _load_logs
-from botcopier.features.engineering import _extract_features
+from botcopier.features.engineering import (
+    FeatureConfig,
+    _extract_features,
+    configure_cache,
+)
 
 
 def test_pandas_dask_equivalence():
     data = Path("tests/fixtures/trades_small.csv")
-    pdf, feats, _ = _load_logs(data)
-    ddf, feats2, _ = _load_logs(data, dask=True)
+    pdf, feats, _ = _load_logs(data, feature_config=configure_cache(FeatureConfig()))
+    ddf, feats2, _ = _load_logs(
+        data, dask=True, feature_config=configure_cache(FeatureConfig())
+    )
     assert feats == feats2
-    pdf_feat, feats, *_ = _extract_features(pdf.copy(), feats)
-    ddf_feat, feats, *_ = _extract_features(ddf, feats)
+    pdf_feat, feats, *_ = _extract_features(
+        pdf.copy(), feats, config=configure_cache(FeatureConfig())
+    )
+    ddf_feat, feats, *_ = _extract_features(ddf, feats, config=configure_cache(FeatureConfig()))
     pd_vals = pdf_feat[feats].fillna(0).to_numpy()
     dd_vals = ddf_feat.compute()[feats].fillna(0).to_numpy()
     assert np.allclose(pd_vals, dd_vals)

--- a/tests/test_data_contract.py
+++ b/tests/test_data_contract.py
@@ -6,7 +6,11 @@ import pandas as pd
 import yaml
 
 from botcopier.data.loading import _load_logs
-from botcopier.features.engineering import _extract_features
+from botcopier.features.engineering import (
+    FeatureConfig,
+    _extract_features,
+    configure_cache,
+)
 from botcopier.training.pipeline import train
 
 
@@ -37,8 +41,11 @@ def test_data_contract(tmp_path: Path) -> None:
     assert len(model["coefficients"]) == len(expected)
 
     # validate feature types using extraction pipeline
-    logs, feature_names, _ = _load_logs(data_file)
-    df, feature_names, *_ = _extract_features(logs, feature_names)
+    feature_config = configure_cache(FeatureConfig())
+    logs, feature_names, _ = _load_logs(data_file, feature_config=feature_config)
+    df, feature_names, *_ = _extract_features(
+        logs, feature_names, config=feature_config
+    )
     for spec in schema["features"]:
         col = df[spec["name"]]
         assert pd.api.types.is_numeric_dtype(col)

--- a/tests/test_data_sanitization.py
+++ b/tests/test_data_sanitization.py
@@ -5,12 +5,13 @@ import types
 import pandas as pd
 
 stub = types.SimpleNamespace(
-    _augment_dataframe=lambda df, ratio: df,
-    _augment_dtw_dataframe=lambda df, ratio: df,
+    _augment_dataframe=lambda df, ratio, **_: df,
+    _augment_dtw_dataframe=lambda df, ratio, **_: df,
 )
 sys.modules.setdefault("botcopier.features.augmentation", stub)
 
 from botcopier.data.loading import _drop_duplicates_and_outliers, _load_logs
+from botcopier.features.engineering import FeatureConfig, configure_cache
 
 
 def _build_df() -> pd.DataFrame:
@@ -35,7 +36,9 @@ def test_load_logs_reports_sanitization(tmp_path, caplog):
     file_path = tmp_path / "trades_raw.csv"
     df.to_csv(file_path, index=False)
     with caplog.at_level(logging.INFO):
-        loaded, _, _ = _load_logs(file_path)
+        loaded, _, _ = _load_logs(
+            file_path, feature_config=configure_cache(FeatureConfig())
+        )
     assert len(loaded) == 100
     assert any(
         "Removed 1 duplicate rows and 1 outlier rows" in m for m in caplog.messages

--- a/tests/test_end_to_end_pipeline.py
+++ b/tests/test_end_to_end_pipeline.py
@@ -2,7 +2,11 @@ from datetime import datetime
 
 from sklearn.feature_extraction import DictVectorizer
 
-from botcopier.features.engineering import _extract_features
+from botcopier.features.engineering import (
+    FeatureConfig,
+    _extract_features,
+    configure_cache,
+)
 from scripts.model_fitting import fit_logistic_regression
 from scripts.evaluation import evaluate_model
 
@@ -34,7 +38,8 @@ def test_end_to_end_pipeline():
             "spread": 2.0,
         },
     ]
-    feats, labels, *_ = _extract_features(rows)
+    config = configure_cache(FeatureConfig())
+    feats, labels, *_ = _extract_features(rows, config=config)
     vec = DictVectorizer(sparse=False)
     X = vec.fit_transform(feats)
     clf = fit_logistic_regression(X, labels)

--- a/tests/test_features_module.py
+++ b/tests/test_features_module.py
@@ -6,7 +6,11 @@ np = pytest.importorskip("numpy")
 pd = pytest.importorskip("pandas")
 
 import botcopier.features.technical as technical
-from botcopier.features.engineering import _extract_features
+from botcopier.features.engineering import (
+    FeatureConfig,
+    _extract_features,
+    configure_cache,
+)
 
 
 def test_extract_features_basic():
@@ -36,7 +40,8 @@ def test_extract_features_basic():
             "spread": 2.0,
         },
     ]
-    feats, labels, *_ = _extract_features(rows)
+    config = configure_cache(FeatureConfig())
+    feats, labels, *_ = _extract_features(rows, config=config)
     assert len(feats) == 2
     assert labels.tolist() == [1, 0]
     assert "atr" in feats[0]
@@ -58,7 +63,8 @@ def test_mandatory_features_present():
             "profit": 1.0,
         }
     ]
-    feats, *_ = _extract_features(rows)
+    config = configure_cache(FeatureConfig())
+    feats, *_ = _extract_features(rows, config=config)
     for key in ["book_bid_vol", "book_ask_vol", "book_imbalance", "equity", "margin_level", "atr"]:
         assert key in feats[0]
 
@@ -84,12 +90,14 @@ def test_news_embeddings_metadata():
             {"symbol": "EURUSD", "timestamp": "2024-01-01T00:00:50Z", "emb0": 0.1, "emb1": 0.75},
         ]
     )
+    config = configure_cache(FeatureConfig())
     df, feature_names, _, _ = _extract_features(
         rows,
         [],
         news_embeddings=news,
         news_embedding_window=2,
         news_embedding_horizon=120.0,
+        config=config,
     )
     assert feature_names
     meta = technical._FEATURE_METADATA.get("__news_embeddings__")

--- a/tests/test_fractal_features.py
+++ b/tests/test_fractal_features.py
@@ -35,6 +35,7 @@ class _Memory:
 joblib.Memory = _Memory
 sys.modules.setdefault("joblib", joblib)
 
+from botcopier.features.engineering import FeatureConfig, configure_cache
 from botcopier.features.technical import _extract_features_impl
 
 
@@ -55,7 +56,8 @@ def _trending_series(n: int, seed: int = 0) -> np.ndarray:
 def test_random_walk_features():
     prices = _random_walk(200)
     df = pd.DataFrame({"symbol": ["EURUSD"] * len(prices), "price": prices})
-    out, features, *_ = _extract_features_impl(df.copy(), [])
+    config = configure_cache(FeatureConfig())
+    out, features, *_ = _extract_features_impl(df.copy(), [], config=config)
     assert "hurst" in features and "fractal_dim" in features
     h = out["hurst"].iloc[-1]
     f = out["fractal_dim"].iloc[-1]
@@ -66,7 +68,8 @@ def test_random_walk_features():
 def test_trending_series_features():
     prices = _trending_series(200)
     df = pd.DataFrame({"symbol": ["EURUSD"] * len(prices), "price": prices})
-    out, *_ = _extract_features_impl(df.copy(), [])
+    config = configure_cache(FeatureConfig())
+    out, *_ = _extract_features_impl(df.copy(), [], config=config)
     h = out["hurst"].iloc[-1]
     f = out["fractal_dim"].iloc[-1]
     assert h > 0.6

--- a/tests/test_graph_features.py
+++ b/tests/test_graph_features.py
@@ -6,6 +6,7 @@ import pandas as pd
 import pytest
 
 import botcopier.features.technical as technical
+from botcopier.features.engineering import FeatureConfig, configure_cache
 from botcopier.models.schema import ModelParams
 
 
@@ -24,8 +25,11 @@ def _build_graph() -> nx.Graph:
 def test_graph_features_update(tmp_path: Path) -> None:
     df = pd.DataFrame({"symbol": ["SYM"], "price": [1.0]})
     g = _build_graph()
+    config = configure_cache(FeatureConfig())
     feats: list[str] = []
-    out, feats1, *_ = technical._extract_features(df.copy(), feats, entity_graph=g)
+    out, feats1, *_ = technical._extract_features(
+        df.copy(), feats, entity_graph=g, config=config
+    )
     assert out["graph_article_count"].iloc[0] == 1
     assert out["graph_sentiment"].iloc[0] == 0.1
     assert "graph_article_count" in feats1
@@ -37,7 +41,9 @@ def test_graph_features_update(tmp_path: Path) -> None:
     g.add_node("A2", type="article", sentiment=0.6)
     g.add_edge("A2", "COMP2")
 
-    out2, feats2, *_ = technical._extract_features(df.copy(), [], entity_graph=g)
+    out2, feats2, *_ = technical._extract_features(
+        df.copy(), [], entity_graph=g, config=config
+    )
     assert out2["graph_article_count"].iloc[0] == 2
     assert out2["graph_sentiment"].iloc[0] == pytest.approx(0.35)
 

--- a/tests/test_symbolic_indicators.py
+++ b/tests/test_symbolic_indicators.py
@@ -5,6 +5,7 @@ import numpy as np
 import pandas as pd
 from sklearn.linear_model import LinearRegression
 
+from botcopier.features.engineering import FeatureConfig, configure_cache
 from botcopier.features.technical import _extract_features_impl
 from botcopier.features.indicator_discovery import evolve_indicators, evaluate_formula
 
@@ -34,8 +35,9 @@ def test_symbolic_indicators_improve_metrics(tmp_path: Path) -> None:
     series = evaluate_formula(df, ["a", "b"], formulas[0])
     assert np.isfinite(series).all()
 
+    config = configure_cache(FeatureConfig())
     df_feat, cols, *_ = _extract_features_impl(
-        df[["a", "b"]].copy(), ["a", "b"], model_json=model
+        df[["a", "b"]].copy(), ["a", "b"], model_json=model, config=config
     )
     assert any(c.startswith("sym_") for c in cols)
 

--- a/tests/test_train_target_clone_imputer.py
+++ b/tests/test_train_target_clone_imputer.py
@@ -6,6 +6,7 @@ import numpy as np
 from sklearn.linear_model import SGDClassifier
 from sklearn.preprocessing import RobustScaler
 
+from botcopier.features.engineering import FeatureConfig, configure_cache
 from botcopier.training.pipeline import (
     train,
     _load_logs,
@@ -44,8 +45,9 @@ def test_imputer_removes_nans_and_affects_coefficients(tmp_path):
     model = json.loads((out_dir / "model.json").read_text())
     imputer = pickle.loads(base64.b64decode(model["imputer"]))
 
-    df_raw, features_raw, _ = _load_logs(data)
-    df_raw, _, _, _ = _extract_features(df_raw, features_raw)
+    config = configure_cache(FeatureConfig())
+    df_raw, features_raw, _ = _load_logs(data, feature_config=config)
+    df_raw, _, _, _ = _extract_features(df_raw, features_raw, config=config)
     for col in model["feature_names"]:
         if col not in df_raw.columns:
             df_raw[col] = 0.0

--- a/tests/test_train_target_clone_sampling.py
+++ b/tests/test_train_target_clone_sampling.py
@@ -2,6 +2,7 @@ import json
 import numpy as np
 import torch
 
+from botcopier.features.engineering import FeatureConfig, configure_cache
 from botcopier.training.pipeline import (
     _load_logs,
     _extract_features,
@@ -19,8 +20,9 @@ def test_smote_balances_classes(tmp_path):
         lines.append(f"1,{2.0 + i*0.01},{i%24}")
     data.write_text("\n".join(lines))
 
-    df, features, _ = _load_logs(data)
-    df, features, _, _ = _extract_features(df, features)
+    config = configure_cache(FeatureConfig())
+    df, features, _ = _load_logs(data, feature_config=config)
+    df, features, _, _ = _extract_features(df, features, config=config)
     X = df[features].to_numpy(dtype=float)
     y = df["label"].astype(int).to_numpy()
     w = np.ones_like(y, dtype=float)

--- a/tests/test_train_target_clone_scaler.py
+++ b/tests/test_train_target_clone_scaler.py
@@ -4,6 +4,7 @@ import numpy as np
 import pandas as pd
 from sklearn.preprocessing import PowerTransformer, RobustScaler
 
+from botcopier.features.engineering import FeatureConfig, configure_cache
 from botcopier.training.pipeline import train, _load_logs, _extract_features
 
 
@@ -26,8 +27,9 @@ def test_scaler_robust_with_outliers(tmp_path):
     model = json.loads((out_dir / "model.json").read_text())
     params = model["session_models"]["asian"]
 
-    df, features, _ = _load_logs(data)
-    df, features, _, _ = _extract_features(df, features)
+    config = configure_cache(FeatureConfig())
+    df, features, _ = _load_logs(data, feature_config=config)
+    df, features, _, _ = _extract_features(df, features, config=config)
     X = df[features].to_numpy(dtype=float)
     skew = pd.DataFrame(X, columns=features).skew().abs()
     skew_cols = skew[skew > 1.0].index.tolist()


### PR DESCRIPTION
## Summary
- remove reliance on module-level feature configuration state by instantiating a `FeatureConfig` whenever callers omit one and clearing caches via the passed instance
- require an explicit configuration for technical feature extraction helpers and guard against accidental usage without one
- refresh documentation and tests to create isolated configs, pass them through loaders and extractors, and verify cache directory / feature flag overrides remain scoped to a single config

## Testing
- `pytest` *(fails: optional dependencies such as numpy, grpc, nats, and pydantic are unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ce070e6c94832fa3c4450afe73be81