### PR TITLE
Add monotonic constraint support to tree estimators

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,20 @@ botcopier online-train --csv notebooks/data/trades_raw.csv --model ./models/late
 botcopier analyze-ticks notebooks/data/ticks.csv --interval daily
 ```
 
+### Monotonic constraints for tree ensembles
+
+Tree-based learners in the registry accept optional monotonicity hints. Provide
+the constraint vector through ``TrainingConfig.monotone_constraints`` in
+``params.yaml`` (or override it via the CLI/``param_grid``) to enforce
+feature-wise increasing ``(+1)``, decreasing ``(-1)`` or unconstrained ``(0)``
+relationships. The vector length must match the feature count; the training
+pipeline validates the shape before fitting the estimators.
+
+CatBoost exposes an additional ``monotone_draft`` knob for advanced constraint
+specifications. Set ``TrainingConfig.catboost_monotone_draft`` to forward the
+string directly to ``catboost.CatBoostClassifier`` alongside the standard
+constraint vector.
+
 ## Documentation and notebooks
 
 The MkDocs site, including automatic API reference pages powered by

--- a/botcopier/cli/__init__.py
+++ b/botcopier/cli/__init__.py
@@ -253,6 +253,7 @@ def train(
         cache_dir=train_cfg.cache_dir,
         model_json=train_cfg.model,
         features=train_cfg.features,
+        monotone_constraints=train_cfg.monotone_constraints,
         random_seed=train_cfg.random_seed,
         hrp_allocation=train_cfg.hrp_allocation,
         strategy_search=train_cfg.strategy_search,
@@ -262,6 +263,7 @@ def train(
         controller_episode_combination_cap=train_cfg.controller_episode_combination_cap,
         controller_baseline_momentum=train_cfg.controller_baseline_momentum,
         regime_features=train_cfg.regime_features,
+        catboost_monotone_draft=train_cfg.catboost_monotone_draft,
         config_hash=config_hash,
         config_snapshot=snapshot.as_dict(),
     )

--- a/botcopier/training/pipeline.py
+++ b/botcopier/training/pipeline.py
@@ -173,6 +173,9 @@ def run_optuna(
         "tracking_uri": train_cfg.tracking_uri,
         "experiment_name": train_cfg.experiment_name,
         "features": list(train_cfg.features) if train_cfg.features else None,
+        "monotone_constraints": list(train_cfg.monotone_constraints)
+        if train_cfg.monotone_constraints
+        else None,
         "regime_features": (
             list(train_cfg.regime_features) if train_cfg.regime_features else None
         ),
@@ -192,6 +195,7 @@ def run_optuna(
         "controller_episode_combination_cap": train_cfg.controller_episode_combination_cap,
         "controller_baseline_momentum": train_cfg.controller_baseline_momentum,
         "random_seed": train_cfg.random_seed,
+        "catboost_monotone_draft": train_cfg.catboost_monotone_draft,
     }
     if train_cfg.half_life_days:
         base_train_kwargs["half_life_days"] = train_cfg.half_life_days
@@ -599,6 +603,12 @@ def train(
         for key in sequence_param_map.get(model_type, set())
         if key in kwargs
     }
+    monotone_constraints_cfg = kwargs.pop("monotone_constraints", None)
+    if monotone_constraints_cfg is not None:
+        extra_model_params["monotone_constraints"] = monotone_constraints_cfg
+    catboost_monotone_draft_cfg = kwargs.pop("catboost_monotone_draft", None)
+    if catboost_monotone_draft_cfg is not None:
+        extra_model_params["monotone_draft"] = catboost_monotone_draft_cfg
 
     half_life_value = half_life_days
     if half_life_value is None:

--- a/config/settings.py
+++ b/config/settings.py
@@ -119,6 +119,8 @@ class TrainingConfig(BaseSettings):
     controller_episode_combination_cap: Optional[int] = None
     controller_baseline_momentum: Optional[float] = 0.9
     meta_weights: Optional[Path] = None
+    monotone_constraints: Optional[List[int]] = None
+    catboost_monotone_draft: Optional[str] = None
 
     model_config = {"env_prefix": "TRAIN_", "extra": "forbid"}
 

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -325,6 +325,21 @@
           "title": "Features",
           "type": "array"
         },
+        "monotone_constraints": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Monotone Constraints"
+        },
         "regime_features": {
           "default": [],
           "items": {
@@ -489,6 +504,18 @@
           ],
           "default": null,
           "title": "Meta Weights"
+        },
+        "catboost_monotone_draft": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Catboost Monotone Draft"
         }
       },
       "title": "TrainingConfig",

--- a/tests/test_monotone_constraints.py
+++ b/tests/test_monotone_constraints.py
@@ -1,0 +1,84 @@
+import pytest
+
+np = pytest.importorskip("numpy")
+pytest.importorskip("sklearn")
+
+from botcopier.models.registry import get_model
+
+
+def _toy_dataset(seed: int = 42) -> tuple[np.ndarray, np.ndarray]:
+    rng = np.random.default_rng(seed)
+    X = rng.normal(size=(200, 2))
+    logits = 1.5 * X[:, 0] - 1.8 * X[:, 1]
+    y = (logits + 0.2 * rng.normal(size=X.shape[0]) > 0).astype(int)
+    return X, y
+
+
+def test_gradient_boosting_monotone_constraints_modify_predictions() -> None:
+    X, y = _toy_dataset()
+    builder = get_model("gradient_boosting")
+    _, unconstrained = builder(X, y, random_state=0)
+    _, constrained = builder(X, y, random_state=0, monotone_constraints=[1, -1])
+
+    unconstrained_probs = unconstrained(X)
+    constrained_probs = constrained(X)
+    diff = np.max(np.abs(unconstrained_probs - constrained_probs))
+    assert diff > 1e-6
+
+    monotone_param = constrained.model.get_params().get("monotonic_cst")  # type: ignore[attr-defined]
+    assert monotone_param is not None
+    assert tuple(monotone_param) == (1, -1)
+
+    with pytest.raises(ValueError, match="feature count"):
+        builder(X, y, monotone_constraints=[1])
+
+
+def test_xgboost_monotone_constraints_modify_predictions() -> None:
+    pytest.importorskip("xgboost")
+    X, y = _toy_dataset()
+    builder = get_model("xgboost")
+    _, unconstrained = builder(X, y, random_state=0, n_estimators=40)
+    _, constrained = builder(
+        X,
+        y,
+        random_state=0,
+        n_estimators=40,
+        monotone_constraints=[1, -1],
+    )
+
+    unconstrained_probs = unconstrained(X)
+    constrained_probs = constrained(X)
+    diff = np.max(np.abs(unconstrained_probs - constrained_probs))
+    assert diff > 1e-6
+
+    monotone_param = constrained.model.get_params().get("monotone_constraints")  # type: ignore[attr-defined]
+    assert isinstance(monotone_param, str)
+    assert monotone_param.replace(" ", "") == "(1,-1)"
+
+    with pytest.raises(ValueError, match="feature count"):
+        builder(X, y, monotone_constraints=[1])
+
+
+def test_catboost_monotone_constraints_modify_predictions() -> None:
+    pytest.importorskip("catboost")
+    X, y = _toy_dataset()
+    builder = get_model("catboost")
+    _, unconstrained = builder(X, y, iterations=50, random_seed=0)
+    _, constrained = builder(
+        X,
+        y,
+        iterations=50,
+        random_seed=0,
+        monotone_constraints=[1, -1],
+    )
+
+    unconstrained_probs = unconstrained(X)
+    constrained_probs = constrained(X)
+    diff = np.max(np.abs(unconstrained_probs - constrained_probs))
+    assert diff > 1e-6
+
+    params = constrained.model.get_params()  # type: ignore[attr-defined]
+    assert params.get("monotone_constraints") == [1, -1]
+
+    with pytest.raises(ValueError, match="feature count"):
+        builder(X, y, iterations=20, random_seed=0, monotone_constraints=[1])


### PR DESCRIPTION
## Summary
- add configuration fields and CLI/pipeline plumbing to pass monotone constraints and CatBoost monotone_draft settings into tree builders
- normalise and validate monotonic constraint vectors for gradient boosting, XGBoost and CatBoost estimators, surfacing clear errors on mismatched lengths
- document the new knobs and add regression tests confirming the constraints reach the estimators and change toy predictions

## Testing
- pytest tests/test_monotone_constraints.py

------
https://chatgpt.com/codex/tasks/task_e_68cf2e64e944832fbfa891b85c1140e0