### PR TITLE
Support nonlinear ONNX autoencoders

### DIFF
--- a/botcopier/utils/inference.py
+++ b/botcopier/utils/inference.py
@@ -63,7 +63,8 @@ def resolve_autoencoder_metadata(
         if loaded:
             _merge(loaded)
 
-    if resolved.get("weights") in (None, []):
+    format_name = str(resolved.get("format") or "").lower()
+    if resolved.get("weights") in (None, []) and format_name != "onnx_nonlin":
         return None
 
     return resolved

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ ALLOWED = {
     "test_generate_mql4_from_model.py",
     "test_batch_backtest.py",
     "test_full_pipeline.py",
+    "test_autoencoder_embeddings.py",
     "performance",
     "test_benchmarks.py",
     "test_nats_publisher_async.py",


### PR DESCRIPTION
## Summary
- inspect ONNX encoder graphs to recover linear weights, record metadata, and persist serialized graphs when nonlinear ops are present
- update autoencoder metadata consumers to recognise `onnx_nonlin` formats and execute stored ONNXRuntime sessions instead of expecting a weight matrix
- add a mocked nonlinear ONNX autoencoder test and allow the autoencoder test module to be collected

## Testing
- pytest tests/test_autoencoder_embeddings.py *(skipped: missing numpy dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68cf19902b44832f94688b9a8d17e2a2