### PR TITLE
Unify inference preprocessing via shared pipeline

### DIFF
--- a/botcopier/scripts/replay_decisions.py
+++ b/botcopier/scripts/replay_decisions.py
@@ -47,6 +47,7 @@ else:  # pragma: no cover - optional dependency
     TCNClassifier = None  # type: ignore
     MixtureOfExperts = None  # type: ignore
 from botcopier.training.pipeline import detect_resources
+from botcopier.utils.inference import FeaturePipeline
 
 try:  # optional graph embedding support
     from graph_dataset import GraphDataset, compute_gnn_embeddings
@@ -76,6 +77,7 @@ except Exception:  # pragma: no cover - optional dependency
 
 
 MODEL_DIR: Path | None = None
+FEATURE_PIPELINE: FeaturePipeline | None = None
 
 
 def _load_model(model_file: Path) -> Dict:
@@ -85,73 +87,14 @@ def _load_model(model_file: Path) -> Dict:
         model = json.load(f)
     global MODEL_DIR
     MODEL_DIR = model_file.parent
+    global FEATURE_PIPELINE
+    FEATURE_PIPELINE = FeaturePipeline.from_model(model, model_dir=MODEL_DIR)
     return model
 
 
-def _masked_encoder_parameters(meta: Dict) -> tuple[np.ndarray | None, np.ndarray | None, list[str]]:
-    inputs = meta.get("input_features") or meta.get("original_features") or []
-    if isinstance(inputs, str):
-        inputs = [inputs]
-    input_cols = [str(col) for col in inputs]
-
-    weights = meta.get("weights")
-    bias = meta.get("bias")
-    weight_arr: np.ndarray | None
-    bias_arr: np.ndarray | None
-    if weights is not None:
-        weight_arr = np.asarray(weights, dtype=float)
-        bias_arr = np.asarray(bias, dtype=float) if bias is not None else None
-        return weight_arr, bias_arr, input_cols
-    weights_file = meta.get("weights_file")
-    if weights_file and MODEL_DIR is not None and _HAS_TORCH:
-        path = Path(weights_file)
-        if not path.is_absolute():
-            path = (MODEL_DIR / path).resolve()
-        if path.exists():
-            try:
-                state = torch.load(path, map_location="cpu")
-            except Exception:  # pragma: no cover - optional dependency
-                state = {}
-            if isinstance(state, dict):
-                state_dict = state.get("state_dict", state)
-                weight_tensor = state_dict.get("weight")
-                bias_tensor = state_dict.get("bias")
-                if isinstance(weight_tensor, torch.Tensor):
-                    weight_arr = weight_tensor.detach().cpu().numpy()
-                elif weight_tensor is not None:
-                    weight_arr = np.asarray(weight_tensor, dtype=float)
-                else:
-                    weight_arr = None
-                if isinstance(bias_tensor, torch.Tensor):
-                    bias_arr = bias_tensor.detach().cpu().numpy()
-                elif bias_tensor is not None:
-                    bias_arr = np.asarray(bias_tensor, dtype=float)
-                else:
-                    bias_arr = None
-                if weight_arr is not None:
-                    return weight_arr, bias_arr, input_cols
-    return None, None, input_cols
-
-
 def _project_features(model: Dict, features: Dict[str, float]) -> np.ndarray:
-    meta = model.get("masked_encoder")
-    if isinstance(meta, dict):
-        weights, bias, input_cols = _masked_encoder_parameters(meta)
-        if weights is not None:
-            cols = input_cols or meta.get("input_features") or []
-            if not cols:
-                cols = model.get("feature_names", [])
-            raw = np.array([float(features.get(name, 0.0)) for name in cols], dtype=float)
-            if raw.size != weights.shape[1]:
-                raise ValueError(
-                    f"masked encoder expected {weights.shape[1]} inputs, received {raw.size}"
-                )
-            encoded = raw @ weights.T
-            if bias is not None and bias.shape[0] == encoded.shape[0]:
-                encoded = encoded + bias
-            return encoded.astype(float)
-    names = model.get("feature_names", [])
-    return np.array([float(features.get(n, 0.0)) for n in names], dtype=float)
+    pipeline = FEATURE_PIPELINE or FeaturePipeline.from_model(model, model_dir=MODEL_DIR)
+    return pipeline.transform_dict(features)
 
 
 def _predict_logistic(model: Dict, features: Dict[str, float]) -> float:

--- a/botcopier/utils/inference.py
+++ b/botcopier/utils/inference.py
@@ -1,0 +1,266 @@
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+import numpy as np
+from sklearn.preprocessing import PowerTransformer
+
+from botcopier.models.schema import FeatureMetadata
+from botcopier.training.preprocessing import (
+    apply_autoencoder_from_metadata,
+    load_autoencoder_metadata,
+)
+
+
+logger = logging.getLogger(__name__)
+
+
+def _normalise_feature_list(values: Sequence[Any]) -> list[str]:
+    return [str(v) for v in values if v is not None]
+
+
+def resolve_autoencoder_metadata(
+    meta: Mapping[str, Any] | None, model_dir: Path | None
+) -> dict[str, Any] | None:
+    """Return encoder metadata ensuring weights are populated when available."""
+
+    if not isinstance(meta, Mapping):
+        return None
+
+    resolved: dict[str, Any] = {k: v for k, v in meta.items()}
+
+    def _merge(source: Mapping[str, Any] | None) -> None:
+        if not isinstance(source, Mapping):
+            return
+        for key, value in source.items():
+            if key not in resolved or resolved[key] in (None, []):
+                resolved[key] = value
+
+    meta_file = resolved.get("metadata_file")
+    if meta_file and model_dir is not None:
+        path = Path(str(meta_file))
+        if not path.is_absolute():
+            path = (model_dir / path).resolve()
+        try:
+            data = json.loads(path.read_text())
+        except FileNotFoundError:
+            logger.warning("Autoencoder metadata file not found at %s", path)
+        except json.JSONDecodeError:
+            logger.warning("Failed to parse autoencoder metadata at %s", path)
+        else:
+            _merge(data)
+
+    weights_file = resolved.get("weights_file")
+    if (resolved.get("weights") in (None, [])) and weights_file and model_dir is not None:
+        path = Path(str(weights_file))
+        if not path.is_absolute():
+            path = (model_dir / path).resolve()
+        loaded = load_autoencoder_metadata(path)
+        if loaded:
+            _merge(loaded)
+
+    if resolved.get("weights") in (None, []):
+        return None
+
+    return resolved
+
+
+@dataclass
+class FeaturePipeline:
+    """Utility encapsulating feature transformations required for inference."""
+
+    feature_names: list[str]
+    feature_metadata: list[FeatureMetadata]
+    input_columns: list[str]
+    schema_columns: list[str]
+    autoencoder_meta: dict[str, Any] | None = None
+    autoencoder_inputs: list[str] = field(default_factory=list)
+    autoencoder_outputs: list[str] = field(default_factory=list)
+    power_transformer: PowerTransformer | None = None
+    power_indices: list[int] = field(default_factory=list)
+    feature_name_to_original: dict[str, str] = field(default_factory=dict)
+
+    @classmethod
+    def from_model(
+        cls, model: Mapping[str, Any], *, model_dir: Path | None = None
+    ) -> "FeaturePipeline":
+        if "session_models" in model and model["session_models"]:
+            params = next(iter(model["session_models"].values()))
+        else:
+            params = model
+
+        feature_names = [str(f) for f in params.get("feature_names") or model.get("feature_names", [])]
+        metadata_raw = params.get("feature_metadata") or model.get("feature_metadata") or []
+        feature_metadata: list[FeatureMetadata] = []
+        for entry in metadata_raw:
+            if isinstance(entry, FeatureMetadata):
+                feature_metadata.append(entry)
+            else:
+                try:
+                    feature_metadata.append(FeatureMetadata(**entry))
+                except Exception:
+                    continue
+
+        feature_name_to_original: dict[str, str] = {}
+        if feature_metadata and len(feature_metadata) == len(feature_names):
+            for name, meta in zip(feature_names, feature_metadata):
+                feature_name_to_original[name] = meta.original_column
+
+        expected_cols = [meta.original_column for meta in feature_metadata] if feature_metadata else []
+        input_columns = _normalise_feature_list(expected_cols or feature_names)
+
+        auto_meta = (
+            params.get("autoencoder")
+            or model.get("autoencoder")
+            or params.get("masked_encoder")
+            or model.get("masked_encoder")
+        )
+        autoencoder_meta = resolve_autoencoder_metadata(auto_meta, model_dir)
+
+        auto_inputs: list[str] = []
+        auto_outputs: list[str] = []
+        schema_columns = list(input_columns)
+
+        if autoencoder_meta:
+            sources = autoencoder_meta.get("input_features") or autoencoder_meta.get("original_features")
+            if sources:
+                auto_inputs = _normalise_feature_list(sources)
+            elif input_columns:
+                auto_inputs = list(input_columns)
+            outputs = autoencoder_meta.get("feature_names") or []
+            auto_outputs = [str(name) for name in outputs if str(name) in feature_names]
+            if not auto_outputs:
+                latent_dim = int(autoencoder_meta.get("latent_dim", len(feature_names)))
+                latent_dim = max(0, min(latent_dim, len(feature_names)))
+                auto_outputs = feature_names[:latent_dim]
+            schema_columns = list(auto_inputs)
+
+        combined_inputs: list[str] = []
+        for name in (*input_columns, *auto_inputs):
+            if name and name not in combined_inputs:
+                combined_inputs.append(name)
+        input_columns = combined_inputs
+
+        pt_meta = params.get("power_transformer") or model.get("power_transformer")
+        power_transformer: PowerTransformer | None = None
+        power_indices: list[int] = []
+        if pt_meta:
+            pt = PowerTransformer(method="yeo-johnson")
+            pt.lambdas_ = np.asarray(pt_meta.get("lambdas", []), dtype=float)
+            from sklearn.preprocessing import StandardScaler
+
+            scaler = StandardScaler()
+            scaler.mean_ = np.asarray(pt_meta.get("mean", []), dtype=float)
+            scaler.scale_ = np.asarray(pt_meta.get("scale", []), dtype=float)
+            pt._scaler = scaler
+            pt.n_features_in_ = pt.lambdas_.shape[0]
+            power_transformer = pt
+            selected = [str(f) for f in pt_meta.get("features", [])]
+            for name in selected:
+                if name in feature_names:
+                    power_indices.append(feature_names.index(name))
+
+        return cls(
+            feature_names=list(feature_names),
+            feature_metadata=feature_metadata,
+            input_columns=input_columns,
+            schema_columns=schema_columns,
+            autoencoder_meta=autoencoder_meta,
+            autoencoder_inputs=auto_inputs,
+            autoencoder_outputs=auto_outputs,
+            power_transformer=power_transformer,
+            power_indices=power_indices,
+            feature_name_to_original=feature_name_to_original,
+        )
+
+    def transform_array(self, values: Sequence[float]) -> np.ndarray:
+        arr = np.asarray(values, dtype=float)
+        if arr.ndim != 1:
+            arr = arr.ravel()
+        length = arr.shape[0]
+        if length == len(self.input_columns):
+            mapping = {name: float(arr[idx]) for idx, name in enumerate(self.input_columns)}
+            features = self._transform_from_mapping(mapping)
+        elif length == len(self.feature_names):
+            features = arr.astype(float)
+        else:
+            raise ValueError("feature length mismatch")
+        return self._apply_power_transform(features)
+
+    def transform_matrix(self, matrix: np.ndarray) -> np.ndarray:
+        data = np.asarray(matrix, dtype=float)
+        if data.ndim != 2:
+            raise ValueError("feature matrix must be 2-dimensional")
+        if data.shape[1] == len(self.input_columns):
+            if data.shape[0] == 0:
+                return np.zeros((0, len(self.feature_names)), dtype=float)
+            rows = [self.transform_array(row) for row in data]
+            return np.vstack(rows)
+        if data.shape[1] == len(self.feature_names):
+            features = data.astype(float)
+            if features.size == 0 or not self.power_indices or self.power_transformer is None:
+                return features
+            transformed = self.power_transformer.transform(features[:, self.power_indices])
+            result = features.copy()
+            result[:, self.power_indices] = transformed
+            return result
+        raise ValueError("feature matrix column mismatch")
+
+    def transform_dict(self, values: Mapping[str, float]) -> np.ndarray:
+        mapping = {str(k): float(v) for k, v in values.items()}
+        features = self._transform_from_mapping(mapping)
+        return self._apply_power_transform(features)
+
+    def _transform_from_mapping(self, mapping: Mapping[str, float]) -> np.ndarray:
+        resolved = {str(k): float(v) for k, v in mapping.items()}
+        for name, original in self.feature_name_to_original.items():
+            if original in mapping and name not in resolved:
+                resolved[name] = float(mapping[original])
+
+        if self.autoencoder_meta and self.autoencoder_inputs:
+            missing = [name for name in self.autoencoder_inputs if name not in resolved]
+            if missing:
+                raise ValueError(
+                    f"missing autoencoder inputs: {', '.join(sorted(missing))}"
+                )
+            arr = np.asarray([resolved[name] for name in self.autoencoder_inputs], dtype=float)
+            embedding = apply_autoencoder_from_metadata(arr.reshape(1, -1), self.autoencoder_meta)
+            latent = embedding.ravel()
+            outputs = self.autoencoder_outputs or self.feature_names[: len(latent)]
+            if len(outputs) != len(latent):
+                limit = min(len(outputs), len(latent))
+                outputs = outputs[:limit]
+                latent = latent[:limit]
+            for name, value in zip(outputs, latent):
+                resolved[name] = float(value)
+
+        final: list[float] = []
+        missing_final: list[str] = []
+        for name in self.feature_names:
+            if name in resolved:
+                final.append(float(resolved[name]))
+            else:
+                missing_final.append(name)
+        if missing_final:
+            raise ValueError(
+                "missing features: " + ", ".join(sorted(missing_final))
+            )
+        return np.asarray(final, dtype=float)
+
+    def _apply_power_transform(self, features: np.ndarray) -> np.ndarray:
+        arr = np.asarray(features, dtype=float)
+        if arr.ndim != 1:
+            arr = arr.ravel()
+        if self.power_transformer is None or not self.power_indices:
+            return arr
+        subset = arr[self.power_indices].reshape(1, -1)
+        transformed = self.power_transformer.transform(subset).ravel()
+        result = arr.copy()
+        for idx, value in zip(self.power_indices, transformed):
+            result[idx] = float(value)
+        return result
+

--- a/tests/test_inference_consistency.py
+++ b/tests/test_inference_consistency.py
@@ -1,0 +1,64 @@
+import importlib
+from pathlib import Path
+
+import pytest
+
+np = pytest.importorskip("numpy")
+
+from botcopier.training import pipeline
+from botcopier.utils.inference import FeaturePipeline
+
+
+def test_inference_matches_pipeline_for_autoencoder_and_power_transform(tmp_path: Path) -> None:
+    weights = np.array([[0.5, -0.2], [0.3, 0.4]], dtype=float)
+    bias = np.array([0.1, -0.05], dtype=float)
+    model = {
+        "feature_names": ["latent_0", "latent_1"],
+        "feature_metadata": [
+            {"original_column": "f0"},
+            {"original_column": "f1"},
+        ],
+        "coefficients": [0.4, -0.25],
+        "intercept": -0.1,
+        "clip_low": [-10.0, -10.0],
+        "clip_high": [10.0, 10.0],
+        "feature_mean": [0.0, 0.0],
+        "feature_std": [1.0, 1.0],
+        "autoencoder": {
+            "input_features": ["f0", "f1"],
+            "weights": weights.tolist(),
+            "bias": bias.tolist(),
+            "feature_names": ["latent_0", "latent_1"],
+            "latent_dim": 2,
+        },
+        "power_transformer": {
+            "features": ["latent_1"],
+            "lambdas": [0.2],
+            "mean": [0.1],
+            "scale": [1.5],
+        },
+        "threshold": 0.0,
+    }
+
+    X = np.array([[0.5, 0.3], [1.2, -0.4], [-0.1, 0.8]], dtype=float)
+
+    expected = pipeline.predict_expected_value(model, X)
+
+    serve_module = importlib.reload(importlib.import_module("botcopier.scripts.serve_model"))
+    serve_module.MODEL_DIR = tmp_path
+    serve_module._configure_model(model)
+    serve_preds = np.array([serve_module._predict_one(row.tolist()) for row in X])
+    np.testing.assert_allclose(serve_preds, expected)
+
+    replay_module = importlib.reload(importlib.import_module("botcopier.scripts.replay_decisions"))
+    replay_module.MODEL_DIR = tmp_path
+    replay_module.FEATURE_PIPELINE = FeaturePipeline.from_model(model, model_dir=tmp_path)
+    replay_preds = np.array(
+        [
+            replay_module._predict_logistic(
+                model, {"f0": float(row[0]), "f1": float(row[1])}
+            )
+            for row in X
+        ]
+    )
+    np.testing.assert_allclose(replay_preds, expected)


### PR DESCRIPTION
## Summary
- add a shared FeaturePipeline helper that applies autoencoder weights and power transforms using stored metadata
- update the FastAPI server, replay tool, and pipeline.predict_expected_value to rely on the shared preprocessing so online/offline paths stay consistent
- add a regression test covering autoencoder + power-transform parity and update the masked encoder test to exercise the new pipeline logic

## Testing
- pytest tests/test_inference_consistency.py *(skipped: numpy not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cf0cc830a4832fb96d9a600e61a8c6