### PR TITLE
Add runtime support for lag/diff features in MQL4 generator

### DIFF
--- a/tests/sample_models/lag_diff_model.json
+++ b/tests/sample_models/lag_diff_model.json
@@ -1,0 +1,17 @@
+{
+  "feature_names": [
+    "price",
+    "price_lag_1",
+    "price_lag_5",
+    "price_diff",
+    "volume",
+    "volume_lag_1",
+    "volume_diff",
+    "spread",
+    "spread_lag_1",
+    "spread_lag_5",
+    "spread_diff",
+    "spread*spread_lag_1",
+    "spread*spread_diff"
+  ]
+}


### PR DESCRIPTION
## Summary
- add a reusable MarketSeries helper and update spread interactions to use historical values
- resolve standalone *_lag_* and *_diff features when building GetFeature switch cases
- cover lag/diff generation with a sample model fixture and regression tests

## Testing
- pytest tests/test_generate_mql4_from_model.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d097fc148c832f9743c575cebb3ccb