### PR TITLE
Improve metrics aggregation persistence

### DIFF
--- a/botcopier/training/pipeline.py
+++ b/botcopier/training/pipeline.py
@@ -122,7 +122,7 @@ from botcopier.training.weighting import (
 from botcopier.utils.inference import FeaturePipeline
 from botcopier.utils.random import set_seed
 from logging_utils import setup_logging
-from metrics.aggregator import add_metric
+from metrics.aggregator import add_metric, configure_metrics_dir
 
 logger = logging.getLogger(__name__)
 
@@ -163,6 +163,7 @@ def run_optuna(
 
     overrides = dict(settings_overrides or {})
     data_cfg, train_cfg, exec_cfg = load_settings(overrides, path=config_path)
+    configure_metrics_dir(data_cfg.metrics_dir)
     data_path = resolve_data_path(data_cfg)
     study_out_dir = Path(data_cfg.out_dir) if data_cfg.out_dir else model_json_path.parent
     study_out_dir.mkdir(parents=True, exist_ok=True)
@@ -2694,6 +2695,7 @@ def main() -> None:
     )
     args = p.parse_args()
     data_cfg, train_cfg, exec_cfg = load_settings(vars(args))
+    configure_metrics_dir(data_cfg.metrics_dir)
     setup_logging(enable_tracing=exec_cfg.trace, exporter=exec_cfg.trace_exporter)
     set_seed(train_cfg.random_seed)
     train(

--- a/config/settings.py
+++ b/config/settings.py
@@ -60,6 +60,7 @@ class DataConfig(BaseSettings):
     log_dir: Optional[Path] = None
     out_dir: Optional[Path] = None
     files_dir: Optional[Path] = None
+    metrics_dir: Optional[Path] = None
     metrics_file: Optional[Path] = None
     tick_file: Optional[Path] = None
     baseline_file: Optional[Path] = None

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -58,6 +58,12 @@ botcopier evaluate notebooks/data/predictions.csv notebooks/data/trades_raw.csv 
 Both commands write their configuration snapshot to ``params.yaml`` and print a
 JSON metrics summary so you can track changes between runs.
 
+Metrics captured by the training pipeline are persisted as ``*.metrics.json``
+files in the directory specified by ``data.metrics_dir`` (or the
+``DATA_METRICS_DIR`` environment variable).  The aggregator reloads any existing
+history on start-up so dashboards and scripts can resume without losing
+previous observations.
+
 When you have exported raw tick history from MetaTrader, compute quick summary
 statistics directly from the CLI:
 

--- a/metrics/__init__.py
+++ b/metrics/__init__.py
@@ -1,12 +1,20 @@
 """Metric utilities exposed for convenience."""
 from .registry import get_metrics, load_plugins, register_metric
-from .aggregator import add_metric, get_aggregated_metrics, reset_metrics
+from .aggregator import (
+    add_metric,
+    configure_metrics_dir,
+    get_aggregated_metrics,
+    get_metrics_directory,
+    reset_metrics,
+)
 
 __all__ = [
     "get_metrics",
     "register_metric",
     "load_plugins",
     "add_metric",
+    "configure_metrics_dir",
     "get_aggregated_metrics",
+    "get_metrics_directory",
     "reset_metrics",
 ]

--- a/metrics/aggregator.py
+++ b/metrics/aggregator.py
@@ -2,18 +2,138 @@
 from __future__ import annotations
 
 import json
+import logging
+import os
+import tempfile
+import threading
 from collections import defaultdict
 from pathlib import Path
 from typing import Any, Dict, List
-import threading
+
+logger = logging.getLogger(__name__)
 
 # In-memory storage of metrics per strategy
 _METRICS: Dict[str, List[Any]] = defaultdict(list)
 _LOCK = threading.Lock()
 
 # Persist metrics alongside this module for easy inspection
-_METRICS_DIR = Path(__file__).resolve().parent
 _FILE_SUFFIX = ".metrics.json"
+_METRICS_DIR: Path
+
+
+def _normalise_path(path: Path | str) -> Path:
+    candidate = Path(path).expanduser()
+    try:
+        return candidate.resolve()
+    except OSError:
+        return candidate
+
+
+def _ensure_directory_writable(path: Path) -> Path | None:
+    path = path.expanduser()
+    try:
+        path.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        logger.debug("Failed to create metrics directory %s: %s", path, exc)
+        return None
+    probe = path / "._botcopier_metrics_probe"
+    try:
+        with probe.open("w", encoding="utf-8") as fh:
+            fh.write("")
+    except OSError as exc:
+        logger.debug("Metrics directory %s is not writable: %s", path, exc)
+        return None
+    finally:
+        try:
+            probe.unlink()
+        except OSError:
+            pass
+    return path
+
+
+def _default_metrics_dir() -> Path:
+    base = Path(tempfile.gettempdir()) / "botcopier-metrics"
+    writable = _ensure_directory_writable(base)
+    if writable:
+        return writable
+    fallback = Path(tempfile.mkdtemp(prefix="botcopier-metrics-"))
+    writable = _ensure_directory_writable(fallback)
+    if writable:
+        return writable
+    raise RuntimeError("Unable to create a writable metrics directory")
+
+
+def _strategy_from_path(path: Path) -> str | None:
+    name = path.name
+    if not name.endswith(_FILE_SUFFIX):
+        return None
+    return name[: -len(_FILE_SUFFIX)]
+
+
+def _load_persisted_metrics(directory: Path) -> None:
+    for file_path in directory.glob(f"*{_FILE_SUFFIX}"):
+        strategy_id = _strategy_from_path(file_path)
+        if not strategy_id:
+            continue
+        try:
+            with file_path.open("r", encoding="utf-8") as fh:
+                payload = json.load(fh)
+        except (OSError, json.JSONDecodeError) as exc:
+            logger.debug("Failed to load metrics from %s: %s", file_path, exc)
+            continue
+        if isinstance(payload, list):
+            _METRICS[strategy_id].extend(payload)
+
+
+def _apply_metrics_dir(directory: Path) -> Path:
+    global _METRICS_DIR
+    with _LOCK:
+        _METRICS.clear()
+        _load_persisted_metrics(directory)
+        _METRICS_DIR = directory
+    return directory
+
+
+def configure_metrics_dir(metrics_dir: Path | str | None = None) -> Path:
+    """Configure the directory used to persist aggregated metrics."""
+
+    candidates: List[Path] = []
+    if metrics_dir is not None:
+        candidates.append(_normalise_path(metrics_dir))
+    env_dir = os.getenv("DATA_METRICS_DIR")
+    if env_dir:
+        candidates.append(_normalise_path(env_dir))
+
+    resolved: Path | None = None
+    seen: set[str] = set()
+    for candidate in candidates:
+        key = str(candidate)
+        if key in seen:
+            continue
+        seen.add(key)
+        writable = _ensure_directory_writable(candidate)
+        if writable is not None:
+            resolved = writable
+            break
+        logger.warning(
+            "Metrics directory %s is not writable; falling back to a temporary directory",
+            candidate,
+        )
+
+    if resolved is None:
+        resolved = _default_metrics_dir()
+    return _apply_metrics_dir(resolved)
+
+
+def get_metrics_directory() -> Path:
+    """Return the directory currently used for metric persistence."""
+
+    with _LOCK:
+        return _METRICS_DIR
+
+
+# Resolve the metrics directory during import so persisted history is available
+_METRICS_DIR = configure_metrics_dir()
 
 
 def add_metric(strategy_id: str, metric: Any) -> None:

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -44,6 +44,19 @@
           "default": null,
           "title": "Files Dir"
         },
+        "metrics_dir": {
+          "anyOf": [
+            {
+              "format": "path",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Metrics Dir"
+        },
         "metrics_file": {
           "anyOf": [
             {

--- a/tests/test_metrics_aggregator.py
+++ b/tests/test_metrics_aggregator.py
@@ -1,0 +1,56 @@
+"""Tests for the metrics aggregator persistence behaviour."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+import metrics.aggregator as aggregator
+
+
+def test_metrics_directory_environment_override(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    previous_dir = aggregator.get_metrics_directory()
+    monkeypatch.setenv("DATA_METRICS_DIR", str(tmp_path))
+    try:
+        configured = aggregator.configure_metrics_dir()
+        assert configured == tmp_path.resolve()
+        aggregator.add_metric("env", {"value": 1})
+        payload = json.loads((tmp_path / "env.metrics.json").read_text())
+        assert payload == [{"value": 1}]
+    finally:
+        aggregator.configure_metrics_dir(previous_dir)
+
+
+def test_metrics_directory_read_only_falls_back(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    previous_dir = aggregator.get_metrics_directory()
+    read_only = tmp_path / "locked"
+    read_only.mkdir()
+    read_only.chmod(0o500)
+    monkeypatch.setenv("DATA_METRICS_DIR", str(read_only))
+    try:
+        configured = aggregator.configure_metrics_dir()
+        assert configured.resolve() != read_only.resolve()
+        aggregator.add_metric("beta", 2)
+        assert (configured / "beta.metrics.json").exists()
+    finally:
+        read_only.chmod(0o700)
+        aggregator.configure_metrics_dir(previous_dir)
+
+
+def test_persisted_metrics_reload(tmp_path: Path) -> None:
+    previous_dir = aggregator.get_metrics_directory()
+    metrics_dir = tmp_path / "persisted"
+    metrics_dir.mkdir()
+    initial = [{"value": 1}]
+    (metrics_dir / "gamma.metrics.json").write_text(json.dumps(initial))
+    try:
+        aggregator.configure_metrics_dir(metrics_dir)
+        aggregated = aggregator.get_aggregated_metrics()
+        assert aggregated["gamma"] == initial
+        aggregator.add_metric("gamma", {"value": 2})
+        updated = json.loads((metrics_dir / "gamma.metrics.json").read_text())
+        assert updated == [{"value": 1}, {"value": 2}]
+    finally:
+        aggregator.configure_metrics_dir(previous_dir)


### PR DESCRIPTION
## Summary
- resolve the metrics aggregator directory via configuration/environment overrides and hydrate stored history when the module loads
- expose configuration helpers, update the training pipeline to honour `data.metrics_dir`, and document how to override the metrics location
- extend the settings schema/configuration to include `metrics_dir` and add tests covering environment overrides, read-only fallbacks, and persisted metric reloads

## Testing
- pytest *(fails: missing optional dependencies such as numpy, grpc, nats, and pydantic in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cf6e067cc8832f85b3651d67f82e0d