### PR TITLE
Enable FeaturePipeline expected value predictions with model directory context

### DIFF
--- a/tests/test_inference_consistency.py
+++ b/tests/test_inference_consistency.py
@@ -1,9 +1,17 @@
 import importlib
+import sys
+import types
 from pathlib import Path
 
 import pytest
 
 np = pytest.importorskip("numpy")
+
+if "gplearn" not in sys.modules:
+    gplearn_mod = types.ModuleType("gplearn")
+    gplearn_mod.genetic = types.SimpleNamespace(SymbolicTransformer=object)
+    sys.modules["gplearn"] = gplearn_mod
+    sys.modules["gplearn.genetic"] = gplearn_mod.genetic
 
 from botcopier.training import pipeline
 from botcopier.utils.inference import FeaturePipeline
@@ -42,7 +50,7 @@ def test_inference_matches_pipeline_for_autoencoder_and_power_transform(tmp_path
 
     X = np.array([[0.5, 0.3], [1.2, -0.4], [-0.1, 0.8]], dtype=float)
 
-    expected = pipeline.predict_expected_value(model, X)
+    expected = pipeline.predict_expected_value(model, X, model_dir=tmp_path)
 
     serve_module = importlib.reload(importlib.import_module("botcopier.scripts.serve_model"))
     serve_module.MODEL_DIR = tmp_path

--- a/tests/test_train_target_clone_validation.py
+++ b/tests/test_train_target_clone_validation.py
@@ -434,7 +434,7 @@ def test_expected_value_pipeline_outputs_expected_profit(tmp_path: Path) -> None
         proc = pd.concat(list(proc), ignore_index=True)
     proc, fcols, _, _ = _extract_features(proc, fcols, config=feature_config)
     X = proc[model["feature_names"]].to_numpy(dtype=float)
-    preds = predict_expected_value(model, X)
+    preds = predict_expected_value(model, X, model_dir=out_dir)
     mean = np.array(params["feature_mean"])
     std = np.array(params["feature_std"])
     X_scaled = (X - mean) / np.where(std == 0, 1, std)


### PR DESCRIPTION
## Summary
- allow `predict_expected_value` to accept a `model_dir` and forward it to the `FeaturePipeline` so autoencoder assets resolve relative to the stored model, while re-exporting expected compatibility flags/classes
- refresh inference-facing tests to pass the model directory, rely on preprocessing helpers, and add a regression covering ONNX autoencoders that only ship `weights_file`

## Testing
- pytest tests/test_autoencoder_embeddings.py
- pytest tests/test_inference_consistency.py::test_inference_matches_pipeline_for_autoencoder_and_power_transform
- pytest tests/test_feature_schema.py
- pytest tests/test_train_target_clone_validation.py::test_expected_value_pipeline_outputs_expected_profit *(fails: engineered feature columns absent in the minimal fixture data)*

------
https://chatgpt.com/codex/tasks/task_e_68cf43b79998832f9430cb6bb4c835a8