### PR TITLE
Fix CV indentation and fallback metrics after shrinkage updates

### DIFF
--- a/botcopier/scripts/serve_model.py
+++ b/botcopier/scripts/serve_model.py
@@ -196,7 +196,13 @@ def _configure_model(model: dict) -> None:
     OOD_INFO = model.get("ood", {})
     OOD_MEAN = np.asarray(OOD_INFO.get("mean", []), dtype=float)
     OOD_COV = np.asarray(OOD_INFO.get("covariance", []), dtype=float)
-    OOD_INV = np.linalg.pinv(OOD_COV) if OOD_COV.size else np.empty((0, 0))
+    OOD_PREC = np.asarray(OOD_INFO.get("precision", []), dtype=float)
+    if OOD_PREC.size:
+        OOD_INV = OOD_PREC
+    elif OOD_COV.size:
+        OOD_INV = np.linalg.pinv(OOD_COV)
+    else:
+        OOD_INV = np.empty((0, 0))
     OOD_THRESHOLD = float(OOD_INFO.get("threshold", float("inf")))
 
     coeffs = model.get("entry_coefficients") or model.get("coefficients") or []

--- a/tests/test_target_clone_cross_validation.py
+++ b/tests/test_target_clone_cross_validation.py
@@ -18,7 +18,7 @@ def test_cross_validation_metrics_written(tmp_path: Path) -> None:
         "0,-0.6,18,1.5\n"
     )
     out_dir = tmp_path / "out"
-    train(data, out_dir)
+    train(data, out_dir, force_heavy=True)
     model = json.loads((out_dir / "model.json").read_text())
     assert "cv_metrics" in model
     assert "threshold" in model
@@ -29,6 +29,8 @@ def test_cross_validation_metrics_written(tmp_path: Path) -> None:
     assert cv_metrics["threshold"] == pytest.approx(model["threshold"])
     assert "brier_score" in cv_metrics
     assert "sharpe_ratio" in cv_metrics
+    assert "ood_rate" in cv_metrics
+    assert "ood_threshold" in cv_metrics
     for params in model["session_models"].values():
         assert params["cv_metrics"]
         assert "conformal_lower" in params and "conformal_upper" in params
@@ -36,8 +38,12 @@ def test_cross_validation_metrics_written(tmp_path: Path) -> None:
         assert "metrics" in params
         assert params["metrics"]["threshold"] == pytest.approx(model["threshold"])
         assert "brier_score" in params["metrics"]
+        assert "ood_rate" in params["metrics"]
+        assert "ood_threshold" in params["metrics"]
         for fm in params["cv_metrics"]:
             assert "accuracy" in fm and "profit" in fm
+            assert "ood_rate" in fm
+            assert "ood_threshold" in fm
 
 
 def test_training_fails_when_threshold_unmet(tmp_path: Path) -> None:
@@ -53,4 +59,57 @@ def test_training_fails_when_threshold_unmet(tmp_path: Path) -> None:
     )
     out_dir = tmp_path / "out"
     with pytest.raises(ValueError):
-        train(data, out_dir, min_accuracy=1.1, min_profit=0.1)
+        train(
+            data,
+            out_dir,
+            min_accuracy=1.1,
+            min_profit=0.1,
+            force_heavy=True,
+        )
+
+
+def test_ood_shrinkage_handles_rank_deficiency(tmp_path: Path) -> None:
+    np = pytest.importorskip("numpy")
+    data = tmp_path / "trades_raw.csv"
+    data.write_text(
+        "label,profit,hour,spread\n"
+        "1,1.0,3,1.0\n"
+        "0,-0.5,3,1.1\n"
+        "1,0.8,3,1.2\n"
+        "0,-0.4,3,1.3\n"
+        "1,0.6,3,1.4\n"
+        "0,-0.3,3,1.5\n"
+        "1,0.7,3,1.6\n"
+        "0,-0.2,3,1.7\n"
+    )
+    out_dir = tmp_path / "out"
+    train(
+        data,
+        out_dir,
+        force_heavy=True,
+        feature_subset=["spread", "hour_cos"],
+    )
+    model = json.loads((out_dir / "model.json").read_text())
+    ood = model["ood"]
+    cov = np.asarray(ood["covariance"], dtype=float)
+    precision = np.asarray(ood.get("precision", []), dtype=float)
+    assert cov.shape[0] == cov.shape[1] == 2
+    assert precision.shape == cov.shape
+    assert np.all(np.isfinite(cov))
+    assert np.all(np.isfinite(precision))
+    assert np.allclose(cov, cov.T, atol=1e-10)
+    assert np.allclose(precision, precision.T, atol=1e-10)
+    assert np.linalg.matrix_rank(cov) == cov.shape[0]
+    sign, _ = np.linalg.slogdet(cov)
+    assert sign > 0.0
+    identity = np.eye(cov.shape[0])
+    assert np.allclose(cov @ precision, identity, atol=1e-2)
+    assert "ood_rate" in model["cv_metrics"]
+    assert "ood_threshold" in model["cv_metrics"]
+    assert model["cv_metrics"]["ood_rate"] >= 0.0
+    for params in model["session_models"].values():
+        assert "ood_rate" in params["metrics"]
+        assert "ood_threshold" in params["metrics"]
+        for fold_metrics in params["cv_metrics"]:
+            assert "ood_rate" in fold_metrics
+            assert "ood_threshold" in fold_metrics


### PR DESCRIPTION
## Summary
- realign the cross-validation training loops after the shrinkage refactor to avoid syntax errors
- ensure fold metrics are initialised for fallback aggregation and keep OOD metrics available for logging
- persist the precision matrix for serving and extend cross-validation tests with heavy-pipeline coverage

## Testing
- pytest tests/test_target_clone_cross_validation.py

------
https://chatgpt.com/codex/tasks/task_e_68cf7b7233d8832f960ae9c8f088825d