### PR TITLE
Improve optional dependency logging

### DIFF
--- a/botcopier/models/registry.py
+++ b/botcopier/models/registry.py
@@ -25,12 +25,22 @@ from .schema import ModelParams
 logger = logging.getLogger(__name__)
 tracer = trace.get_tracer(__name__)
 
+
+def _log_optional_dependency(
+    library: str, feature: str, exc: ImportError
+) -> None:
+    """Log a short message when an optional dependency is unavailable."""
+
+    message = f"{feature} disabled (missing {library})"
+    logger.info(message)
+    logger.debug("%s import error: %s", library, exc)
+
 try:  # Optional dependency
     import torch
 
     _HAS_TORCH = True
-except ImportError:  # pragma: no cover - optional
-    logger.exception("PyTorch is unavailable")
+except ImportError as exc:  # pragma: no cover - optional
+    _log_optional_dependency("PyTorch", "PyTorch models", exc)
     torch = None  # type: ignore
     _HAS_TORCH = False
 
@@ -38,8 +48,8 @@ try:  # Optional dependency
     import xgboost as xgb  # type: ignore
 
     _HAS_XGB = True
-except ImportError:  # pragma: no cover - optional
-    logger.exception("XGBoost is unavailable")
+except ImportError as exc:  # pragma: no cover - optional
+    _log_optional_dependency("XGBoost", "XGBoost models", exc)
     xgb = None  # type: ignore
     _HAS_XGB = False
 
@@ -47,8 +57,8 @@ try:  # Optional dependency
     import catboost as cb  # type: ignore
 
     _HAS_CATBOOST = True
-except ImportError:  # pragma: no cover - optional
-    logger.exception("CatBoost is unavailable")
+except ImportError as exc:  # pragma: no cover - optional
+    _log_optional_dependency("CatBoost", "CatBoost models", exc)
     cb = None  # type: ignore
     _HAS_CATBOOST = False
 

--- a/tests/optional/test_missing_dependencies.py
+++ b/tests/optional/test_missing_dependencies.py
@@ -1,5 +1,7 @@
 import importlib
+import logging
 import sys
+import types
 
 import pytest
 
@@ -20,6 +22,63 @@ def test_missing_catboost_raises(monkeypatch):
     registry = importlib.import_module("botcopier.models.registry")
     with pytest.raises(ImportError, match="catboost is required"):
         registry._fit_catboost_classifier()
+    monkeypatch.undo()
+    importlib.reload(registry)
+
+
+def test_missing_torch_logs_info(monkeypatch, caplog):
+    caplog.clear()
+    monkeypatch.setitem(sys.modules, "torch", None)
+    monkeypatch.setitem(sys.modules, "xgboost", types.ModuleType("xgboost"))
+    monkeypatch.setitem(sys.modules, "catboost", types.ModuleType("catboost"))
+    sys.modules.pop("botcopier.models.registry", None)
+    with caplog.at_level(logging.INFO, logger="botcopier.models.registry"):
+        registry = importlib.import_module("botcopier.models.registry")
+    records = [
+        record
+        for record in caplog.records
+        if record.name == "botcopier.models.registry"
+    ]
+    assert len(records) == 1
+    record = records[0]
+    assert record.levelno == logging.INFO
+    message = record.getMessage().lower()
+    assert "pytorch" in message
+    assert "disabled" in message
+    assert "no module named" not in message
+    monkeypatch.undo()
+    importlib.reload(registry)
+
+
+def test_missing_torch_logs_debug_details(monkeypatch, caplog):
+    caplog.clear()
+    monkeypatch.setitem(sys.modules, "torch", None)
+    monkeypatch.setitem(sys.modules, "xgboost", types.ModuleType("xgboost"))
+    monkeypatch.setitem(sys.modules, "catboost", types.ModuleType("catboost"))
+    sys.modules.pop("botcopier.models.registry", None)
+    with caplog.at_level(logging.DEBUG, logger="botcopier.models.registry"):
+        registry = importlib.import_module("botcopier.models.registry")
+    info_records = [
+        record
+        for record in caplog.records
+        if record.name == "botcopier.models.registry" and record.levelno == logging.INFO
+    ]
+    debug_records = [
+        record
+        for record in caplog.records
+        if record.name == "botcopier.models.registry" and record.levelno == logging.DEBUG
+    ]
+    assert info_records
+    assert debug_records
+    info_message = info_records[0].getMessage().lower()
+    assert "pytorch" in info_message
+    assert "disabled" in info_message
+    debug_record = debug_records[0]
+    debug_message = debug_record.getMessage().lower()
+    assert "import error" in debug_message
+    if debug_record.args:
+        exc_text = str(debug_record.args[-1]).lower()
+        assert exc_text in debug_message
     monkeypatch.undo()
     importlib.reload(registry)
 


### PR DESCRIPTION
## Summary
- replace optional dependency ImportError handlers with concise info/debug logging
- add regression tests to confirm informational logs and verbose exception details when torch is missing

## Testing
- pytest tests/optional/test_missing_dependencies.py::test_missing_torch_logs_info tests/optional/test_missing_dependencies.py::test_missing_torch_logs_debug_details

------
https://chatgpt.com/codex/tasks/task_e_68d051b5f5e0832f8423bd012177bfe5