### PR TITLE
Handle missing scientific deps in evaluation

### DIFF
--- a/docs/feature_plugins.md
+++ b/docs/feature_plugins.md
@@ -60,6 +60,13 @@ fancy = "my_pkg.metrics:fancy_metric"
 Metrics can be selected when training with ``--metric fancy`` or by setting
 ``training.metrics`` in a configuration file.
 
+Built-in evaluation metrics such as ``accuracy``, ``precision``, ``recall``,
+``profit``, ``sharpe_ratio``, ``sortino_ratio``, ``max_drawdown`` and ``var_95``
+depend on the optional scientific stack (``numpy``, ``pandas`` and
+``scikit-learn``).  When these packages are not installed the evaluation module
+raises ``ImportError("optional dependencies not installed")`` rather than
+attempting to run with partial functionality.
+
 ## Evaluation hooks
 
 Evaluation hooks extend the JSON payload returned by the ``evaluate`` command.

--- a/tests/test_evaluation_optional_dependencies.py
+++ b/tests/test_evaluation_optional_dependencies.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+
+import pytest
+
+from botcopier.scripts import evaluation
+
+
+def test_evaluate_requires_optional_dependencies(monkeypatch, tmp_path: Path) -> None:
+    """``evaluate`` should raise when pandas/numpy are unavailable."""
+
+    monkeypatch.setattr(evaluation, "pd", None)
+
+    with pytest.raises(ImportError, match="optional dependencies not installed"):
+        evaluation.evaluate(tmp_path / "pred.csv", tmp_path / "trades.csv", window=60)
+
+
+def test_load_predictions_requires_numpy_for_variance(monkeypatch, tmp_path: Path) -> None:
+    """Parsing variance without NumPy should raise the documented ImportError."""
+
+    csv_path = tmp_path / "preds.csv"
+    csv_path.write_text(
+        "timestamp;symbol;direction;lots;probability;variance\n"
+        "2024.01.01 00:00:00;EURUSD;buy;0.1;0.8;0.2\n"
+    )
+
+    monkeypatch.setattr(evaluation, "np", None)
+
+    with pytest.raises(ImportError, match="optional dependencies not installed"):
+        evaluation._load_predictions(csv_path)
+
+
+def test_threshold_search_requires_numpy(monkeypatch) -> None:
+    """Threshold search must surface the existing ImportError when NumPy is missing."""
+
+    monkeypatch.setattr(evaluation, "np", None)
+
+    with pytest.raises(ImportError, match="numpy is required for threshold search"):
+        evaluation.search_decision_threshold([1.0], [0.5], [1.0])


### PR DESCRIPTION
## Summary
- guard evaluation helpers so missing NumPy/Pandas raise the documented ImportError and replace direct np.nan usages with math.nan
- prevent variance parsing without NumPy and treat risk-limited thresholds with no trades as invalid to maintain ValueError behaviour
- add regression tests that monkeypatch NumPy/Pandas availability and document the scientific dependencies required by built-in metrics

## Testing
- pytest tests/test_evaluation_optional_dependencies.py tests/test_evaluate.py

------
https://chatgpt.com/codex/tasks/task_e_68cee20c02ec832f9eda18ff9f58f27a