### PR TITLE
Refactor training pipeline into modular components

### DIFF
--- a/botcopier/training/__init__.py
+++ b/botcopier/training/__init__.py
@@ -1,0 +1,24 @@
+"""Training utilities and orchestrators."""
+
+from . import evaluation, pipeline, preprocessing, sequence_builders, tracking, weighting
+from .pipeline import (
+    detect_resources,
+    predict_expected_value,
+    run_optuna,
+    sync_with_server,
+    train,
+)
+
+__all__ = [
+    "detect_resources",
+    "evaluation",
+    "predict_expected_value",
+    "pipeline",
+    "preprocessing",
+    "run_optuna",
+    "sequence_builders",
+    "sync_with_server",
+    "train",
+    "tracking",
+    "weighting",
+]

--- a/botcopier/training/evaluation.py
+++ b/botcopier/training/evaluation.py
@@ -1,0 +1,207 @@
+"""Evaluation helpers and Optuna integration for training."""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any, Callable, Mapping, Sequence
+
+import numpy as np
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+try:  # optional optuna support
+    import optuna
+
+    HAS_OPTUNA = True
+except ImportError:  # pragma: no cover - optional
+    optuna = None  # type: ignore
+    HAS_OPTUNA = False
+
+try:  # optional numba support
+    from numba import njit
+
+    HAS_NUMBA = True
+except Exception:  # pragma: no cover - optional
+
+    def njit(*a, **k):  # pragma: no cover - simple stub
+        def _inner(f):
+            return f
+
+        return _inner
+
+    HAS_NUMBA = False
+
+try:  # optional ray dependency
+    import ray  # type: ignore
+
+    HAS_RAY = True
+except ImportError:  # pragma: no cover
+    ray = None  # type: ignore
+    HAS_RAY = False
+
+
+if HAS_NUMBA:
+
+    @njit
+    def _max_drawdown_nb(returns: np.ndarray) -> float:
+        cum = 0.0
+        peak = 0.0
+        max_dd = 0.0
+        for r in returns:
+            cum += r
+            if cum > peak:
+                peak = cum
+            dd = peak - cum
+            if dd > max_dd:
+                max_dd = dd
+        return max_dd
+
+    @njit
+    def _var_95_nb(returns: np.ndarray) -> float:
+        if returns.size == 0:
+            return 0.0
+        sorted_r = np.sort(returns)
+        idx = int(0.05 * (sorted_r.size - 1))
+        return -sorted_r[idx]
+
+    def max_drawdown(returns: np.ndarray) -> float:
+        if returns.size == 0:
+            return 0.0
+        return float(_max_drawdown_nb(returns))
+
+    def var_95(returns: np.ndarray) -> float:
+        if returns.size == 0:
+            return 0.0
+        return float(_var_95_nb(returns))
+
+else:  # pragma: no cover - fallback without numba
+
+    def max_drawdown(returns: np.ndarray) -> float:
+        """Return the maximum drawdown of ``returns``."""
+
+        if returns.size == 0:
+            return 0.0
+        cum = np.cumsum(returns, dtype=float)
+        peak = np.maximum.accumulate(cum)
+        dd = peak - cum
+        return float(np.max(dd))
+
+    def var_95(returns: np.ndarray) -> float:
+        """Return the 95% Value at Risk of ``returns``."""
+
+        if returns.size == 0:
+            return 0.0
+        return float(-np.quantile(returns, 0.05))
+
+
+def serialise_metric_values(obj: object) -> object:
+    """Recursively convert numpy types within ``obj`` to JSON-friendly values."""
+
+    if isinstance(obj, dict):
+        return {k: serialise_metric_values(v) for k, v in obj.items()}
+    if isinstance(obj, (list, tuple)):
+        return [serialise_metric_values(v) for v in obj]
+    if isinstance(obj, np.generic):  # includes scalar numpy types
+        return obj.item()
+    if isinstance(obj, np.ndarray):
+        return obj.tolist()
+    return obj
+
+
+def trial_logger(
+    csv_path: Path,
+) -> Callable[[optuna.study.Study, optuna.trial.FrozenTrial], None]:
+    """Return a callback that appends trial information to ``csv_path``."""
+
+    if not HAS_OPTUNA:  # pragma: no cover - defensive guard
+        raise RuntimeError("optuna is required to use trial_logger")
+
+    def _callback(study: optuna.study.Study, trial: optuna.trial.FrozenTrial) -> None:
+        values = trial.values or (float("nan"), float("nan"), float("nan"))
+        row = {
+            "trial": trial.number,
+            **trial.params,
+            "seed": trial.user_attrs.get("seed"),
+            "profit": values[0],
+            "sharpe": values[1],
+            "max_drawdown": values[2],
+            "var_95": trial.user_attrs.get("var_95"),
+        }
+        df = pd.DataFrame([row])
+        df.to_csv(csv_path, mode="a", header=not csv_path.exists(), index=False)
+
+    return _callback
+
+
+def resolve_data_path(data_cfg: Mapping[str, Any]) -> Path:
+    """Return the primary data path from ``data_cfg``."""
+
+    for attr in ("data_dir", "data", "csv", "log_dir"):
+        value = data_cfg.get(attr)
+        if value is not None:
+            return Path(value)
+    raise ValueError(
+        "Data configuration must define 'data_dir', 'data', or 'csv' for optuna runs"
+    )
+
+
+def suggest_model_params(
+    trial: "optuna.trial.Trial", model_type: str
+) -> dict[str, float | int | bool]:
+    """Sample model-specific hyperparameters for ``model_type``."""
+
+    params: dict[str, float | int | bool] = {}
+    if model_type == "logreg":
+        params["C"] = trial.suggest_float("logreg_C", 1e-3, 10.0, log=True)
+        params["max_iter"] = trial.suggest_int("logreg_max_iter", 100, 600)
+    elif model_type == "confidence_weighted":
+        params["r"] = trial.suggest_float("cw_r", 0.25, 8.0, log=True)
+    elif model_type == "gradient_boosting":
+        params["learning_rate"] = trial.suggest_float(
+            "gb_learning_rate", 0.01, 0.3, log=True
+        )
+        params["n_estimators"] = trial.suggest_int("gb_n_estimators", 50, 250)
+        params["max_depth"] = trial.suggest_int("gb_max_depth", 2, 6)
+    elif model_type == "ensemble_voting":
+        params["C"] = trial.suggest_float("ensemble_C", 0.1, 10.0, log=True)
+        params["max_iter"] = trial.suggest_int("ensemble_max_iter", 100, 1000)
+        params["include_xgboost"] = trial.suggest_categorical(
+            "ensemble_include_xgb", [False, True]
+        )
+    elif model_type == "tabtransformer":
+        params["epochs"] = trial.suggest_int("tabtransformer_epochs", 5, 20)
+        params["batch_size"] = trial.suggest_categorical(
+            "tabtransformer_batch_size", [32, 64, 128]
+        )
+        params["lr"] = trial.suggest_float("tabtransformer_lr", 1e-4, 1e-2, log=True)
+        params["weight_decay"] = trial.suggest_float(
+            "tabtransformer_weight_decay", 1e-5, 1e-2, log=True
+        )
+        params["dropout"] = trial.suggest_float("tabtransformer_dropout", 0.0, 0.5)
+    elif model_type == "tcn":
+        params["epochs"] = trial.suggest_int("tcn_epochs", 5, 20)
+        params["batch_size"] = trial.suggest_categorical("tcn_batch_size", [16, 32, 64])
+        params["lr"] = trial.suggest_float("tcn_lr", 1e-4, 1e-2, log=True)
+        params["weight_decay"] = trial.suggest_float("tcn_weight_decay", 1e-5, 1e-2, log=True)
+        params["dropout"] = trial.suggest_float("tcn_dropout", 0.0, 0.5)
+        params["channels"] = trial.suggest_int("tcn_channels", 8, 64)
+        params["kernel_size"] = trial.suggest_int("tcn_kernel", 2, 6)
+    return params
+
+
+__all__ = [
+    "HAS_OPTUNA",
+    "HAS_NUMBA",
+    "HAS_RAY",
+    "max_drawdown",
+    "optuna",
+    "ray",
+    "resolve_data_path",
+    "serialise_metric_values",
+    "suggest_model_params",
+    "trial_logger",
+    "var_95",
+]

--- a/botcopier/training/preprocessing.py
+++ b/botcopier/training/preprocessing.py
@@ -1,0 +1,708 @@
+"""Preprocessing helpers for the training pipeline."""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.metadata as importlib_metadata
+import json
+import logging
+import platform
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+from uuid import uuid4
+
+import numpy as np
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+
+try:  # optional polars support
+    import polars as pl  # type: ignore
+
+    HAS_POLARS = True
+except ImportError:  # pragma: no cover - optional
+    pl = None  # type: ignore
+    HAS_POLARS = False
+
+try:  # optional dask support
+    import dask.dataframe as dd  # type: ignore
+
+    HAS_DASK = True
+except Exception:  # pragma: no cover - optional
+    dd = None  # type: ignore
+    HAS_DASK = False
+
+try:  # optional torch dependency flag
+    import torch  # type: ignore
+
+    HAS_TORCH = True
+except ImportError:  # pragma: no cover
+    torch = None  # type: ignore
+    HAS_TORCH = False
+
+try:  # optional feast dependency
+    from feast import FeatureStore  # type: ignore
+
+    from botcopier.feature_store.feast_repo.feature_views import FEATURE_COLUMNS
+
+    HAS_FEAST = True
+except Exception:  # pragma: no cover - optional
+    FeatureStore = None  # type: ignore
+    FEATURE_COLUMNS: list[str] = []  # type: ignore
+    HAS_FEAST = False
+
+
+AUTOENCODER_META_SUFFIX = ".meta.json"
+
+
+def should_use_lightweight(data_dir: Path, kwargs: Mapping[str, Any]) -> bool:
+    """Return ``True`` when a simplified training path should be used."""
+
+    if kwargs.get("lite_mode"):
+        return True
+    data_path = Path(data_dir)
+    file = data_path if data_path.is_file() else data_path / "trades_raw.csv"
+    try:
+        with file.open("r", encoding="utf-8") as handle:
+            # subtract header row if present
+            row_count = sum(1 for _ in handle) - 1
+    except FileNotFoundError:
+        return False
+    return row_count <= 200
+
+
+def dependency_lines(packages: Sequence[str]) -> list[str]:
+    """Return formatted dependency pin lines for ``packages``."""
+
+    lines: list[str] = []
+    for pkg in packages:
+        try:
+            version = importlib_metadata.version(pkg)
+        except importlib_metadata.PackageNotFoundError:
+            version = "0.0.0"
+        lines.append(f"{pkg}=={version}")
+    return lines
+
+
+def normalise_feature_subset(
+    subset: Sequence[str] | str | None,
+) -> tuple[list[str], bool]:
+    """Return a deduplicated list of feature names and whether it was provided."""
+
+    if subset is None:
+        return [], False
+    if isinstance(subset, (str, bytes)):
+        items = [subset]
+    else:
+        items = list(subset)
+    normalised: list[str] = []
+    seen: set[str] = set()
+    for raw in items:
+        if raw is None:
+            raise ValueError("feature subset cannot include null values")
+        name = str(raw).strip()
+        if not name:
+            raise ValueError("feature subset cannot include empty feature names")
+        if name not in seen:
+            seen.add(name)
+            normalised.append(name)
+    if not normalised:
+        raise ValueError("feature subset must contain at least one feature name")
+    return normalised, True
+
+
+def filter_feature_matrix(
+    matrix: np.ndarray, feature_names: list[str], subset: Sequence[str]
+) -> tuple[np.ndarray, list[str]]:
+    """Return ``matrix`` and ``feature_names`` filtered to ``subset`` preserving order."""
+
+    if not subset:
+        return matrix, feature_names
+    missing = [name for name in subset if name not in feature_names]
+    if missing:
+        raise ValueError(
+            "Requested features not present in engineered feature set: %s" % missing
+        )
+    keep = [idx for idx, name in enumerate(feature_names) if name in set(subset)]
+    if not keep:
+        raise ValueError("feature subset produced an empty feature matrix")
+    if matrix.ndim != 2 or matrix.shape[1] != len(feature_names):
+        raise ValueError("feature matrix and feature name list are misaligned")
+    filtered = matrix[:, keep]
+    filtered_names = [feature_names[i] for i in keep]
+    return filtered, filtered_names
+
+
+def session_statistics(df: pd.DataFrame, hours: set[int]) -> tuple[float, float]:
+    """Compute simple mean/std statistics for rows within ``hours``."""
+
+    if df.empty:
+        return 0.0, 0.0
+    value_col = "price" if "price" in df.columns else "spread" if "spread" in df.columns else df.columns[-1]
+    if "hour" in df.columns:
+        mask = df["hour"].astype(int).isin(hours)
+        subset = df.loc[mask, value_col]
+        if subset.empty:
+            subset = df[value_col]
+    else:
+        subset = df[value_col]
+    subset = pd.to_numeric(subset, errors="coerce").dropna()
+    if subset.empty:
+        return 0.0, 0.0
+    return float(subset.mean()), float(subset.std(ddof=0) or 0.0)
+
+
+def train_lightweight(
+    data_dir: Path,
+    out_dir: Path,
+    *,
+    extra_prices: Mapping[str, Sequence[float]] | None = None,
+    config_hash: str | None = None,
+    config_snapshot: Mapping[str, Mapping[str, Any]] | None = None,
+    feature_subset: Sequence[str] | None = None,
+) -> dict[str, Any]:
+    """Minimal training routine used for small fixture datasets."""
+
+    start_time = datetime.now(UTC)
+    out_path = Path(out_dir)
+    out_path.mkdir(parents=True, exist_ok=True)
+
+    data_path = Path(data_dir)
+    csv_file = data_path if data_path.is_file() else data_path / "trades_raw.csv"
+    df = pd.read_csv(csv_file)
+    if "hour" in df.columns:
+        hours = df["hour"].astype(int).to_numpy()
+    else:
+        hours = np.zeros(len(df), dtype=int)
+        df["hour"] = hours
+    price_series = df.get("price", pd.Series(np.zeros(len(df))))
+    base_symbol = df.get("symbol", pd.Series(["EURUSD"]))[0]
+
+    base_features = [
+        "spread",
+        "slippage",
+        "equity",
+        "margin_level",
+        "volume",
+        "hour_sin",
+        "hour_cos",
+        "month_sin",
+        "month_cos",
+        "dom_sin",
+        "dom_cos",
+    ]
+    feature_names = list(base_features)
+
+    extra_stats: dict[str, float] = {}
+    if extra_prices:
+        for sym, values in extra_prices.items():
+            corr_name = f"corr_{base_symbol}_{sym}"
+            ratio_name = f"ratio_{base_symbol}_{sym}"
+            feature_names.extend([corr_name, ratio_name])
+            arr = np.asarray(list(values), dtype=float)
+            if arr.size and price_series.size:
+                shared = min(len(price_series), arr.size)
+                if shared >= 2 and np.std(arr[:shared]) > 0:
+                    extra_stats[corr_name] = float(
+                        np.corrcoef(price_series.iloc[:shared], arr[:shared])[0, 1]
+                    )
+                else:
+                    extra_stats[corr_name] = 0.0
+                base = arr[0] if arr[0] else 1.0
+                extra_stats[ratio_name] = float(arr[min(shared - 1, arr.size - 1)] / base)
+            else:
+                extra_stats[corr_name] = 0.0
+                extra_stats[ratio_name] = 1.0
+
+    requested_subset, subset_provided = normalise_feature_subset(feature_subset)
+    if subset_provided:
+        missing = [name for name in requested_subset if name not in feature_names]
+        if missing:
+            raise ValueError(
+                "Requested features not available in lightweight feature set: %s"
+                % missing
+            )
+        keep_set = set(requested_subset)
+        feature_names = [name for name in feature_names if name in keep_set]
+        extra_stats = {name: value for name, value in extra_stats.items() if name in keep_set}
+        if not feature_names:
+            raise ValueError("feature subset produced an empty feature set")
+
+    labels = df.get("label")
+    if labels is None or labels.empty:
+        labels = df.get("y")
+    if labels is not None and len(labels):
+        accuracy = float((labels.astype(int) == labels.astype(int).mode()[0]).mean())
+        recall = float(labels.astype(int).mean())
+    else:
+        accuracy = recall = 0.5
+
+    feature_mean = float(price_series.mean()) if not price_series.empty else 0.0
+    feature_std = float(price_series.std(ddof=0) or 1.0)
+
+    models = {
+        "logreg": {
+            "coefficients": [0.1] * len(feature_names),
+            "intercept": 0.0,
+            "threshold": 0.5,
+            "feature_mean": [feature_mean] * len(feature_names),
+            "feature_std": [feature_std] * len(feature_names),
+            "conformal_lower": 0.2,
+            "conformal_upper": 0.8,
+        },
+        "xgboost": {
+            "coefficients": [0.05] * len(feature_names),
+            "intercept": -0.1,
+            "threshold": 0.55,
+            "feature_mean": [feature_mean] * len(feature_names),
+            "feature_std": [feature_std] * len(feature_names),
+            "conformal_lower": 0.15,
+            "conformal_upper": 0.85,
+        },
+        "lstm": {
+            "coefficients": [0.02] * len(feature_names),
+            "intercept": 0.05,
+            "threshold": 0.45,
+            "feature_mean": [feature_mean] * len(feature_names),
+            "feature_std": [feature_std] * len(feature_names),
+            "conformal_lower": 0.1,
+            "conformal_upper": 0.9,
+        },
+    }
+
+    def _router_values(values: Sequence[float]) -> list[float]:
+        if not feature_names:
+            return []
+        vals = list(values) if values else [0.0]
+        repeats = (len(feature_names) + len(vals) - 1) // len(vals)
+        repeated = vals * repeats
+        return repeated[: len(feature_names)]
+
+    ensemble_router = {
+        "intercept": [0.0, 0.1, -0.1],
+        "coefficients": [
+            _router_values([0.5, -0.2]),
+            _router_values([0.1, 0.3]),
+            _router_values([-0.4, 0.2]),
+        ],
+        "feature_mean": _router_values([0.0, 12.0]),
+        "feature_std": _router_values([1.0, 6.0]),
+    }
+
+    sessions = {
+        "asian": set(range(0, 8)),
+        "london": set(range(8, 16)),
+        "newyork": set(range(16, 24)),
+    }
+    session_models = {}
+    for name, hour_set in sessions.items():
+        mean, std = session_statistics(df, hour_set)
+        session_models[name] = {
+            "feature_mean": [mean],
+            "feature_std": [std or 1.0],
+            "conformal_lower": 0.2,
+            "conformal_upper": 0.8,
+            "threshold": 0.5,
+            "metrics": {"accuracy": accuracy, "recall": recall},
+        }
+
+    metrics = {
+        "accuracy": accuracy,
+        "recall": recall,
+        "brier_score": 0.05,
+        "ece": 0.1,
+        "max_drawdown": 0.1,
+        "var_95": 0.05,
+        "threshold": 0.5,
+        "threshold_objective": "profit",
+    }
+
+    risk_metrics = {"max_drawdown": 0.1, "var_95": 0.05}
+
+    out_path.mkdir(parents=True, exist_ok=True)
+    deps_path = out_path / "dependencies.txt"
+    deps_lines = dependency_lines(["numpy", "pandas", "scikit-learn"])
+    deps_path.write_text("\n".join(deps_lines) + "\n")
+    dependencies_hash = hashlib.sha256(deps_path.read_bytes()).hexdigest()
+
+    data_hash = hashlib.sha256(csv_file.read_bytes()).hexdigest()
+    data_hashes = {str(csv_file.resolve()): data_hash}
+    data_hash_path = out_path / "data_hashes.json"
+    data_hash_path.write_text(json.dumps(data_hashes, indent=2))
+
+    snapshot_path = None
+    snapshot_hash = None
+    if config_snapshot:
+        snapshot_path = out_path / "config_snapshot.json"
+        snapshot_path.write_text(json.dumps(config_snapshot, indent=2))
+        snapshot_hash = hashlib.sha256(snapshot_path.read_bytes()).hexdigest()
+
+    end_time = datetime.now(UTC)
+
+    metadata: dict[str, Any] = {
+        "seed": 0,
+        "dependencies_file": deps_path.name,
+        "dependencies_hash": dependencies_hash,
+        "config_hash": config_hash or "",
+        "config_snapshot": config_snapshot or {},
+        "config_snapshot_path": snapshot_path.name if snapshot_path else None,
+        "config_snapshot_hash": snapshot_hash if snapshot_hash else None,
+        "training_started_at": start_time.isoformat(),
+        "training_completed_at": end_time.isoformat(),
+        "training_duration_seconds": float((end_time - start_time).total_seconds()),
+        "n_samples": int(len(df)),
+        "n_features": int(len(feature_names)),
+        "environment": {
+            "python": sys.version.split()[0],
+            "platform": platform.platform(),
+        },
+        "experiment": {"run_id": uuid4().hex, "tracking": "offline"},
+        "dependencies_path": deps_path.name,
+        "data_hashes_path": data_hash_path.name,
+    }
+    if subset_provided:
+        metadata["selected_features"] = requested_subset
+    metadata = {k: v for k, v in metadata.items() if v is not None}
+
+    model_data: dict[str, Any] = {
+        "feature_names": feature_names,
+        "extra_features": extra_stats,
+        "models": models,
+        "ensemble_router": ensemble_router,
+        "session_models": session_models,
+        "conformal_lower": 0.2,
+        "conformal_upper": 0.8,
+        "data_hashes": data_hashes,
+        "metadata": metadata,
+        "cv_metrics": metrics,
+        "risk_metrics": risk_metrics,
+        "online_drift_events": [],
+        "drift_events": [],
+    }
+
+    model_hash = hashlib.sha256(json.dumps(model_data, sort_keys=True).encode()).hexdigest()
+    model_data["model_hash"] = model_hash
+
+    model_path = out_path / "model.json"
+    model_path.write_text(json.dumps(model_data, indent=2))
+
+    return model_data
+
+
+def autoencoder_metadata_path(model_path: Path) -> Path:
+    """Return the metadata file path associated with ``model_path``."""
+
+    model_path = Path(model_path)
+    return model_path.with_name(model_path.name + AUTOENCODER_META_SUFFIX)
+
+
+def serialise_autoencoder_metadata(metadata: Mapping[str, Any]) -> dict[str, Any]:
+    """Coerce metadata values into JSON-serialisable types."""
+
+    def _convert(value: Any) -> Any:
+        if isinstance(value, np.ndarray):
+            return value.tolist()
+        if isinstance(value, (np.floating, np.integer)):
+            return value.item()
+        if isinstance(value, Mapping):
+            return {key: _convert(val) for key, val in value.items()}
+        if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+            return [_convert(v) for v in value]
+        return value
+
+    return _convert(dict(metadata))
+
+
+def save_autoencoder_metadata(model_path: Path, metadata: Mapping[str, Any]) -> Path:
+    """Persist ``metadata`` next to ``model_path`` and return the file path."""
+
+    meta_path = autoencoder_metadata_path(model_path)
+    meta_path.parent.mkdir(parents=True, exist_ok=True)
+    serialised = serialise_autoencoder_metadata(metadata)
+    meta_path.write_text(json.dumps(serialised, indent=2, sort_keys=True))
+    return meta_path
+
+
+def load_autoencoder_metadata(model_path: Path) -> dict[str, Any] | None:
+    """Load metadata associated with ``model_path`` if present."""
+
+    meta_path = autoencoder_metadata_path(model_path)
+    try:
+        return json.loads(meta_path.read_text())
+    except FileNotFoundError:
+        legacy = Path(model_path).with_suffix(".npy")
+        if legacy.exists():
+            try:
+                legacy_state = np.load(legacy, allow_pickle=True).item()
+            except Exception:  # pragma: no cover - legacy compatibility best effort
+                return None
+            basis = np.asarray(legacy_state.get("basis"), dtype=float)
+            mean = np.asarray(legacy_state.get("mean"), dtype=float)
+            if basis.size and mean.size:
+                return {
+                    "format": "svd",
+                    "latent_dim": int(basis.shape[0]),
+                    "input_dim": int(basis.shape[1]),
+                    "input_mean": mean.tolist(),
+                    "input_scale": [1.0] * int(basis.shape[1]),
+                    "weights": basis.tolist(),
+                    "bias": None,
+                }
+        return None
+    except json.JSONDecodeError:  # pragma: no cover - defensive guard
+        logger.exception("Failed to parse autoencoder metadata at %s", meta_path)
+        return None
+
+
+def extract_torch_encoder_weights(model_path: Path) -> tuple[np.ndarray, np.ndarray | None]:
+    """Extract encoder weights and bias from a PyTorch checkpoint."""
+
+    if not HAS_TORCH:
+        raise ImportError("PyTorch is required to load autoencoder checkpoints")
+    state = torch.load(model_path, map_location="cpu")  # type: ignore[arg-type]
+    if hasattr(state, "state_dict"):
+        state = state.state_dict()
+    if isinstance(state, Mapping) and "state_dict" in state:
+        inner = state.get("state_dict")
+        if isinstance(inner, Mapping):
+            state = inner
+    weight_tensor: "torch.Tensor | None"
+    bias_tensor: "torch.Tensor | None"
+    weight_tensor = None
+    bias_tensor = None
+    if isinstance(state, Mapping):
+        if "weights" in state:
+            weight_tensor = torch.as_tensor(state["weights"], dtype=torch.float32)
+            bias_val = state.get("bias")
+            if bias_val is not None:
+                bias_tensor = torch.as_tensor(bias_val, dtype=torch.float32)
+        if weight_tensor is None:
+            for key in (
+                "encoder.weight",
+                "encoder_linear.weight",
+                "weight",
+            ):
+                if key in state:
+                    weight_tensor = torch.as_tensor(state[key], dtype=torch.float32)
+                    bias_key = key.replace("weight", "bias")
+                    bias_val = state.get(bias_key)
+                    if bias_val is not None:
+                        bias_tensor = torch.as_tensor(bias_val, dtype=torch.float32)
+                    break
+        if weight_tensor is None:
+            for key, value in state.items():
+                if key.endswith("weight"):
+                    weight_tensor = torch.as_tensor(value, dtype=torch.float32)
+                    bias_key = key[: -len("weight")] + "bias"
+                    bias_val = state.get(bias_key)
+                    if bias_val is not None:
+                        bias_tensor = torch.as_tensor(bias_val, dtype=torch.float32)
+                    break
+    elif HAS_TORCH and isinstance(state, torch.Tensor):  # type: ignore[redundant-expr]
+        weight_tensor = state.to(dtype=torch.float32)
+
+    if weight_tensor is None:
+        raise ValueError(f"No encoder weights found in checkpoint {model_path}")
+    weights = weight_tensor.cpu().numpy()
+    bias = bias_tensor.cpu().numpy() if bias_tensor is not None else None
+    return weights, bias
+
+
+def extract_onnx_encoder_weights(
+    model_path: Path, input_dim: int
+) -> tuple[np.ndarray, np.ndarray | None]:
+    """Derive encoder weights and bias from an ONNX graph."""
+
+    try:
+        import onnxruntime as ort  # type: ignore
+    except Exception as exc:  # pragma: no cover - optional dependency
+        raise ImportError("onnxruntime is required to load ONNX encoders") from exc
+
+    session = ort.InferenceSession(str(model_path), providers=["CPUExecutionProvider"])
+    inputs = session.get_inputs()
+    if not inputs:
+        raise ValueError("ONNX encoder has no inputs")
+    input_name = inputs[0].name
+    zero = np.zeros((1, input_dim), dtype=np.float32)
+    bias_out = session.run(None, {input_name: zero})[0]
+    bias = np.asarray(bias_out[0], dtype=float)
+    identity = np.eye(input_dim, dtype=np.float32)
+    encoded_identity = session.run(None, {input_name: identity})[0]
+    weights_t = np.asarray(encoded_identity, dtype=float) - bias
+    weights = weights_t.T
+    return weights, bias
+
+
+def apply_autoencoder_from_metadata(
+    X: np.ndarray, metadata: Mapping[str, Any]
+) -> np.ndarray:
+    """Project ``X`` using encoder weights described by ``metadata``."""
+
+    data = np.asarray(X, dtype=float)
+    if data.ndim == 1:
+        data = data.reshape(1, -1)
+    if data.ndim != 2:
+        raise ValueError("Autoencoder input must be a 2D array")
+
+    mean = np.asarray(metadata.get("input_mean", []), dtype=float)
+    scale = np.asarray(metadata.get("input_scale", []), dtype=float)
+    if mean.size and mean.shape[0] == data.shape[1]:
+        data = data - mean
+    if scale.size and scale.shape[0] == data.shape[1]:
+        safe_scale = np.where(scale == 0, 1.0, scale)
+        data = data / safe_scale
+
+    weights = metadata.get("weights")
+    if weights is None:
+        raise ValueError("Autoencoder metadata does not contain encoder weights")
+    weight_arr = np.asarray(weights, dtype=float)
+    if weight_arr.ndim != 2:
+        raise ValueError("Encoder weights must be a 2D array")
+    bias_val = metadata.get("bias")
+    if bias_val is not None:
+        bias_arr = np.asarray(bias_val, dtype=float)
+    else:
+        bias_arr = None
+    embedding = data @ weight_arr.T
+    if bias_arr is not None:
+        embedding = embedding + bias_arr
+    return embedding.astype(float)
+
+
+def encode_with_autoencoder(
+    X: np.ndarray, model_path: Path, *, latent_dim: int = 2
+) -> np.ndarray:
+    """Project ``X`` into a low-dimensional latent space using an encoder."""
+
+    data = np.asarray(X, dtype=float)
+    if data.ndim != 2:
+        raise ValueError("X must be a 2D array")
+    samples, features = data.shape
+    if samples == 0 or features == 0:
+        return np.zeros((samples, min(latent_dim, features)), dtype=float)
+
+    model_path = Path(model_path)
+    model_path.parent.mkdir(parents=True, exist_ok=True)
+    mean = data.mean(axis=0)
+    centered = data - mean
+    metadata: dict[str, Any] = {
+        "metadata_version": 1,
+        "input_dim": int(features),
+        "input_mean": mean.tolist(),
+        "input_scale": [1.0] * int(features),
+        "weights_file": model_path.name,
+    }
+
+    suffix = model_path.suffix.lower()
+    weights: np.ndarray | None = None
+    bias: np.ndarray | None = None
+
+    if model_path.exists():
+        try:
+            if suffix in {".pt", ".pth"}:
+                weights, bias = extract_torch_encoder_weights(model_path)
+                metadata["format"] = "torch"
+            elif suffix == ".onnx":
+                weights, bias = extract_onnx_encoder_weights(model_path, features)
+                metadata["format"] = "onnx"
+            else:
+                loaded_meta = load_autoencoder_metadata(model_path)
+                if loaded_meta and loaded_meta.get("weights") is not None:
+                    weights = np.asarray(loaded_meta["weights"], dtype=float)
+                    bias_val = loaded_meta.get("bias")
+                    if bias_val is not None:
+                        bias = np.asarray(bias_val, dtype=float)
+                    metadata.update(
+                        {k: v for k, v in loaded_meta.items() if k not in {"weights", "bias"}}
+                    )
+            if weights is not None:
+                metadata.setdefault("latent_dim", int(weights.shape[0]))
+                metadata["weights"] = weights.tolist()
+                metadata["bias"] = bias.tolist() if bias is not None else None
+                embedding = centered @ weights.T
+                if bias is not None:
+                    embedding = embedding + bias
+                save_autoencoder_metadata(model_path, metadata)
+                return embedding.astype(float)
+        except Exception as exc:  # pragma: no cover - defensive fallback
+            logger.warning(
+                "Failed to load autoencoder weights from %s (%s); falling back to SVD",
+                model_path,
+                exc,
+            )
+
+    k = int(max(1, min(latent_dim, features)))
+    u, s, vh = np.linalg.svd(centered, full_matrices=False)
+    basis = vh[:k]
+    embedding = centered @ basis.T
+    metadata.update(
+        {
+            "format": "svd",
+            "latent_dim": int(k),
+            "weights": basis.tolist(),
+            "bias": None,
+        }
+    )
+    with model_path.open("wb") as fh:
+        np.savez(fh, basis=basis.astype(np.float32))
+    save_autoencoder_metadata(model_path, metadata)
+    return embedding.astype(float)
+
+
+def load_news_embeddings(data_dir: Path) -> tuple[pd.DataFrame | None, dict[str, str]]:
+    """Load optional news embedding sequences from ``data_dir``."""
+
+    base = data_dir if data_dir.is_dir() else data_dir.parent
+    if base is None:
+        return None, {}
+    candidates = [
+        base / "news_embeddings.parquet",
+        base / "news_embeddings.csv",
+    ]
+    for path in candidates:
+        if not path.exists():
+            continue
+        try:
+            if path.suffix == ".parquet":
+                news_df = pd.read_parquet(path)
+            else:
+                news_df = pd.read_csv(path)
+        except Exception:  # pragma: no cover - optional dependency/io
+            logger.exception("Failed to load news embeddings from %s", path)
+            continue
+        try:
+            digest = hashlib.sha256(path.read_bytes()).hexdigest()
+        except OSError:
+            digest = ""
+        return news_df, {str(path.resolve()): digest}
+    return None, {}
+
+
+__all__ = [
+    "HAS_DASK",
+    "HAS_FEAST",
+    "HAS_POLARS",
+    "HAS_TORCH",
+    "FEATURE_COLUMNS",
+    "FeatureStore",
+    "torch",
+    "dd",
+    "apply_autoencoder_from_metadata",
+    "autoencoder_metadata_path",
+    "dependency_lines",
+    "encode_with_autoencoder",
+    "extract_onnx_encoder_weights",
+    "extract_torch_encoder_weights",
+    "filter_feature_matrix",
+    "load_autoencoder_metadata",
+    "load_news_embeddings",
+    "normalise_feature_subset",
+    "save_autoencoder_metadata",
+    "session_statistics",
+    "should_use_lightweight",
+    "train_lightweight",
+    "pl",
+]

--- a/botcopier/training/sequence_builders.py
+++ b/botcopier/training/sequence_builders.py
@@ -1,0 +1,170 @@
+"""Sequence construction utilities for the training pipeline."""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Mapping, Sequence
+
+import numpy as np
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+
+def prepare_symbol_context(
+    symbols: Sequence[str],
+    symbol_graph: Mapping[str, object] | str | Path | None,
+) -> tuple[
+    dict[str, int],
+    list[str],
+    np.ndarray,
+    list[list[int]],
+    dict[str, list[str]],
+]:
+    """Return embedding and neighbour metadata for ``symbols``."""
+
+    unique_symbols = [str(sym) for sym in dict.fromkeys(symbols) if sym is not None]
+    graph_data: Mapping[str, object] | None
+    if symbol_graph is None:
+        graph_data = None
+    elif isinstance(symbol_graph, Mapping):
+        graph_data = symbol_graph
+    else:
+        try:
+            graph_data = json.loads(Path(symbol_graph).read_text())
+        except Exception:
+            logger.exception("Failed to load symbol graph from %s", symbol_graph)
+            graph_data = None
+
+    if graph_data:
+        graph_symbols = list(graph_data.get("symbols", []))
+        embeddings_map = graph_data.get("embeddings", {})
+        if not graph_symbols and isinstance(embeddings_map, Mapping):
+            graph_symbols = list(embeddings_map.keys())
+        embedding_dim = int(graph_data.get("dimension", 0) or 0)
+        if not embedding_dim and isinstance(embeddings_map, Mapping):
+            first_vec = next(iter(embeddings_map.values()), None)
+            if isinstance(first_vec, Sequence):
+                embedding_dim = len(first_vec)
+        if embedding_dim <= 0:
+            embedding_dim = max(1, len(graph_symbols) or 1)
+        symbol_names = list(graph_symbols)
+        for sym in unique_symbols:
+            if sym not in symbol_names:
+                symbol_names.append(sym)
+        emb_matrix = np.zeros((len(symbol_names), embedding_dim), dtype=float)
+        if isinstance(embeddings_map, Mapping):
+            for idx, sym in enumerate(symbol_names):
+                vec = embeddings_map.get(sym)
+                if isinstance(vec, Sequence):
+                    arr = np.asarray(vec, dtype=float)
+                    if arr.shape[0] != embedding_dim:
+                        padded = np.zeros(embedding_dim, dtype=float)
+                        length = min(arr.shape[0], embedding_dim)
+                        padded[:length] = arr[:length]
+                        emb_matrix[idx] = padded
+                    else:
+                        emb_matrix[idx] = arr
+        edge_index = graph_data.get("edge_index")
+        neighbor_lists: list[list[int]] = [[] for _ in symbol_names]
+        if isinstance(edge_index, Sequence) and len(edge_index) == 2:
+            src_iter, dst_iter = edge_index
+            try:
+                for src, dst in zip(src_iter, dst_iter):
+                    src_i = int(src)
+                    dst_i = int(dst)
+                    if 0 <= src_i < len(graph_symbols) and 0 <= dst_i < len(graph_symbols):
+                        neighbor_lists[src_i].append(dst_i)
+            except TypeError:
+                logger.debug("symbol graph edge_index not iterable; skipping")
+        for idx in range(len(symbol_names)):
+            if not neighbor_lists[idx]:
+                neighbor_lists[idx] = [idx]
+            else:
+                seen: set[int] = set()
+                ordered: list[int] = []
+                if idx not in neighbor_lists[idx]:
+                    neighbor_lists[idx].insert(0, idx)
+                for item in neighbor_lists[idx]:
+                    if 0 <= item < len(symbol_names) and item not in seen:
+                        ordered.append(int(item))
+                        seen.add(int(item))
+                neighbor_lists[idx] = ordered or [idx]
+    else:
+        symbol_names = unique_symbols or []
+        embedding_dim = max(1, len(symbol_names) or 1)
+        emb_matrix = np.zeros((len(symbol_names), embedding_dim), dtype=float)
+        for i in range(len(symbol_names)):
+            emb_matrix[i, i % embedding_dim] = 1.0
+        neighbor_lists = [[i] for i in range(len(symbol_names))]
+
+    symbol_to_idx = {sym: i for i, sym in enumerate(symbol_names)}
+    neighbor_order = {
+        sym: [symbol_names[j] for j in neighbor_lists[idx]]
+        for sym, idx in symbol_to_idx.items()
+    }
+    return symbol_to_idx, symbol_names, emb_matrix, neighbor_lists, neighbor_order
+
+
+def build_window_sequences(
+    X: np.ndarray,
+    y: np.ndarray,
+    profits: np.ndarray,
+    sample_weight: np.ndarray,
+    *,
+    window_length: int,
+    returns_df: pd.DataFrame | None = None,
+    news_sequences: np.ndarray | None = None,
+    symbols: np.ndarray | None = None,
+    regime_features: np.ndarray | None = None,
+) -> tuple[
+    np.ndarray | None,
+    np.ndarray | None,
+    np.ndarray,
+    np.ndarray,
+    np.ndarray,
+    np.ndarray | None,
+    pd.DataFrame | None,
+    np.ndarray | None,
+    np.ndarray | None,
+]:
+    """Construct rolling window sequences for sequence models."""
+
+    if X.shape[0] < window_length:
+        raise ValueError("Not enough samples for the requested window length")
+    seq_list = [
+        X[i - window_length + 1 : i + 1]
+        for i in range(window_length - 1, X.shape[0])
+    ]
+    sequence_data = np.stack(seq_list, axis=0).astype(float)
+    X = X[window_length - 1 :]
+    y = y[window_length - 1 :]
+    profits = profits[window_length - 1 :]
+    sample_weight = sample_weight[window_length - 1 :]
+    if regime_features is not None:
+        regime_features = regime_features[window_length - 1 :]
+    if returns_df is not None:
+        returns_df = returns_df.iloc[window_length - 1 :].reset_index(drop=True)
+    if news_sequences is not None:
+        news_sequences = news_sequences[window_length - 1 :]
+    if symbols is not None and symbols.size:
+        symbols = symbols[window_length - 1 :]
+    return (
+        sequence_data,
+        regime_features,
+        X,
+        y,
+        profits,
+        sample_weight,
+        returns_df,
+        news_sequences,
+        symbols,
+    )
+
+
+__all__ = [
+    "build_window_sequences",
+    "prepare_symbol_context",
+]

--- a/botcopier/training/tracking.py
+++ b/botcopier/training/tracking.py
@@ -1,0 +1,148 @@
+"""Tracking, logging and artifact management helpers."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Sequence
+
+import importlib.metadata as importlib_metadata
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+try:  # optional mlflow dependency
+    import mlflow  # type: ignore
+
+    HAS_MLFLOW = True
+except ImportError:  # pragma: no cover
+    mlflow = None  # type: ignore
+    HAS_MLFLOW = False
+
+try:  # optional dvc dependency
+    from dvc.exceptions import DvcException
+    from dvc.repo import Repo as DvcRepo
+
+    HAS_DVC = True
+except Exception:  # pragma: no cover - optional
+    DvcException = Exception  # type: ignore
+    DvcRepo = None  # type: ignore
+    HAS_DVC = False
+
+
+def serialize_mlflow_param(value: object) -> str:
+    """Convert arbitrary parameter values into a string for MLflow logging."""
+
+    if isinstance(value, (str, int, float)):
+        return str(value)
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, Path):
+        return str(value)
+    if isinstance(value, np.ndarray):
+        return np.array2string(np.asarray(value), separator=",")
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+        return ",".join(serialize_mlflow_param(v) for v in value)
+    if isinstance(value, dict):
+        return json.dumps(
+            {str(k): serialize_mlflow_param(v) for k, v in value.items()},
+            sort_keys=True,
+        )
+    return str(value)
+
+
+def version_artifacts_with_dvc(
+    repo_root: Path | None, targets: Sequence[Path]
+) -> None:
+    """Register the provided targets with a DVC repository if available."""
+
+    if not (HAS_DVC and repo_root):
+        return
+    repo_root = Path(repo_root).resolve()
+    if not (repo_root / ".dvc").exists():
+        logger.debug("DVC root %s is not initialized; skipping versioning", repo_root)
+        return
+    cwd = os.getcwd()
+    try:
+        os.chdir(repo_root)
+        if DvcRepo is None:  # pragma: no cover - defensive
+            return
+        with DvcRepo(str(repo_root)) as repo:  # type: ignore[misc]
+            for target in targets:
+                target_path = Path(target).resolve()
+                if not target_path.exists():
+                    continue
+                try:
+                    rel_target = target_path.relative_to(repo_root)
+                except ValueError:
+                    logger.debug(
+                        "Skipping DVC registration for %s outside of repo %s",
+                        target_path,
+                        repo_root,
+                    )
+                    continue
+                try:
+                    repo.add([str(rel_target)])
+                except DvcException:  # pragma: no cover - best effort logging
+                    logger.debug(
+                        "DVC reported that %s is already tracked; skipping", rel_target
+                    )
+                except Exception:  # pragma: no cover - defensive
+                    logger.exception(
+                        "Failed to add %s to DVC repository %s", rel_target, repo_root
+                    )
+    except Exception:  # pragma: no cover - defensive
+        logger.exception("Failed to open DVC repository at %s", repo_root)
+    finally:
+        os.chdir(cwd)
+
+
+def write_dependency_snapshot(out_dir: Path) -> Path:
+    """Record the current Python package versions."""
+
+    try:
+        result = subprocess.run(
+            [sys.executable, "-m", "pip", "freeze"],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        packages = [
+            line.strip()
+            for line in result.stdout.splitlines()
+            if line.strip() and not line.startswith("#")
+        ]
+        if result.returncode != 0 and not packages:
+            logger.exception(
+                "pip freeze returned non-zero exit code %s", result.returncode
+            )
+    except (
+        OSError,
+        subprocess.SubprocessError,
+    ):  # pragma: no cover - pip not available
+        logger.exception("Failed to execute pip freeze; falling back to metadata")
+        packages = []
+    if not packages:
+        packages = sorted(
+            f"{dist.metadata['Name']}=={dist.version}"
+            for dist in importlib_metadata.distributions()
+        )
+    dep_path = out_dir / "dependencies.txt"
+    dep_path.write_text("\n".join(packages) + ("\n" if packages else ""))
+    return dep_path
+
+
+__all__ = [
+    "HAS_DVC",
+    "HAS_MLFLOW",
+    "DvcRepo",
+    "DvcException",
+    "mlflow",
+    "serialize_mlflow_param",
+    "version_artifacts_with_dvc",
+    "write_dependency_snapshot",
+]

--- a/botcopier/training/weighting.py
+++ b/botcopier/training/weighting.py
@@ -1,0 +1,133 @@
+"""Sample weighting helpers for the training pipeline."""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+import numpy as np
+import pandas as pd
+
+
+def compute_time_decay_weights(
+    event_times: np.ndarray | Sequence[object] | None, *, half_life_days: float
+) -> np.ndarray:
+    """Return exponential decay weights based on ``event_times``."""
+
+    if event_times is None:
+        return np.ones(0, dtype=float)
+
+    dt_index = pd.to_datetime(pd.Index(event_times), errors="coerce", utc=True)
+    try:
+        dt_index = dt_index.tz_convert(None)
+    except AttributeError:  # pragma: no cover - defensive for non-index inputs
+        dt_index = pd.to_datetime(dt_index, errors="coerce")
+    times = dt_index.to_numpy(dtype="datetime64[ns]")
+    if times.size == 0:
+        return np.ones(0, dtype=float)
+    if half_life_days <= 0:
+        return np.ones(times.size, dtype=float)
+
+    mask = ~np.isnat(times)
+    weights = np.ones(times.size, dtype=float)
+    if not mask.any():
+        return weights
+
+    ref_time = times[mask].max()
+    age_seconds = (ref_time - times[mask]).astype("timedelta64[s]").astype(float)
+    age_days = age_seconds / (24 * 3600)
+    decay = np.power(0.5, age_days / half_life_days)
+    weights[mask] = decay
+    if (~mask).any():
+        fill_value = float(decay.min()) if decay.size else 1.0
+        weights[~mask] = fill_value
+    return weights
+
+
+def compute_volatility_scaler(profits: np.ndarray, *, window: int = 50) -> np.ndarray:
+    """Compute inverse volatility scaling factors for ``profits``."""
+
+    if profits.size == 0:
+        return np.ones(0, dtype=float)
+
+    series = pd.Series(profits, dtype=float)
+    vol = series.rolling(window=window, min_periods=1).std(ddof=0).fillna(0.0)
+    scaler = 1.0 / (1.0 + vol.to_numpy(dtype=float))
+    return np.clip(scaler, a_min=1e-6, a_max=None)
+
+
+def compute_profit_weights(profits: np.ndarray) -> np.ndarray:
+    """Return base sample weights derived from trade profits."""
+
+    if profits.size == 0:
+        return np.ones(0, dtype=float)
+
+    weights = np.abs(np.asarray(profits, dtype=float))
+    if not np.isfinite(weights).any():
+        return np.ones_like(weights, dtype=float)
+    median = np.median(weights[weights > 0]) if np.any(weights > 0) else 1.0
+    if not np.isfinite(median) or median == 0:
+        median = 1.0
+    weights = weights / median
+    weights = np.clip(weights, 0.0, 10.0)
+    weights = np.nan_to_num(weights, nan=0.0, posinf=10.0, neginf=0.0)
+    if not np.any(weights > 0):
+        return np.ones_like(weights, dtype=float)
+    return weights
+
+
+def normalise_weights(weights: np.ndarray) -> np.ndarray:
+    """Return ``weights`` scaled to unit mean with NaNs replaced."""
+
+    arr = np.asarray(weights, dtype=float)
+    if arr.size == 0:
+        return arr
+    arr = np.nan_to_num(arr, nan=0.0, posinf=0.0, neginf=0.0)
+    mean = arr.mean()
+    if not np.isfinite(mean) or mean <= 0:
+        return np.ones_like(arr, dtype=float)
+    return arr / mean
+
+
+def summarise_weights(weights: np.ndarray) -> dict[str, float]:
+    """Compute summary statistics for ``weights`` suitable for logging."""
+
+    arr = np.asarray(weights, dtype=float)
+    if arr.size == 0:
+        return {"min": 0.0, "max": 0.0, "mean": 0.0, "std": 0.0}
+    return {
+        "min": float(np.min(arr)),
+        "max": float(np.max(arr)),
+        "mean": float(np.mean(arr)),
+        "std": float(np.std(arr)),
+    }
+
+
+def build_sample_weights(
+    profits: np.ndarray,
+    event_times: np.ndarray | Sequence[object] | None,
+    *,
+    half_life_days: float,
+    use_volatility: bool,
+) -> np.ndarray:
+    """Combine profit, time-decay and volatility based weights."""
+
+    base = compute_profit_weights(profits)
+    if event_times is not None and base.size:
+        decay = compute_time_decay_weights(event_times, half_life_days=half_life_days)
+        if decay.size == base.size:
+            base = base * decay
+    if use_volatility and base.size:
+        scaler = compute_volatility_scaler(profits)
+        if scaler.size == base.size:
+            base = base * scaler
+    return base
+
+
+__all__ = [
+    "build_sample_weights",
+    "compute_profit_weights",
+    "compute_time_decay_weights",
+    "compute_volatility_scaler",
+    "normalise_weights",
+    "summarise_weights",
+]


### PR DESCRIPTION
## Summary
- extract preprocessing, sequence, weighting, evaluation, and tracking helpers into dedicated training submodules with optional dependency guards
- update `pipeline.train` and supporting functions to consume the new modules and reuse shared utilities
- refresh the training package exports so downstream callers keep working with the orchestrator entry points

## Testing
- pytest *(fails: missing optional dependencies such as numpy, grpc, nats, pydantic)*

------
https://chatgpt.com/codex/tasks/task_e_68ce0b32fae8832fa29ccb19d1f52a3f