### PR TITLE
Align autoencoder schema columns with raw inputs

### DIFF
--- a/botcopier/training/pipeline.py
+++ b/botcopier/training/pipeline.py
@@ -2544,7 +2544,7 @@ def predict_expected_value(
 
     schema_cols: Sequence[str] = []
     if raw_features.shape[1] == len(pipeline.input_columns):
-        schema_cols = pipeline.schema_columns
+        schema_cols = pipeline.input_columns
     elif raw_features.shape[1] == len(pipeline.feature_names):
         schema_cols = [] if pipeline.autoencoder_meta is not None else pipeline.feature_names
     elif raw_features.shape[1] != len(pipeline.feature_names):

--- a/botcopier/utils/inference.py
+++ b/botcopier/utils/inference.py
@@ -205,12 +205,12 @@ class FeaturePipeline:
             auto_inputs = _deduplicate_preserving_order(auto_inputs)
 
         combined_inputs = _deduplicate_preserving_order((*input_columns, *auto_inputs))
-        input_columns = combined_inputs
-
-        if autoencoder_meta and auto_inputs:
-            schema_columns = list(auto_inputs)
-        else:
-            schema_columns = list(combined_inputs)
+        input_columns = list(combined_inputs)
+        # The schema used for validating raw inputs must mirror the full set of
+        # columns expected by the pipeline.  Track autoencoder inputs
+        # separately via ``autoencoder_inputs`` so callers can still perform
+        # targeted validation when required.
+        schema_columns = list(input_columns)
 
         pt_meta = params.get("power_transformer") or model.get("power_transformer")
         power_transformer: PowerTransformer | None = None


### PR DESCRIPTION
## Summary
- ensure the feature pipeline exposes schema columns that match the combined raw input set while keeping autoencoder inputs tracked separately
- use the unified input column list for predict_expected_value validation and add coverage for mixed autoencoder/pass-through inputs

## Testing
- `pytest tests/test_feature_pipeline_autoencoder_outputs.py`


------
https://chatgpt.com/codex/tasks/task_e_68d07b94f008832f874ba3cb347ace8c