### PR TITLE
Support standalone tree checkpoints

### DIFF
--- a/botcopier/scripts/grpc_predict_server.py
+++ b/botcopier/scripts/grpc_predict_server.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import base64
+import io
 import json
 import logging
 import math
@@ -247,6 +248,27 @@ def _make_xgboost_predictor(config: dict[str, object]) -> Callable[[Sequence[flo
     return _predict
 
 
+def _make_catboost_predictor(config: dict[str, object]) -> Callable[[Sequence[float]], float]:
+    try:
+        import catboost as cb  # type: ignore
+    except ImportError as exc:  # pragma: no cover - optional dependency
+        raise RuntimeError("catboost is required to load this estimator") from exc
+
+    payload = config.get("cb_model") or config.get("model")
+    if not payload:
+        raise ValueError("missing catboost model payload")
+    buffer = io.BytesIO(base64.b64decode(payload))
+    model = cb.CatBoostClassifier()
+    model.load_model(stream=buffer)
+
+    def _predict(features: Sequence[float]) -> float:
+        arr = np.asarray(features, dtype=float).reshape(1, -1)
+        prob = model.predict_proba(arr)[0, 1]
+        return float(prob)
+
+    return _predict
+
+
 def _predict_logistic(features: Sequence[float]) -> float:
     if not LINEAR_CONFIG.get("coefficients"):
         if not COEFFS:
@@ -328,6 +350,28 @@ def _configure_runtime(model: dict) -> None:
                 logger.exception(
                     "Failed to initialise estimator %s", estimator.get("name", est_type)
                 )
+    standalone_estimators: list[tuple[str, Callable[[dict[str, object]], Callable[[Sequence[float]], float]], dict[str, object]]] = []
+    gb_model = model.get("gb_model")
+    if gb_model:
+        standalone_estimators.append(
+            ("gradient_boosting", _make_gradient_boosting_predictor, {"model": gb_model})
+        )
+    booster_payload = model.get("booster")
+    if booster_payload:
+        standalone_estimators.append(
+            ("xgboost", _make_xgboost_predictor, {"booster": booster_payload})
+        )
+    cb_model = model.get("cb_model")
+    if cb_model:
+        standalone_estimators.append(
+            ("catboost", _make_catboost_predictor, {"cb_model": cb_model})
+        )
+    for name, factory, cfg in standalone_estimators:
+        try:
+            ENSEMBLE_MODELS.append(factory(cfg))
+        except Exception:  # pragma: no cover - defensive logging
+            logger.exception("Failed to initialise standalone %s predictor", name)
+
     threshold_candidates.extend([model.get("decision_threshold"), model.get("threshold")])
     THRESHOLD = _resolve_threshold(threshold_candidates)
     _initialise_masked_encoder(model.get("masked_encoder"))

--- a/tests/test_serve_tree_models.py
+++ b/tests/test_serve_tree_models.py
@@ -1,0 +1,62 @@
+import base64
+import importlib
+import pickle
+from pathlib import Path
+
+import pytest
+
+np = pytest.importorskip("numpy")
+pytest.importorskip("sklearn")
+
+from botcopier.models.registry import get_model
+from botcopier.utils.inference import FeaturePipeline
+
+
+def _build_gradient_boosting_checkpoint() -> tuple[dict[str, object], np.ndarray, np.ndarray]:
+    rng = np.random.default_rng(42)
+    X = rng.normal(size=(32, 3))
+    logits = 0.6 * X[:, 0] - 0.4 * X[:, 1] + 0.2 * X[:, 2]
+    y = (logits > 0).astype(int)
+    builder = get_model("gradient_boosting")
+    meta, _ = builder(X, y, random_state=0)
+    payload = meta["gb_model"]
+    model = {
+        "feature_names": [f"f{i}" for i in range(X.shape[1])],
+        "feature_metadata": [{"original_column": f"f{i}"} for i in range(X.shape[1])],
+        "gb_model": payload,
+        "threshold": 0.0,
+    }
+    estimator = pickle.loads(base64.b64decode(payload))
+    expected = estimator.predict_proba(X)[:, 1]
+    return model, X, expected
+
+
+def _feature_dict(row: np.ndarray) -> dict[str, float]:
+    return {f"f{i}": float(value) for i, value in enumerate(row)}
+
+
+def test_serve_model_handles_gradient_boosting(tmp_path: Path) -> None:
+    model, X, expected = _build_gradient_boosting_checkpoint()
+    serve_module = importlib.reload(importlib.import_module("botcopier.scripts.serve_model"))
+    serve_module.MODEL_DIR = tmp_path
+    serve_module._configure_model(model)
+    preds = np.array([serve_module._predict_one(row.tolist()) for row in X])
+    np.testing.assert_allclose(preds, expected, rtol=1e-6, atol=1e-6)
+
+
+def test_replay_script_handles_gradient_boosting(tmp_path: Path) -> None:
+    model, X, expected = _build_gradient_boosting_checkpoint()
+    replay_module = importlib.reload(importlib.import_module("botcopier.scripts.replay_decisions"))
+    replay_module.MODEL_DIR = tmp_path
+    replay_module.FEATURE_PIPELINE = FeaturePipeline.from_model(model, model_dir=tmp_path)
+    probs = [replay_module._predict_gradient_boosting(model, _feature_dict(row)) for row in X]
+    np.testing.assert_allclose(probs, expected, rtol=1e-6, atol=1e-6)
+
+
+def test_grpc_predict_server_handles_gradient_boosting(tmp_path: Path) -> None:
+    model, X, expected = _build_gradient_boosting_checkpoint()
+    grpc_module = importlib.reload(importlib.import_module("botcopier.scripts.grpc_predict_server"))
+    grpc_module.MODEL_DIR = tmp_path
+    grpc_module._configure_runtime(model)
+    preds = np.array([grpc_module._predict_one(row.tolist()) for row in X])
+    np.testing.assert_allclose(preds, expected, rtol=1e-6, atol=1e-6)


### PR DESCRIPTION
## Summary
- detect gradient boosting, xgboost, and catboost payloads when configuring the HTTP server so tree checkpoints work without an ensemble wrapper
- mirror the standalone tree detection in the gRPC server and replay utility, including shared helpers for the different booster types
- add regression coverage that trains a gradient-boosting checkpoint and exercises the HTTP server, gRPC runtime, and replay script paths

## Testing
- pytest tests/test_serve_tree_models.py *(skipped: optional sklearn dependency unavailable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cf26d9bdbc832fac6af90d188828ca