### PR TITLE
Add AutoML controller combination cap and telemetry instrumentation

### DIFF
--- a/botcopier/cli/__init__.py
+++ b/botcopier/cli/__init__.py
@@ -182,6 +182,10 @@ def train(
         None,
         help="Number of feature subsets sampled per controller episode",
     ),
+    controller_episode_combination_cap: Optional[int] = typer.Option(
+        None,
+        help="Maximum controller feature/model combinations evaluated per episode",
+    ),
     controller_baseline_momentum: Optional[float] = typer.Option(
         None,
         help="Momentum for the controller's reward baseline (set to 0 to disable)",
@@ -227,6 +231,12 @@ def train(
         train_cfg = train_cfg.model_copy(
             update={"controller_episode_sample_size": controller_episode_sample_size}
         )
+    if controller_episode_combination_cap is not None:
+        train_cfg = train_cfg.model_copy(
+            update={
+                "controller_episode_combination_cap": controller_episode_combination_cap
+            }
+        )
     if controller_baseline_momentum is not None:
         train_cfg = train_cfg.model_copy(
             update={"controller_baseline_momentum": controller_baseline_momentum}
@@ -249,6 +259,7 @@ def train(
         reuse_controller=train_cfg.reuse_controller,
         controller_max_subset_size=train_cfg.controller_max_subset_size,
         controller_episode_sample_size=train_cfg.controller_episode_sample_size,
+        controller_episode_combination_cap=train_cfg.controller_episode_combination_cap,
         controller_baseline_momentum=train_cfg.controller_baseline_momentum,
         regime_features=train_cfg.regime_features,
         config_hash=config_hash,

--- a/config/settings.py
+++ b/config/settings.py
@@ -116,6 +116,7 @@ class TrainingConfig(BaseSettings):
     reuse_controller: bool = False
     controller_max_subset_size: Optional[int] = None
     controller_episode_sample_size: Optional[int] = None
+    controller_episode_combination_cap: Optional[int] = None
     controller_baseline_momentum: Optional[float] = 0.9
     meta_weights: Optional[Path] = None
 

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -452,6 +452,19 @@
           "default": null,
           "title": "Controller Episode Sample Size"
         },
+        "controller_episode_combination_cap": {
+          "anyOf": [
+            {
+              "minimum": 1,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Controller Episode Combination Cap"
+        },
         "controller_baseline_momentum": {
           "anyOf": [
             {


### PR DESCRIPTION
## Summary
- add a configurable per-episode combination cap to the AutoML controller with improved subset tracking and telemetry
- plumb the new controller option through configuration, CLI, and trainers while emitting telemetry metrics for visibility
- extend controller tests to cover large feature spaces, deduped sampling, and telemetry invariants

## Testing
- `pytest tests/test_automl_controller.py`


------
https://chatgpt.com/codex/tasks/task_e_68ce15664c58832f81d71b1393431dd3