### PR TITLE
Deduplicate feature pipeline schema inputs

### DIFF
--- a/tests/test_autoencoder_embeddings.py
+++ b/tests/test_autoencoder_embeddings.py
@@ -9,6 +9,11 @@ import pytest
 np = pytest.importorskip("numpy")
 pytest.importorskip("pandas")
 
+training_mod = sys.modules.get("botcopier.training")
+if training_mod is not None and not hasattr(training_mod, "__path__"):
+    sys.modules.pop("botcopier.training", None)
+    sys.modules.pop("botcopier.training.preprocessing", None)
+
 if "gplearn" not in sys.modules:
     gplearn_mod = types.ModuleType("gplearn")
     gplearn_mod.genetic = types.SimpleNamespace(SymbolicTransformer=object)

--- a/tests/test_feature_schema.py
+++ b/tests/test_feature_schema.py
@@ -1,8 +1,22 @@
+import sys
+import types
+
 import pytest
 
 np = pytest.importorskip("numpy")
 pd = pytest.importorskip("pandas")
 pa = pytest.importorskip("pandera")
+
+training_mod = sys.modules.get("botcopier.training")
+if training_mod is not None and not hasattr(training_mod, "__path__"):
+    sys.modules.pop("botcopier.training", None)
+    sys.modules.pop("botcopier.training.preprocessing", None)
+
+if "gplearn" not in sys.modules:
+    gplearn_mod = types.ModuleType("gplearn")
+    gplearn_mod.genetic = types.SimpleNamespace(SymbolicTransformer=object)
+    sys.modules["gplearn"] = gplearn_mod
+    sys.modules["gplearn.genetic"] = gplearn_mod.genetic
 
 from botcopier.data.feature_schema import FeatureSchema
 from botcopier.training.pipeline import predict_expected_value
@@ -45,3 +59,25 @@ def test_predict_expected_value_feature_mismatch():
     X = np.array([[1.0]])
     with pytest.raises(ValueError):
         predict_expected_value(model, X)
+
+
+def test_predict_expected_value_accepts_alias_metadata():
+    model = {
+        "feature_names": ["feat_a", "feat_b"],
+        "feature_metadata": [
+            {"original_column": "base"},
+            {"original_column": "base"},
+        ],
+        "feature_mean": [0.0, 0.0],
+        "feature_std": [1.0, 1.0],
+        "coefficients": [0.6, -0.25],
+        "intercept": 0.1,
+    }
+    X = np.array([[1.2], [-0.3], [0.0]], dtype=float)
+
+    preds = predict_expected_value(model, X)
+
+    features = np.column_stack([X[:, 0], X[:, 0]])
+    logits = features @ np.array(model["coefficients"], dtype=float) + model["intercept"]
+    expected = 1.0 / (1.0 + np.exp(-logits))
+    np.testing.assert_allclose(preds, expected)


### PR DESCRIPTION
## Summary
- ensure the feature pipeline deduplicates inferred input columns and keeps schema columns in sync, including autoencoder inputs
- update test scaffolding and add coverage for autoencoder metadata sharing original columns
- add a regression test confirming predict_expected_value handles aliased source columns

## Testing
- pytest tests/test_feature_pipeline_autoencoder_outputs.py tests/test_feature_schema.py tests/test_autoencoder_embeddings.py

------
https://chatgpt.com/codex/tasks/task_e_68d06ce85334832fbd758b983c784e50